### PR TITLE
Fix wrong electricity consumption in tutorial

### DIFF
--- a/tutorial/westeros/westeros_baseline.ipynb
+++ b/tutorial/westeros/westeros_baseline.ipynb
@@ -398,7 +398,7 @@
     }
    },
    "source": [
-    "Note present day: [~17000 GWh in Austria](http://www.iea.org/statistics/statisticssearch/report/?country=AUSTRIA&product=electricityandheat&year=2015) with population [~9M](http://www.austria.org/population/) which is ~1890 kWh per capita"
+    "Note present day: [~72000 GWh in Austria](https://www.iea.org/statistics/?country=AUSTRIA&year=2016&category=Energy%20consumption&indicator=undefined&mode=chart&dataTable=INDICATORS) with population [~8.7M](http://www.austria.org/population/) which is ~8300 kWh per capita"
    ]
   },
   {


### PR DESCRIPTION
The old link does not work any longer (404 error), but 17000 GWh
electricity consumption per year is probably a typo and should be 71000
GWh (in 2016 it rose to 72000 GWh).

(I guess this fix is too small to be mentioned in the release notes.)