### PR TITLE
WIP - do not merge: generic MESSAGEix reporting class

### DIFF
--- a/message_ix/__init__.py
+++ b/message_ix/__init__.py
@@ -5,6 +5,7 @@ import ixmp.model_settings as model_settings
 
 from message_ix import default_paths
 from message_ix.core import *
+from message_ix.reporting import *
 
 
 model_file = os.path.join(default_paths.model_path(), '{model}_run.gms')

--- a/message_ix/reporting.py
+++ b/message_ix/reporting.py
@@ -2,9 +2,11 @@
 
 import pandas as pd
 import numpy as np
+import collections
+import six
+
 import message_ix
 import ixmp
-import pyam
 
 
 IAMC_IDX = ['region', 'variable', 'unit', 'year']
@@ -76,6 +78,16 @@ class PostProcess(object):
 def _apply_filters(data, filters):
     keep = np.array([True] * len(data))
     for col, values in filters.items():
-        values = [values] if pyam.isstr(values) else values
+        values = values if islistable(values) else [values]
         keep &= [i in values for i in data[col]]
     return data[keep].copy()
+
+
+def isstr(x):
+    """Returns True if x is a string"""
+    return isinstance(x, six.string_types)
+
+
+def islistable(x):
+    """Returns True if x is a list but not a string"""
+    return isinstance(x, collections.Iterable) and not isstr(x)

--- a/message_ix/reporting.py
+++ b/message_ix/reporting.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+import numpy as np
+import message_ix
+import ixmp
+import pyam
+
+
+IAMC_IDX = ['region', 'variable', 'unit', 'year']
+
+
+class PostProcess(object):
+    """Execute postprocessing on a message_ix.Scenario
+
+    Parameters
+    ----------
+    scenario : message_ix.Scenario
+    """
+    def __init__(self, scenario):
+        if not isinstance(scenario, message_ix.Scenario):
+            msg = 'Postprocess can only be used with a `message_ix.Scenario`'
+            raise ValueError(msg)
+        if np.isnan(scenario.var('OBJ')['lvl']):
+            raise ValueError('this scenario has not been solved!')
+        self.scenario = scenario
+        self.data = pd.DataFrame(columns=IAMC_IDX + ['value'])
+        self.data = self.data.reset_index(drop=True)\
+            .set_index(IAMC_IDX)
+
+    def activity(self, variable, region='node_loc', year='year_act'):
+        """Aggregates the activity level across technologies
+        and converts results to the IAMC template
+
+        Parameters
+        ----------
+        variable: dict
+            mapping of IAMC-variable to filters by variable/parameter columns
+        region: str
+            the variable/parameter column to be used for the IAMC region column
+        year: str
+            the variable/parameter column to be used for the IAMC year column
+        """
+        data = []
+        act = self.scenario.var('ACT')
+        for v, mapping in variable.items():
+            df = _apply_filters(act, mapping)
+            df['variable'] = v
+            df['unit'] = ''
+            df.rename(columns={region: 'region', year: 'year', 'lvl': 'value'},
+                      inplace=True)
+            df = df.groupby(IAMC_IDX).sum()['value']
+            data.append(df)
+        data = pd.concat(data).to_frame()
+        self.data = data.combine_first(self.data)
+
+    def finalize(self, comment=None):
+        """Finalizes the reporting by committing to the database
+
+        Parameters
+        ----------
+        comment: str, optional
+            annotation for commit of timeseries to the database
+        """
+        try:
+            self.scenario.check_out(timeseries_only=True)
+            self.scenario.add_timeseries(self.data.reset_index())
+            self.commit(comment or 'MESSAGEix postprocessing')
+        except Exception:
+            self.scenario.discard_changes()
+            ixmp.logger().error('Error saving timeseries data to the database')
+
+
+# %%  auxiliary functions
+
+def _apply_filters(data, filters):
+    keep = np.array([True] * len(data))
+    for col, values in filters.items():
+        values = [values] if pyam.isstr(values) else values
+        keep &= [i in values for i in data[col]]
+    return data[keep].copy()

--- a/message_ix/reporting.py
+++ b/message_ix/reporting.py
@@ -65,7 +65,7 @@ class PostProcess(object):
         try:
             self.scenario.check_out(timeseries_only=True)
             self.scenario.add_timeseries(self.data.reset_index())
-            self.commit(comment or 'MESSAGEix postprocessing')
+            self.scenario.commit(comment or 'MESSAGEix postprocessing')
         except Exception:
             self.scenario.discard_changes()
             ixmp.logger().error('Error saving timeseries data to the database')

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -57,7 +57,7 @@ def test_westeros(capsys):
     nb, errors = _notebook_run(fname, capsys=capsys)
     assert errors == []
 
-    obs = eval(nb.cells[-11]['outputs'][0]['data']['text/plain'])
+    obs = eval(nb.cells[-16]['outputs'][0]['data']['text/plain'])
     exp = 3.600316973564438e+17
     assert np.isclose(obs, exp)
 

--- a/tutorial/westeros/westeros.ipynb
+++ b/tutorial/westeros/westeros.ipynb
@@ -1226,7 +1226,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pp.activity({'Wind': {'technology': 'wind_ppl'}})"
+    "pp.activity(\n",
+    "    {'Primary Energy|Wind': {'technology': 'wind_ppl'},\n",
+    "     'Primary Energy|Coal|Vintage 690': {'technology': 'coal_ppl', 'year_vtg': 690},\n",
+    "     'Primary Energy|Coal|Vintage 700': {'technology': 'coal_ppl', 'year_vtg': 700},\n",
+    "     'Primary Energy|Coal|Vintage 710': {'technology': 'coal_ppl', 'year_vtg': 710},\n",
+    "     'Primary Energy|Coal|Vintage 720': {'technology': 'coal_ppl', 'year_vtg': 720}\n",
+    "    }\n",
+    ")"
    ]
   },
   {

--- a/tutorial/westeros/westeros.ipynb
+++ b/tutorial/westeros/westeros.ipynb
@@ -1197,6 +1197,49 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## First suggestion for new postprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp._jobj.addNode('Westeros', '', '')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp = message_ix.PostProcess(scenario)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp.activity({'Wind': {'technology': 'wind_ppl'}})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pp.finalize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "slideshow": {
      "slide_type": "slide"


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

# Adding to RELEASE_NOTES.md

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

This PR is intended to restart the discussion concerning the API of a generic MESSAEGix reporting class, based on existing work byn @OFR-IIASA and @ClaraLuisa (but as a new clean class to make the discussion more focused).

The use of this class is illustrated in the Westeros tutorial, and looks like

```
pp = message_ix.PostProcess(scenario)
pp.activity({'Wind': {'technology': 'wind_ppl'}})
pp.finalize()
```

where the first line initializes the postprocessing class, the second line is an example of how to translate results to an IAMC-style timeseries variable (only activity implemented now), and the third line commits the generated reporting to the database.

The `finalize()` function could also be used to perform aggregations over the nodes or across variables (e.g, from `Primary Energy|*` to `Primary Energy`).

One open question for me is whether all timeseries existing in the scenario (for example historical data before the first model year) should be loaded to the `PostProcess` instance at the beginning.