### PR TITLE
Refactoring Scenario api for consistency with `ixmp.Scenario`

### DIFF
--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -55,8 +55,7 @@ class Scenario(ixmp.Scenario):
 
         self.is_message_scheme = True
 
-        super(Scenario, self).__init__(
-              mp, model, scenario, jscen, cache=cache)
+        super(Scenario, self).__init__(mp, model, scenario, jscen, cache=cache)
 
     def add_spatial_sets(self, data):
         """Add sets related to spatial dimensions of the model

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -53,6 +53,7 @@ class Scenario(ixmp.Scenario):
         else:
             jscen = mp._jobj.getScenario(model, scenario)
 
+        self.is_message_scheme = True
 
         super(Scenario, self).__init__(
               mp, model, scenario, jscen, cache=cache)

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -1,6 +1,7 @@
 import collections
 import ixmp
 import itertools
+import warnings
 
 import pandas as pd
 
@@ -10,17 +11,17 @@ from message_ix.utils import isscalar, logger
 
 class Scenario(ixmp.Scenario):
 
-    def __init__(self, platform, model, scen, version=None, annotation=None,
-                 cache=False, clone=None):
+    def __init__(self, mp, model, scenario, version=None, annotation=None,
+                 cache=False, clone=None, **kwargs):
         """Initialize a new message_ix.Scenario (structured input data and solution)
         or get an existing scenario from the ixmp database instance
 
         Parameters
         ----------
-        platform : ixmp.Platform
+        mp : ixmp.Platform
         model : string
             model name
-        scen : string
+        scenario : string
             scenario name
         version : string or integer
             initialize a new scenario (if version == 'new'), or
@@ -32,23 +33,29 @@ class Scenario(ixmp.Scenario):
         clone : Scenario, optional
             make a clone of an existing scenario
         """
+        if 'scen' in kwargs:
+            warnings.warn(
+                '`scen` is deprecated and will be removed in the next' +
+                ' release, please use `scenario`')
+            scenario = kwargs.pop('scen')
+
         if version is not None and clone is not None:
             raise ValueError(
                 'Can not provide both version and clone as arguments')
-        jobj = platform._jobj
         if clone is not None:
-            jscen = clone._jobj.clone(model, scen, annotation,
+            jscen = clone._jobj.clone(model, scenario, annotation,
                                       clone._keep_sol, clone._first_model_year)
         elif version == 'new':
             scheme = 'MESSAGE'
-            jscen = jobj.newScenario(model, scen, scheme, annotation)
+            jscen = mp._jobj.newScenario(model, scenario, scheme, annotation)
         elif isinstance(version, int):
-            jscen = jobj.getScenario(model, scen, version)
+            jscen = mp._jobj.getScenario(model, scenario, version)
         else:
-            jscen = jobj.getScenario(model, scen)
+            jscen = mp._jobj.getScenario(model, scenario)
+
 
         super(Scenario, self).__init__(
-            platform, model, scen, jscen, cache=cache)
+              mp, model, scenario, jscen, cache=cache)
 
     def add_spatial_sets(self, data):
         """Add sets related to spatial dimensions of the model

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -11,7 +11,7 @@ from message_ix.utils import isscalar, logger
 
 class Scenario(ixmp.Scenario):
 
-    def __init__(self, mp, model, scenario, version=None, annotation=None,
+    def __init__(self, mp, model, scenario=None, version=None, annotation=None,
                  cache=False, clone=None, **kwargs):
         """Initialize a new message_ix.Scenario (structured input data and solution)
         or get an existing scenario from the ixmp database instance


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

# Adding to RELEASE_NOTES.md

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description

This PR implements two refactors (arg `mp` instead of  platform, `scenario` instead of `scen`) for the `message_ix.Scenario` constructor in line with recent changes in `ixmp`. It also adds an attribute `is_message_scheme` for a subsequent validation/deprecation warning in `ixmp.Scenario` (see https://github.com/iiasa/ixmp/pull/79).