### PR TITLE
MESSAGEix manuscript reference update #107

### DIFF
--- a/NOTICE.rst
+++ b/NOTICE.rst
@@ -46,13 +46,13 @@ A) Reference to the scientific publication and online resources
 Please cite the following manuscript when using the |MESSAGEix| framework and/or the ix modeling platform 
 for scientific publications or technical reports:
 
-  Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
-  Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
-  Keywan Riahi, and Volker Krey.
-  "The MESSAGEix Integrated Assessment Model and the ix modeling platform".
-  *Environmental Modelling & Software* 112:143-156, 2019. 
-  doi: `10.1016/j.envsoft.2018.11.012`_
-  electronic pre-print available at `pure.iiasa.ac.at/15157/`_.
+  | Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
+    Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
+    Keywan Riahi, and Volker Krey.
+  | "The MESSAGEix Integrated Assessment Model and the ix modeling platform".
+  | *Environmental Modelling & Software* 112:143-156, 2019. 
+  | doi: `10.1016/j.envsoft.2018.11.012`_
+  | electronic pre-print available at `pure.iiasa.ac.at/15157/`_.
 
 Also, please include a hyperlink to the online resource `MESSAGEix.iiasa.ac.at`_
 in any publication/report, or on a website describing your model
@@ -92,7 +92,9 @@ Please refer to `Contributor Guidelines`_ for details.
 References
 ----------
 
-[1] Clara Orthofer, Daniel Huppmann, and Volker Krey. "South Africa's shale gas resources - chance or challenge?"
-2018, submitted. Electronic pre-print available at `pure.iiasa.ac.at/15085/`_.
+[1] | Clara Orthofer, Daniel Huppmann, and Volker Krey.
+    | "South Africa's shale gas resources - chance or challenge?"
+    | 2018, submitted. 
+      electronic pre-print available at `pure.iiasa.ac.at/15085/`_
 
 .. _`pure.iiasa.ac.at/15085/` : https://pure.iiasa.ac.at/15085/

--- a/NOTICE.rst
+++ b/NOTICE.rst
@@ -46,14 +46,19 @@ A) Reference to the scientific publication and online resources
 Please cite the following manuscript when using the |MESSAGEix| framework and/or the ix modeling platform 
 for scientific publications or technical reports:
 
-  Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, 
-  Clara Orthofer, Michael Pimmer, Adriano Vinca, Alessio Mastrucci, Keywan Riahi, and Volker Krey. 
-  "The |MESSAGEix| Integrated Assessment Model and the ix modeling platform". 2018, submitted. 
-  Electronic pre-print available at `pure.iiasa.ac.at/15157/`_.
+  Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
+  Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
+  Keywan Riahi, and Volker Krey.
+  "The MESSAGEix Integrated Assessment Model and the ix modeling platform".
+  *Environmental Modelling & Software* 112:143-156, 2019. 
+  doi: `10.1016/j.envsoft.2018.11.012`_
+  electronic pre-print available at `pure.iiasa.ac.at/15157/`_.
 
 Also, please include a hyperlink to the online resource `MESSAGEix.iiasa.ac.at`_
 in any publication/report, or on a website describing your model
-or scientific analysis using the |MESSAGEix| framework.
+or scientific analysis using the MESSAGEix framework.
+
+..  _`10.1016/j.envsoft.2018.11.012` : https://doi.org/10.1016/j.envsoft.2018.11.012
 
 .. _`pure.iiasa.ac.at/15157/` : https://pure.iiasa.ac.at/15157/
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ master branch of the repository
 Please cite the following manuscript when using the MESSAGEix framework and/or
 the ix modeling platform for scientific publications or technical reports:
 
