### PR TITLE
remove ixmp-install from `install.bat`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -64,7 +64,7 @@ copyright = u'2018, IIASA, Energy Program'
 author = u'IIASA, Energy Program'
 
 # retrieve MESSAGEix version number from model/version.gms
-fname = os.path.join('..', '..', 'model', 'version.gms')
+fname = os.path.join('..', '..', 'message_ix', 'model', 'version.gms')
 with open(fname) as f:
     s = str(f.readlines())
 

--- a/install.bat
+++ b/install.bat
@@ -5,9 +5,6 @@ del .foo
 echo %MESSAGE_IX%
 
 echo Python MESSAGE_IX setup
-chdir ixmp
-python setup.py install
-chdir ../
 python setup.py install
 
 echo R MESSAGE_IX setup
@@ -17,9 +14,6 @@ IF ERRORLEVEL 1 (
     @rem set ERRORLEVEL to 0 -> ignore R setup
     VERIFY
 ) ELSE (
-    chdir ixmp
-    rscript rixmp/build_rixmp.R [--verbose]
-    chdir ../
     rscript rmessageix/build_rmessageix.R [--verbose]
 )
 
@@ -27,14 +21,13 @@ if %errorlevel% neq 0 GOTO InstallError
 
 setx IXMP_PATH "%MESSAGE_IX%"
 
-copy model\\templates\\MESSAGE_master_template.gms model\\MESSAGE_master.gms
-copy model\\templates\\MESSAGE_project_template.gpr model\\MESSAGE_project.gpr
+copy message_ix\\model\\templates\\MESSAGE_master_template.gms model\\MESSAGE_master.gms
+copy message_ix\\model\\templates\\MESSAGE_project_template.gpr model\\MESSAGE_project.gpr
 
 chdir doc/
 call make.bat html
 chdir ../
 
-py.test ixmp\\tests
 py.test tests
 
 pause


### PR DESCRIPTION
This PR removes the installation of ixmp (previously a submodule) from the installation using `install.bat`.

Also, it updates the path to the MESSAGE-GAMS version (folder moved for installation of GAMS code) in the sphinx documentation `config.py`.

Note that the GAMS code has a hard-coded version number (see `message_ix/model/version.gms`), which must match the version number in the compiled `ixmp.jar`.  This should be integrated with the repository version tag.