### PR TITLE
Change URLs in tutorial/README.rst to point to 1.2.0 tutorials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - source activate testing
 
 install:
-  - git clone https://github.com/iiasa/ixmp.git
+  - git clone --depth 1 --branch v0.2.0 https://github.com/iiasa/ixmp.git
   - cd ixmp && python setup.py install && cd ..
   - pip install .[reporting]
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See `doc/README.md` for further details.
 
 ### Installation
 
-See [‘Installation’ in the documentation](https://message.iiasa.ac.at/en/v1.2/getting_started.html) or the file `INSTALL.rst`.
+See [‘Installation’ in the documentation](https://message.iiasa.ac.at/en/v1.2.0/getting_started.html) or the file `INSTALL.rst`.
 
 
 ### Tutorials

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ See `doc/README.md` for further details.
 
 ### Installation
 
-See [‘Installation’ in the documentation](https://message.iiasa.ac.at/en/v1.2.0/getting_started.html) or the file `INSTALL.rst`.
+See [‘Installation’ in the documentation](https://message.iiasa.ac.at/en/1.2.x/getting_started.html) or the file `INSTALL.rst`.
 
 
 ### Tutorials
 
 Several introductory tutorials are provided.
-See [‘Tutorials’ in the documentation](https://message.iiasa.ac.at/en/v1.2/tutorials.html) or the file
+See [‘Tutorials’ in the documentation](https://message.iiasa.ac.at/en/1.2.x/tutorials.html) or the file
 `tutorial/README.rst`.
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - conda install --yes -c conda-forge ixmp xlsxwriter xlrd
   - conda remove --force --yes ixmp
 
-  - git clone https://github.com/iiasa/ixmp.git
+  - git clone --depth 1 --branch v0.2.0 https://github.com/iiasa/ixmp.git
   - cd ixmp && python setup.py install && cd ..
 
   - pip install .[reporting]

--- a/tutorial/README.rst
+++ b/tutorial/README.rst
@@ -62,11 +62,11 @@ Westeros Electrified
 This tutorial demonstrates how to model a very simple energy system, and then
 uses it to illustrate a range of framework features.
 
-1. `Build the baseline model <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/westeros/westeros_baseline.ipynb>`_.
-2. `Introduce emissions <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/westeros/westeros_emissions_bounds.ipynb>`_ and a bound on the emissions.
-3. `Limit emissions using a tax <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/westeros/westeros_emissions_taxes.ipynb>`_ instead of a bound.
-4. `Represent both coal and wind electricity <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/westeros/westeros_firm_capacity.ipynb>`_, using a “firm capacity” formulation: each generation technology can supply some firm capacity, but the variable, renewable technology (wind) supplies less than coal.
-5. Represent coal and wind electricity using a different, `“flexibility requirement” formulation <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/westeros/westeros_flexible_generation.ipynb>`_, wherein wind *requires* and coal *supplies* flexibility.
+1. `Build the baseline model <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/westeros/westeros_baseline.ipynb>`_.
+2. `Introduce emissions <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/westeros/westeros_emissions_bounds.ipynb>`_ and a bound on the emissions.
+3. `Limit emissions using a tax <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/westeros/westeros_emissions_taxes.ipynb>`_ instead of a bound.
+4. `Represent both coal and wind electricity <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/westeros/westeros_firm_capacity.ipynb>`_, using a “firm capacity” formulation: each generation technology can supply some firm capacity, but the variable, renewable technology (wind) supplies less than coal.
+5. Represent coal and wind electricity using a different, `“flexibility requirement” formulation <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/westeros/westeros_flexible_generation.ipynb>`_, wherein wind *requires* and coal *supplies* flexibility.
 
 Austrian energy system
 ----------------------
@@ -74,7 +74,7 @@ Austrian energy system
 This tutorial demonstrates a stylized representation of a national electricity
 sector model, with several fossil and renewable power plant types.
 
-1. Prepare the base model version, in `Python <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_reticulate.ipynb>`__.
-2. Plot results, in `Python <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_load_scenario.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_load_scenario_R.ipynb>`__.
-3. `Run a single policy scenario <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_single_policy.ipynb>`_.
-4. Run multiple policy scenarios. This tutorial has two notebooks: `an introduction with some exercises <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_multiple_policies.ipynb>`_ and `completed code for the exercises <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_multiple_policies-answers.ipynb>`_.
+1. Prepare the base model version, in `Python <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/Austrian_energy_system/austria.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/Austrian_energy_system/austria_reticulate.ipynb>`__.
+2. Plot results, in `Python <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/Austrian_energy_system/austria_load_scenario.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/Austrian_energy_system/austria_load_scenario_R.ipynb>`__.
+3. `Run a single policy scenario <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/Austrian_energy_system/austria_single_policy.ipynb>`_.
+4. Run multiple policy scenarios. This tutorial has two notebooks: `an introduction with some exercises <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/Austrian_energy_system/austria_multiple_policies.ipynb>`_ and `completed code for the exercises <https://github.com/iiasa/message_ix/blob/1.2.x/tutorial/Austrian_energy_system/austria_multiple_policies-answers.ipynb>`_.

--- a/tutorial/README.rst
+++ b/tutorial/README.rst
@@ -62,11 +62,11 @@ Westeros Electrified
 This tutorial demonstrates how to model a very simple energy system, and then
 uses it to illustrate a range of framework features.
 
-1. `Build the baseline model <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/westeros/westeros_baseline.ipynb>`_.
-2. `Introduce emissions <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/westeros/westeros_emissions_bounds.ipynb>`_ and a bound on the emissions.
-3. `Limit emissions using a tax <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/westeros/westeros_emissions_taxes.ipynb>`_ instead of a bound.
-4. `Represent both coal and wind electricity <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/westeros/westeros_firm_capacity.ipynb>`_, using a “firm capacity” formulation: each generation technology can supply some firm capacity, but the variable, renewable technology (wind) supplies less than coal.
-5. Represent coal and wind electricity using a different, `“flexibility requirement” formulation <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/westeros/westeros_flexible_generation.ipynb>`_, wherein wind *requires* and coal *supplies* flexibility.
+1. `Build the baseline model <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/westeros/westeros_baseline.ipynb>`_.
+2. `Introduce emissions <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/westeros/westeros_emissions_bounds.ipynb>`_ and a bound on the emissions.
+3. `Limit emissions using a tax <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/westeros/westeros_emissions_taxes.ipynb>`_ instead of a bound.
+4. `Represent both coal and wind electricity <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/westeros/westeros_firm_capacity.ipynb>`_, using a “firm capacity” formulation: each generation technology can supply some firm capacity, but the variable, renewable technology (wind) supplies less than coal.
+5. Represent coal and wind electricity using a different, `“flexibility requirement” formulation <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/westeros/westeros_flexible_generation.ipynb>`_, wherein wind *requires* and coal *supplies* flexibility.
 
 Austrian energy system
 ----------------------
@@ -74,7 +74,7 @@ Austrian energy system
 This tutorial demonstrates a stylized representation of a national electricity
 sector model, with several fossil and renewable power plant types.
 
-1. Prepare the base model version, in `Python <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/Austrian_energy_system/austria.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/Austrian_energy_system/austria_reticulate.ipynb>`__.
-2. Plot results, in `Python <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/Austrian_energy_system/austria_load_scenario.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/Austrian_energy_system/austria_load_scenario_R.ipynb>`__.
-3. `Run a single policy scenario <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/Austrian_energy_system/austria_single_policy.ipynb>`_.
-4. Run multiple policy scenarios. This tutorial has two notebooks: `an introduction with some exercises <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/Austrian_energy_system/austria_multiple_policies.ipynb>`_ and `completed code for the exercises <https://github.com/iiasa/message_ix/blob/v1.1.0/tutorial/Austrian_energy_system/austria_multiple_policies-answers.ipynb>`_.
+1. Prepare the base model version, in `Python <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_reticulate.ipynb>`__.
+2. Plot results, in `Python <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_load_scenario.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_load_scenario_R.ipynb>`__.
+3. `Run a single policy scenario <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_single_policy.ipynb>`_.
+4. Run multiple policy scenarios. This tutorial has two notebooks: `an introduction with some exercises <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_multiple_policies.ipynb>`_ and `completed code for the exercises <https://github.com/iiasa/message_ix/blob/v1.2.0/tutorial/Austrian_energy_system/austria_multiple_policies-answers.ipynb>`_.


### PR DESCRIPTION
This changes the URLs in tutorial/README.rst, so that the built documentation on the `1.2.x` branch will point to the 1.2.0 tutorials.

This change does not require a new patch release (e.g. 1.2.1) because there is not change to code, only docs.