### PR TITLE
no copying gdx files during install and setting of model directory

### DIFF
--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -12,13 +12,11 @@ from six.moves.urllib.request import urlretrieve
 from message_ix.default_path_constants import CONFIG_PATH, DEFAULT_MODEL_PATH
 from message_ix.utils import logger
 
-GMS_EXT = ['.gms', '.opt', '.md']
 
-
-def recursive_copy(src, dst, overwrite=False, valid_ext=GMS_EXT):
+def recursive_copy(src, dst, overwrite=False, skip_ext=[]):
     """Copy src to dst recursively"""
     for root, dirs, files in os.walk(src):
-        for f in [_f for _f in files if os.path.splitext(_f)[1] in valid_ext]:
+        for f in [f for f in files if os.path.splitext(f)[1] not in skip_ext]:
             rel_path = root.replace(src, '').lstrip(os.sep)
             dst_path = os.path.join(dst, rel_path)
 
@@ -50,7 +48,8 @@ def do_config(model_path=None, overwrite=False):
         if not os.path.exists(model_path):
             logger().info('Creating model directory: {}'.format(model_path))
             os.makedirs(model_path)
-        recursive_copy(DEFAULT_MODEL_PATH, model_path, overwrite=overwrite)
+        recursive_copy(DEFAULT_MODEL_PATH, model_path, overwrite=overwrite,
+                       skip_ext=['gdx'])
         config['MODEL_PATH'] = model_path
 
     # overwrite config if already exists

--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -2,7 +2,6 @@ import argparse
 import json
 import message_ix
 import os
-import pathlib
 import shutil
 import tempfile
 import zipfile
@@ -19,7 +18,7 @@ GMS_EXT = ['.gms', '.opt', '.md']
 def recursive_copy(src, dst, overwrite=False, valid_ext=GMS_EXT):
     """Copy src to dst recursively"""
     for root, dirs, files in os.walk(src):
-        for f in [_f for _f in files if pathlib.Path(_f).suffix in valid_ext]:
+        for f in [_f for _f in files if os.path.splitext(_f)[1] in valid_ext]:
             rel_path = root.replace(src, '').lstrip(os.sep)
             dst_path = os.path.join(dst, rel_path)
 

--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import message_ix
 import os
+from os.path import splitext
 import shutil
 import tempfile
 import zipfile
@@ -12,11 +13,13 @@ from six.moves.urllib.request import urlretrieve
 from message_ix.default_path_constants import CONFIG_PATH, DEFAULT_MODEL_PATH
 from message_ix.utils import logger
 
+GMS_EXT = ['.gms', '.opt', '.md']
+
 
 def recursive_copy(src, dst, overwrite=False):
     """Copy src to dst recursively"""
     for root, dirs, files in os.walk(src):
-        for f in files:
+        for f in [_f for _f in files if splitext(_f)[1] in GMS_EXT]:
             rel_path = root.replace(src, '').lstrip(os.sep)
             dst_path = os.path.join(dst, rel_path)
 

--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import message_ix
 import os
-from os.path import splitext
+import pathlib
 import shutil
 import tempfile
 import zipfile
@@ -16,10 +16,10 @@ from message_ix.utils import logger
 GMS_EXT = ['.gms', '.opt', '.md']
 
 
-def recursive_copy(src, dst, overwrite=False):
+def recursive_copy(src, dst, overwrite=False, valid_ext=GMS_EXT):
     """Copy src to dst recursively"""
     for root, dirs, files in os.walk(src):
-        for f in [_f for _f in files if splitext(_f)[1] in GMS_EXT]:
+        for f in [_f for _f in files if pathlib.Path(_f).suffix in valid_ext]:
             rel_path = root.replace(src, '').lstrip(os.sep)
             dst_path = os.path.join(dst, rel_path)
 

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,12 @@ EXTRAS_REQUIRE = {
     'tutorial': ['jupyter', 'matplotlib'],
 }
 
-GMS_EXT = ['.gms', '.opt', '.md']
 
-
-def all_subdirs(path, strip=None):
+def all_gams_files(path, strip=None):
     paths = []
     for root, dirnames, files in os.walk(path):
-        for f in [_f for _f in files if os.path.splitext(_f)[1] in GMS_EXT]:
+        for f in [_f for _f in files
+                  if os.path.splitext(_f)[1] in ['.gms', '.opt', '.md']]:
             paths.append(os.path.join(root, f))
     if strip:
         n = len(strip) if strip.endswith(os.sep) else len(strip + os.sep)
@@ -63,10 +62,7 @@ def main():
     cmdclass = {
     }
     pack_data = {
-        # for some reason the model/ directory had to be added separately
-        # it worked locally but not on CI:
-        # https://circleci.com/gh/iiasa/message_ix/29
-        'message_ix': all_subdirs('message_ix/model', strip='message_ix')
+        'message_ix': all_gams_files('message_ix/model', strip='message_ix')
     }
     setup_kwargs = {
         "name": "message_ix",

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,14 @@ EXTRAS_REQUIRE = {
     'tutorial': ['jupyter', 'matplotlib'],
 }
 
+GMS_EXT = ['.gms', '.opt', '.md']
+
 
 def all_subdirs(path, strip=None):
     paths = []
-    for root, dirnames, filenames in os.walk(path):
-        for dirname in dirnames:
-            paths.append(os.path.join(root, dirname, '*'))
+    for root, dirnames, files in os.walk(path):
+        for f in [_f for _f in files if os.path.splitext(_f)[1] in GMS_EXT]:
+            paths.append(os.path.join(root, f))
     if strip:
         n = len(strip) if strip.endswith(os.sep) else len(strip + os.sep)
         paths = [x[n:] for x in paths]
@@ -64,8 +66,7 @@ def main():
         # for some reason the model/ directory had to be added separately
         # it worked locally but not on CI:
         # https://circleci.com/gh/iiasa/message_ix/29
-        'message_ix': all_subdirs('message_ix/model', strip='message_ix') +
-        ['model/*gms', 'model/*opt'],
+        'message_ix': all_subdirs('message_ix/model', strip='message_ix')
     }
     setup_kwargs = {
         "name": "message_ix",


### PR DESCRIPTION
This PR changes the setup and model-directory config such that `gdx` files are no longer copied back and forth.