### PR TITLE
Updating read_excel for initializing new sets and parameters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@
   [#242](https://github.com/iiasa/message_ix/pull/242),
   [#263](https://github.com/iiasa/message_ix/pull/263): Enhance reporting.
 - [#232](https://github.com/iiasa/message_ix/pull/232): Add Westeros tutorial for modelling seasonality, update existing tutorials.
+- [#265](https://github.com/iiasa/message_ix/pull/265): Modifies excel_read for initializing new sets and parameters when reading from Excel.
 
 # v1.2.0
 

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -390,6 +390,15 @@ class Scenario(ixmp.Scenario):
             'par': self.add_par,
         }
 
+        def is_init(ix_type, name, idx_sets=None):
+            if ix_type == 'set':
+                if name not in self.set_list():
+                    self.init_set(name, idx_sets)
+            elif ix_type == 'par':
+                if name not in self.par_list():
+                    self.init_par(name, idx_sets)
+
+
         logger().info('Reading data from {}'.format(fname))
         dfs = pd_read(fname, sheet_name=None)
 
@@ -409,6 +418,7 @@ class Scenario(ixmp.Scenario):
             if len(data) > 0:
                 ix_type = ix_types[name]
                 logger().info('Loading data for {}'.format(name))
+                is_init(ix_type, name)
                 funcs[ix_type](name, data)
         if commit_steps:
             self.commit('Loaded initial data from {}'.format(fname))
@@ -428,6 +438,8 @@ class Scenario(ixmp.Scenario):
                         self.platform.add_unit(unit)
                 # load data
                 ix_type = ix_types[sheet_name]
+                indxs = [x for x in df.columns if x not in ['unit', 'value']]
+                is_init(ix_type, sheet_name, indxs)
                 funcs[ix_type](sheet_name, df)
                 if commit_steps:
                     self.commit('Loaded {} from {}'.format(sheet_name, fname))

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -371,7 +371,8 @@ class Scenario(ixmp.Scenario):
 
         pd_write(dfs, fname, index=False)
 
-    def read_excel(self, fname, add_units=False, commit_steps=False):
+    def read_excel(self, fname, add_units=False, commit_steps=False,
+                   init_items=True):
         """Read Excel file data and load into the scenario.
 
         Parameters
@@ -384,6 +385,9 @@ class Scenario(ixmp.Scenario):
         commit_steps : bool
             commit changes after every data addition.
             default: False
+        init_items : bool
+            initializes new sets and parameters when reading from Excel.
+            default: True
         """
         funcs = {
             'set': self.add_set,
@@ -418,7 +422,8 @@ class Scenario(ixmp.Scenario):
             if len(data) > 0:
                 ix_type = ix_types[name]
                 logger().info('Loading data for {}'.format(name))
-                is_init(ix_type, name)
+                if init_items:
+                    is_init(ix_type, name)
                 funcs[ix_type](name, data)
         if commit_steps:
             self.commit('Loaded initial data from {}'.format(fname))
@@ -439,7 +444,8 @@ class Scenario(ixmp.Scenario):
                 # load data
                 ix_type = ix_types[sheet_name]
                 indxs = [x for x in df.columns if x not in ['unit', 'value']]
-                is_init(ix_type, sheet_name, indxs)
+                if init_items:
+                    is_init(ix_type, sheet_name, indxs)
                 funcs[ix_type](sheet_name, df)
                 if commit_steps:
                     self.commit('Loaded {} from {}'.format(sheet_name, fname))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -235,6 +235,13 @@ def test_excel_read_write(test_mp):
     fname = 'test_excel_read_write.xlsx'
 
     scen1 = Scenario(test_mp, *msg_args)
+    scen1 = scen1.clone(keep_solution=False)
+    scen1.check_out()
+    scen1.init_set('new_set')
+    scen1.add_set('new_set', 'member')
+    scen1.init_par('new_par', idx_sets=['new_set'])
+    scen1.add_par('new_par', 'member', 2, '-')
+    scen1.commit('new set and parameter added.')
     scen1.to_excel(fname)
 
     scen2 = Scenario(test_mp, model='foo', scenario='bar', version='new')
@@ -243,6 +250,9 @@ def test_excel_read_write(test_mp):
     exp = scen1.par('input')
     obs = scen2.par('input')
     pdt.assert_frame_equal(exp, obs)
+
+    assert scen2.has_par('new_par')
+    assert float(scen2.par('new_par')['value']) == 2
 
     scen2.commit('foo')  # must be checked in
     scen2.solve()


### PR DESCRIPTION
In response to issue #264, this PR modifies `read_excel` to have the option to initialize any sets and parameters that are not in default lists of a `message_ix` scenario, when reading that from Excel.

- [X] Tests added: existing `test_excel_read_write(test_mp)` modified to test the reading of new sets and parameters
- [X] Documentation added: Not needed
- [X] Release notes updated. 