-  Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
-  Michael Pimmer, Adriano Vinca, Alessio Mastrucci, Keywan Riahi, and Volker
-  Krey.  "The |MESSAGEix| Integrated Assessment Model and the ix modeling
-  platform". 2018, submitted.  Electronic pre-print available at
-  [pure.iiasa.ac.at/15157/](https://pure.iiasa.ac.at/15157/).
-
+> Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
+  Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
+  Keywan Riahi, and Volker Krey.  
+  "The |MESSAGEix| Integrated Assessment Model and the ix modeling platform".  
+  *Environmental Modelling & Software* 112:143-156, 2019.   
+  doi: [10.1016/j.envsoft.2018.11.012](https://doi.org/10.1016/j.envsoft.2018.11.012)  
+  electronic pre-print available at
+  [pure.iiasa.ac.at/15157/](https://pure.iiasa.ac.at/15157/)
 
 
 ## Install from Conda (New Users)

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,9 +1,0 @@
-`ixmp` API Documentation
-------------------------
-
-.. include:: api/ixmp.rst
-
-`message_ix` API Documentation
-------------------------------
-
-.. include:: api/message_ix.rst

--- a/doc/source/bibs/main.bib
+++ b/doc/source/bibs/main.bib
@@ -4,7 +4,7 @@
              Kushin, Nikolay and Vinca, Adriano and Mastrucci, Alessio and
              Riahi, Keywan and Krey, Volker},
    title = {{The MESSAGEix Integrated Assessment Model and the ix modeling platform (ixmp): An open framework for integrated and cross-cutting analysis of energy, climate, the environment, and sustainable development}},
-   journal = {Environmental Modelling & Software},
+   journal = {Environmental Modelling \& Software},
    volume = {112},
    pages = {143-156},
    year = {2019},

--- a/doc/source/bibs/main.bib
+++ b/doc/source/bibs/main.bib
@@ -1,19 +1,15 @@
-%% This BibTeX bibliography file was created using BibDesk.
-%% http://bibdesk.sourceforge.net/
-
-%% Created for Daniel Huppmann at 2018-03-09 15:33:09 +0100 
-
-
-%% Saved with string encoding Unicode (UTF-8) 
-
-
-
-@misc{huppmann_messageix_2018,
-	Author = {Huppmann, Daniel and Gidden, Matthew and Fricko, Oliver and Kolp, Peter and Orthofer, Clara and Pimmer, Michael and Vinca, Adriano and Mastrucci, Alessio and Riahi, Keywan and Krey, Volker},
-	Date-Modified = {2018-03-09 14:33:06 +0000},
-	Title = {{The MESSAGEix Integrated Assessment Model and the ix modeling platform}},
-	Url = {https://pure.iiasa.ac.at/15157/},
-	Year = {submitted}}
+@article{huppmann_messageix_2018,
+   author = {Huppmann, Daniel and Gidden, Matthew and Fricko, Oliver and
+             Kolp, Peter and Orthofer, Clara and Pimmer, Michael and
+             Kushin, Nikolay and Vinca, Adriano and Mastrucci, Alessio and
+             Riahi, Keywan and Krey, Volker},
+   title = {{The MESSAGEix Integrated Assessment Model and the ix modeling platform (ixmp): An open framework for integrated and cross-cutting analysis of energy, climate, the environment, and sustainable development}},
+   journal = {Environmental Modelling & Software},
+   volume = {112},
+   pages = {143-156},
+   year = {2019},
+   doi = {10.1016/j.envsoft.2018.11.012}
+}
 
 @article{johnson_VRE_2016,
 	Abstract = {Abstract In many climate change mitigation scenarios, integrated assessment models of the energy and climate systems rely heavily on renewable energy technologies with variable and uncertain generation, such as wind and solar PV, to achieve substantial decarbonization of the electricity sector. However, these models often include very little temporal resolution and thus have difficulty in representing the integration costs that arise from mismatches between electricity supply and demand. The global integrated assessment model, MESSAGE, has been updated to explicitly model the trade-offs between variable renewable energy (VRE) deployment and its impacts on the electricity system, including the implications for electricity curtailment, backup capacity, and system flexibility. These impacts have been parameterized using a reduced-form approach, which allows \{VRE\} integration impacts to be quantified on a regional basis. In addition, thermoelectric technologies were updated to include two modes of operation, baseload and flexible, to better account for the cost, efficiency, and availability penalties associated with flexible operation. In this paper, the modeling approach used in \{MESSAGE\} is explained and the implications for \{VRE\} deployment in mitigation scenarios are assessed. Three important stylized facts associated with integrating high \{VRE\} shares are successfully reproduced by our modeling approach: (1) the significant reduction in the utilization of non-VRE power plants; (2) the diminishing role for traditional baseload generators, such as nuclear and coal, and the transition to more flexible technologies; and (3) the importance of electricity storage and hydrogen electrolysis in facilitating the deployment of VRE. },

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -34,7 +34,7 @@ to `GAMS`_ for numerical computation.
 This documentation provides an introduction and the mathematical formulation 
 of the |MESSAGEix| equations and auxiliary functions.
 For the scientific reference of the framework, 
-see Huppmann et al. (submitted) :cite:`huppmann_messageix_2018`.
+see Huppmann et al. (2019) :cite:`huppmann_messageix_2018`.
 The formulation of |MESSAGEix| is a re-implementation and extension of `'MESSAGE V'`
 (Messner and Strubegger, 1995 :cite:`messner_users_1995`),
 the Integrated Assessment model developed at IIASA since the 1980s.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -84,7 +84,8 @@ API Documentation
 .. toctree::
    :maxdepth: 1
    
-   api
+   api/ixmp
+   api/message_ix
 
 Using |MESSAGEix|
 -----------------

--- a/doc/source/model.rst
+++ b/doc/source/model.rst
@@ -43,6 +43,8 @@ There are three methods to run the |MESSAGEix| model:
   The scenario name and other arguments can be passed as command line parameters, 
   e.g. :literal:`gams MESSAGE_run.gms --in="<data-file>" --out="<output-file>"`.
 
+.. _`tutorials`: tutorials.html
+
 .. _`auto-doc page`: model/MESSAGE_run.html
    
 Overview of model structure and includes files

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -23,10 +23,13 @@ and the ix modeling platform, please visit `MESSAGEix.iiasa.ac.at/`.
 
 When using the MESSAGEix framework, please cite as:
 
-    Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, 
-    Clara Orthofer, Michael Pimmer, Adriano Vinca, Alessio Mastrucci, Keywan Riahi, and Volker Krey.
-    "The MESSAGEix Integrated Assessment Model and the ix modeling platform". 2018, submitted. 
-    Electronic pre-print available at `pure.iiasa.ac.at/15157/`.
+   Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
+   Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
+   Keywan Riahi, and Volker Krey.
+   "The |MESSAGEix| Integrated Assessment Model and the ix modeling platform".
+   Environmental Modelling & Software 112:143-156, 2019.
+   doi: 10.1016/j.envsoft.2018.11.012
+   electronic pre-print available at pure.iiasa.ac.at/15157/
 
 Please review the NOTICE at `MESSAGEix.iiasa.ac.at/notice.html`
 and included in the GitHub repository for further user guidelines.

--- a/message_ix/model/MESSAGE_run.gms
+++ b/message_ix/model/MESSAGE_run.gms
@@ -23,10 +23,13 @@ and the ix modeling platform, please visit `MESSAGEix.iiasa.ac.at/`.
 
 When using the MESSAGEix framework, please cite as:
 
-    Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, 
-    Clara Orthofer, Michael Pimmer, Adriano Vinca, Alessio Mastrucci, Keywan Riahi, and Volker Krey.
-    "The MESSAGEix Integrated Assessment Model and the ix modeling platform". 2018, submitted. 
-    Electronic pre-print available at `pure.iiasa.ac.at/15157/`.
+   Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
+   Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
+   Keywan Riahi, and Volker Krey.
+   "The |MESSAGEix| Integrated Assessment Model and the ix modeling platform".
+   Environmental Modelling & Software 112:143-156, 2019.
+   doi: 10.1016/j.envsoft.2018.11.012
+   electronic pre-print available at pure.iiasa.ac.at/15157/
 
 Please review the NOTICE at `MESSAGEix.iiasa.ac.at/notice.html`
 and included in the GitHub repository for further user guidelines.

--- a/message_ix/model/templates/MESSAGE_master_template.gms
+++ b/message_ix/model/templates/MESSAGE_master_template.gms
@@ -23,10 +23,13 @@ and the ix modeling platform, please visit `MESSAGEix.iiasa.ac.at/`.
 
 When using the MESSAGEix framework, please cite as:
 
-    Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, 
-    Clara Orthofer, Michael Pimmer, Adriano Vinca, Alessio Mastrucci, Keywan Riahi, and Volker Krey.
-    "The MESSAGEix Integrated Assessment Model and the ix modeling platform". 2018, submitted. 
-    Electronic pre-print available at `pure.iiasa.ac.at/15157/`.
+   Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
+   Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
+   Keywan Riahi, and Volker Krey.
+   "The |MESSAGEix| Integrated Assessment Model and the ix modeling platform".
+   Environmental Modelling & Software 112:143-156, 2019.
+   doi: 10.1016/j.envsoft.2018.11.012
+   electronic pre-print available at pure.iiasa.ac.at/15157/
 
 Please review the NOTICE at `MESSAGEix.iiasa.ac.at/notice.html`
 and included in the GitHub repository for further user guidelines.

--- a/rmessageix/source/README.md
+++ b/rmessageix/source/README.md
@@ -10,8 +10,11 @@ http://MESSAGEix.iiasa.ac.at
 
 References
 
-Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp,  
-  Clara Orthofer, Michael Pimmer, Adriano Vinca, Alessio Mastrucci, Keywan Riahi, and Volker Krey.  
-  "The MESSAGEix Integrated Assessment Model and the ix modeling platform".  
-  2018, submitted. 
-
+Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
+  Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
+  Keywan Riahi, and Volker Krey.
+  "The |MESSAGEix| Integrated Assessment Model and the ix modeling platform".
+  *Environmental Modelling & Software* 112:143-156, 2019. 
+  doi: [10.1016/j.envsoft.2018.11.012](https://doi.org/10.1016/j.envsoft.2018.11.012)
+  electronic pre-print available at
+  [pure.iiasa.ac.at/15157/](https://pure.iiasa.ac.at/15157/).


### PR DESCRIPTION
This PR updates the references in the documentation, notice, etc. to the published version of the MESSAGEix manuscript and to the latest version of the MESSAGEix South Africa manuscript.

The changes are the equivalent updates to https://github.com/iiasa/ixmp/pull/107