### PR TITLE
Fix 2-platform cloning & associated tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,11 @@
 
 # Next Release
 
+- [#182](https://github.com/iiasa/message_ix/pull/182): Fix cross-platform cloning.
 - [#173](https://github.com/iiasa/message_ix/pull/173): The `solve` command now takes additional arguments when solving with CPLEX. The `cplex.opt` file is now generated on the fly during the solve command and removed after successfully solving.
 - [#154](https://github.com/iiasa/message_ix/pull/154): Enable documentation build on ReadTheDocs.
 - [#138](https://github.com/iiasa/message_ix/pull/138): Update documentation and tutorials.
-- [#131](https://github.com/iiasa/message_ix/pull/131): Update clone function syntax scen to scenario
+- [#131](https://github.com/iiasa/message_ix/pull/131): Update clone function argument `scen` to `scenario` with planned deprecation of the former.
 
 # v1.1.0
 

--- a/doc/source/api/ixmp.rst
+++ b/doc/source/api/ixmp.rst
@@ -11,20 +11,28 @@
    TimeSeries
    Scenario
 
-as well as some utility methods:
+as well as some utility classes and methods:
 
 .. autosummary::
 
+   ixmp.config.Config
    ixmp.model_settings.register_model
+   ixmp.testing.dantzig_transport
 
 Core classes
 ------------
 
 .. automodule:: ixmp
-   :members: DEFAULT_LOCAL_DB_PATH, Platform, TimeSeries, Scenario
+   :members: Platform, TimeSeries, Scenario
 
 Utility methods
 ---------------
 
+.. automodule:: ixmp.config
+   :members: Config
+
 .. automodule:: ixmp.model_settings
    :members: register_model
+
+.. automodule:: ixmp.testing
+   :members: dantzig_transport

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -319,43 +319,6 @@ class Scenario(ixmp.Scenario):
         os.remove(fname)
         return ret
 
-    def clone(self, model=None, scenario=None, annotation=None,
-              keep_solution=True, first_model_year=None, **kwargs):
-        """clone the current scenario and return the new scenario
-
-        Parameters
-        ----------
-        model : string
-            new model name
-        scenario : string
-            new scenario name
-        annotation : string
-            explanatory comment (optional)
-        keep_solution : boolean, default, True
-            indicator whether to include an existing solution
-            in the cloned scenario
-        first_model_year: int, default None
-            new first model year in cloned scenario
-            ('slicing', only available for MESSAGE-scheme scenarios)
-        """
-        if 'keep_sol' in kwargs:
-            warnings.warn(
-                '`keep_sol` is deprecated and will be removed in the next' +
-                ' release, please use `keep_solution`')
-            keep_solution = kwargs.pop('keep_sol')
-        if 'scen' in kwargs:
-            warnings.warn(
-                '`scen` is deprecated and will be removed in the next' +
-                ' release, please use `scenario`')
-            scenario = kwargs.pop('scen')
-
-        self._keep_sol = keep_solution
-        self._first_model_year = first_model_year or 0
-        model = self.model if not model else model
-        scenario = self.scenario if not scenario else scenario
-        return Scenario(self.platform, model, scenario, annotation=annotation,
-                        cache=self._cache, clone=self)
-
     def rename(self, name, mapping, keep=False):
         """Rename an element in a set
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,10 @@
 import os
 import pytest
 import shutil
-import subprocess
 import tempfile
 
 import ixmp
 
-from ixmp.default_path_constants import CONFIG_PATH
 
 here = os.path.dirname(os.path.realpath(__file__))
 
@@ -46,60 +44,6 @@ def test_mp():
     mp.open_db()
 
     yield mp
-
-
-@pytest.fixture()
-def test_mp_use_db_config_path():
-    assert not os.path.exists(CONFIG_PATH)
-
-    test_props = create_local_testdb()
-    dirname = os.path.dirname(test_props)
-    basename = os.path.basename(test_props)
-
-    # configure
-    cmd = 'ixmp-config --db_config_path {}'.format(dirname)
-    subprocess.check_call(cmd.split())
-
-    # start jvm
-    ixmp.start_jvm()
-
-    # launch Platform and connect to testdb (reconnect if closed)
-    try:
-        mp = ixmp.Platform(basename)
-        mp.open_db()
-    except:
-        os.remove(CONFIG_PATH)
-        raise
-
-    yield mp
-
-    os.remove(CONFIG_PATH)
-
-
-@pytest.fixture()
-def test_mp_use_default_dbprops_file():
-    assert not os.path.exists(CONFIG_PATH)
-
-    test_props = create_local_testdb()
-
-    # configure
-    cmd = 'ixmp-config --default_dbprops_file {}'.format(test_props)
-    subprocess.check_call(cmd.split())
-
-    # start jvm
-    ixmp.start_jvm()
-
-    # launch Platform and connect to testdb (reconnect if closed)
-    try:
-        mp = ixmp.Platform()
-        mp.open_db()
-    except:
-        os.remove(CONFIG_PATH)
-        raise
-
-    yield mp
-
-    os.remove(CONFIG_PATH)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This PR…
- closes #174 by deleting `message_ix.Scenario.clone()`, letting `ixmp.Scenario.clone()` do the work.
- fixes tests broken by [ixmp#130](https://github.com/iiasa/ixmp/pull/130).
- adds tests for cloning of MESSAGEix scenarios.

**PR checklist:**
- [x] Tests added
- [x] Documentation added
- [x] Description in RELEASE_NOTES.md added