### PR TITLE
added import statement for using add_year function in code (vs. via command line)

### DIFF
--- a/message_ix/tools/add_year/README.rst
+++ b/message_ix/tools/add_year/README.rst
@@ -13,7 +13,7 @@ This tool adds new modeling years to an existing :class:`ixmp.Scenario` (hereaft
 
 …additional years can be added after importing the add_year function::
 
-    from tools.add_year import add_year
+    from message_ix.tools.add_year import add_year
     sc_new = message_ix.Scenario(mp, sc_ref.model, sc_ref.scenario,
                                  version='new')
     add_year(sc_ref, sc_new, [705, 712, 718, 725])

--- a/message_ix/tools/add_year/README.rst
+++ b/message_ix/tools/add_year/README.rst
@@ -11,8 +11,9 @@ This tool adds new modeling years to an existing :class:`ixmp.Scenario` (hereaft
     sc_ref.add_horizon({'year': history + model_horizon,
                           'firstmodelyear': model_horizon[0]})
 
-…additional years can be added::
+…additional years can be added after importing the add_year function::
 
+    from tools.add_year import add_year
     sc_new = message_ix.Scenario(mp, sc_ref.model, sc_ref.scenario,
                                  version='new')
     add_year(sc_ref, sc_new, [705, 712, 718, 725])


### PR DESCRIPTION
When trying to run the add_year function from inside a Jupyter notebook I had to import the add_year function from the package first. Adding the import statement explicitly to the README has the benefit of making it easier for less experienced Python users to utilize this function.