### PR TITLE
fix consistency check for subannual timeslices

### DIFF
--- a/model/MESSAGE/data_load.gms
+++ b/model/MESSAGE/data_load.gms
@@ -152,7 +152,7 @@ if (check,
 
 * check for validity of temporal resolution
 loop(lvl_temporal,
-    loop(time2,
+    loop(time2$( sum(time, map_temporal_hierarchy(lvl_temporal,time,time2) ) ),
         check = 1$( sum( time$( map_temporal_hierarchy(lvl_temporal,time,time2) ),
             duration_time(time) ) ne duration_time(time2) ) ;
     ) ;


### PR DESCRIPTION
This PR fixes the issue identified by Pietro Pelizzarui (https://groups.google.com/forum/#!topic/message_ix/E13e_AdhSqY) - there was an overzealous consistency check that the sum of sub-annual time slice duration adds up to 1.