### PR TITLE
set model config in install.bat

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -21,6 +21,8 @@ if %errorlevel% neq 0 GOTO InstallError
 
 setx IXMP_PATH "%MESSAGE_IX%"
 
+messageix-config --model_path message_ix\\model
+
 copy message_ix\\model\\templates\\MESSAGE_master_template.gms message_ix\\model\\MESSAGE_master.gms
 copy message_ix\\model\\templates\\MESSAGE_project_template.gpr message_ix\\model\\MESSAGE_project.gpr
 


### PR DESCRIPTION
This PR adds the command `messageix-config --model_path` to `install.bat`, so that users cloning the GitHub repository and installing it (on Windows) use the GAMS code as cloned from Git and not as "installed" in `C:/ProgramData/Anaconda3/Lib/...`.

The output of this line is quite verbose because the CLI tries to copy files back to the folder where they came from, and then spits out a warning message that the file already exists. Still, an improvement for now...