### PR TITLE
bump version number of MESSAGEix to 1.0

### DIFF
--- a/message_ix/model/version.gms
+++ b/message_ix/model/version.gms
@@ -1,13 +1,18 @@
-* This file specifies the version number of MESSAGEix
-* !!! DO NOT CHANGE THESE VALUES MANUALLY !!!
-* Changes have to be done by pulling the respective version 
-* from the Github repository at https://github.com/iiasa/message_ix.
+* This file specifies the release version number of MESSAGEix.
+* The version number must match the MESSAGEix-scheme version number
+* in the compiled `ixmp.jar`.
 
-$SETGLOBAL VERSION_MAJOR "0"
-$SETGLOBAL VERSION_MINOR "2"
+* !!! DO NOT CHANGE VALUES IN THIS FILE MANUALLY !!!
+
+* Changes have to be done by pulling the respective version
+* from the Github repository at https://github.com/iiasa/message_ix,
+* or by updating the `message_ix` package
+* using `conda update -c conda-forge message-ix`.
+
+$SETGLOBAL VERSION_MAJOR "1"
+$SETGLOBAL VERSION_MINOR "0"
 $SETGLOBAL VERSION_MICRO "0"
 
-* This file is imported by the script that generates the GAMS documentation
-* from rst-markup text, see ``message_ix\doc\grab_gams_doc.py``.
-* The tag ``|version|`` in any mark-up docstring
+* This file is imported by `message_ix/__init__.py`.
+* In the documentation rst files, the tag ``|version|`` in any mark-up docstring
 * is replaced by '%VERSION_MAJOR%.%VERSION_MINOR%'.


### PR DESCRIPTION
This PR updates the version number of MESSAGEix to `1.0`. It depends on https://github.com/iiasa/ixmp/pull/38 to update the MESSAGE-scheme specifications and version number hard-coded in the `ixmp.jar`.