### PR TITLE
Updating the URL to Anaconda in Installation notes

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -68,7 +68,7 @@ Install |MESSAGEix| from source
 
 
 .. _`GAMS`: http://www.gams.com
-.. _`Anaconda`: https://www.continuum.io/downloads
+.. _`Anaconda`: https://www.anaconda.com/distribution/#download-section
 .. _`ixmp`: https://github.com/iiasa/ixmp
 .. _`Github Desktop`: https://desktop.github.com
 .. _`README`: https://github.com/iiasa/message_ix#install-from-source-advanced-users

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -181,7 +181,7 @@ def test_report_as_pyam(test_mp, caplog, tmp_path):
 
     # Result
     idf2 = rep.get(key2)
-    df2 = idf2.as_pandas()
+    df2 = idf2.as_pandas().sort_values(by=['region']).reset_index()
 
     # Extra columns have been removed:
     # - m and t by the collapse callback.

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -181,7 +181,7 @@ def test_report_as_pyam(test_mp, caplog, tmp_path):
 
     # Result
     idf2 = rep.get(key2)
-    df2 = idf2.as_pandas().sort_values(by=['region']).reset_index()
+    df2 = idf2.as_pandas()
 
     # Extra columns have been removed:
     # - m and t by the collapse callback.


### PR DESCRIPTION
The url link to download Anaconda seems broken. This change does not require a new patch release and has no change to the code, only docs.
