### PR TITLE
Fix convert_pyam to take care of year_time_dim bug

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,7 +16,8 @@
   [#259](https://github.com/iiasa/message_ix/pull/259): Build MESSAGE and MESSAGE_MACRO classes on ixmp model API; adjust Scenario.
 - [#235](https://github.com/iiasa/message_ix/pull/236): Add a reporting tutorial.
 - [#236](https://github.com/iiasa/message_ix/pull/236),
-  [#242](https://github.com/iiasa/message_ix/pull/242): Enhance reporting.
+  [#242](https://github.com/iiasa/message_ix/pull/242),
+  [#263](https://github.com/iiasa/message_ix/pull/263): Enhance reporting.
 - [#232](https://github.com/iiasa/message_ix/pull/232): Add Westeros tutorial for modelling seasonality, update existing tutorials.
 
 # v1.2.0

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -272,8 +272,8 @@ class Reporter(IXMPReporter):
                 {'h', 'y', 'ya', 'yr', 'yv'} - {year_time_dim})
             new_key = ':'.join([qty.name, tag])
             self.add(new_key, (partial(computations.as_pyam, drop=to_drop,
-                                       collapse=collapse),
-                               'scenario', year_time_dim, qty))
+                                       collapse=collapse, year_time_dim=year_time_dim),
+                               'scenario', qty))
             keys.append(new_key)
         return keys
 

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -271,9 +271,11 @@ class Reporter(IXMPReporter):
             to_drop = set(drop) | set(qty.dims) & (
                 {'h', 'y', 'ya', 'yr', 'yv'} - {year_time_dim})
             new_key = ':'.join([qty.name, tag])
-            self.add(new_key, (partial(computations.as_pyam, drop=to_drop,
-                                       collapse=collapse, year_time_dim=year_time_dim),
-                               'scenario', qty))
+            comp = partial(computations.as_pyam,
+                           year_time_dim=year_time_dim,
+                           drop=to_drop,
+                           collapse=collapse)
+            self.add(new_key, (comp, 'scenario', qty))
             keys.append(new_key)
         return keys
 

--- a/message_ix/reporting/pyam.py
+++ b/message_ix/reporting/pyam.py
@@ -11,7 +11,7 @@ from pyam import IAMC_IDX, IamDataFrame, concat as pyam_concat
 log = getLogger(__name__)
 
 
-def as_pyam(scenario, year_time_dim, quantities, drop=[], collapse=None):
+def as_pyam(scenario, quantities, year_time_dim, drop=[], collapse=None):
     """Return a :class:`pyam.IamDataFrame` containing *quantities*.
 
     Warnings are logged if the arguments result in additional, unhandled

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -144,8 +144,9 @@ def test_reporter_convert_pyam(test_mp, caplog, tmp_path):
     ACT = rep.full_key('ACT')
 
     # Add a computation that converts ACT to a pyam.IamDataFrame
-    rep.add('ACT IAMC', (partial(computations.as_pyam, drop=['yv']),
-                         'scenario', 'ya', ACT))
+    rep.add('ACT IAMC', (partial(computations.as_pyam, drop=['yv'],
+                                 year_time_dim='ya'),
+                         'scenario', ACT))
 
     # Result is an IamDataFrame
     idf1 = rep.get('ACT IAMC')


### PR DESCRIPTION
When `year_time_dim` was a used key somewhere, a call to `as_pyam` from `convert_pyam` was reading in a wrong parameter and spit out an error message.

**PR checklist:**

- [x] Tests added.
- [x] ~Documentation added.~
- [x] Release notes updated.