### PR TITLE
adapt to changes rmessage_ix and  reticulate tutorial

### DIFF
--- a/rmessageix/source/R/init_rmessageix.R
+++ b/rmessageix/source/R/init_rmessageix.R
@@ -25,10 +25,10 @@ utils::globalVariables(c("ixmp_path"))
     warning("Check MESSAGE model installation")
   
   # careful to have all the slashes in the same direction
-  model_file = gsub("/","\\\\" ,file.path( paste(ixmp_path, "\\model", sep = '') , "{model}_run.gms" ) )
-  inp = gsub("/","\\\\" , file.path( paste(ixmp_path, "\\model\\data", sep = '') , "MsgData_{case}.gdx" ) )
-  outp = gsub("/","\\\\" , file.path( paste(ixmp_path, "\\model\\output", sep = '') , "MsgOutput_{case}.gdx" ) )
-  iter_file = gsub("/","\\\\" , file.path( paste(ixmp_path, "\\model\\output", sep = '') , "MsgIterationReport_{case}.gdx" ) )
+  model_file = gsub("/","\\\\" ,file.path( paste(ixmp_path, "\\message_ix\\model", sep = '') , "{model}_run.gms" ) )
+  inp = gsub("/","\\\\" , file.path( paste(ixmp_path, "\\message_ix\\model\\data", sep = '') , "MsgData_{case}.gdx" ) )
+  outp = gsub("/","\\\\" , file.path( paste(ixmp_path, "\\message_ix\\model\\output", sep = '') , "MsgOutput_{case}.gdx" ) )
+  iter_file = gsub("/","\\\\" , file.path( paste(ixmp_path, "\\message_ix\\model\\output", sep = '') , "MsgIterationReport_{case}.gdx" ) )
   solve_args = paste("--in=",inp," --out=",outp," --iter=", iter_file, sep = '')
   
   for (i in c("MESSAGE","MESSAGE-MACRO")) {

--- a/tutorial/Austrian_energy_system/austria_reticulate.ipynb
+++ b/tutorial/Austrian_energy_system/austria_reticulate.ipynb
@@ -71,7 +71,7 @@
     "library(dplyr)\n",
     "ixmp <- import('ixmp')\n",
     "\n",
-    "import('message_ix')"
+    "message_ix <- import('message_ix')"
    ]
   },
   {
@@ -96,16 +96,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "model = \"Austrian energy model\"\n",
     "scen = \"baseline\"\n",
     "annot = \"developing a stylized energy system model for illustration and testing\" \n",
     "\n",
-    "scenario = mp$Scenario(model, scen, version='new', annotation=annot, scheme=\"MESSAGE\")"
+    "scenario = message_ix$Scenario(mp, model, scen, version='new', annotation=annot)"
    ]
   },
   {


### PR DESCRIPTION
Fixes #39 change in message_ix model paths redefined considering the new sub-folder message_ix/model
Fixes #31 I only updated the reticulate tutorial because it is the only one using the new message_ix specific classes, form the python code.
