### PR TITLE
add code to get all parameters related to a technology from database

### DIFF
--- a/message_ix/tools/get_tech_data/__init__.py
+++ b/message_ix/tools/get_tech_data/__init__.py
@@ -23,19 +23,25 @@ def dict_to_df(filter_dict: dict) -> pd.DataFrame:
     filter_dict: dictionary 
     """
     if list not in [type(i) for i in filter_dict.values()]:
-        filter_dict = pd.DataFrame.from_dict({k: ([v] if type(v) != list else v) for k, v in filter_dict.items()})
+        filter_dict = pd.DataFrame.from_dict(
+            {k: ([v] if type(v) != list else v) for k, v in
+             filter_dict.items()})
 
     filter_df = pd.DataFrame.from_dict(filter_dict)
     return filter_df
 
 
 # %% III) The main function
-def get_tech_description(base: message_ix.Scenario, key_filter: str, filters: dict, filename: str) -> dict[str:pd.DataFrame]:
-    """Find all parameters that relate to a technology / a year/ a commodity / ect. given in the filter
+def get_tech_description(base: message_ix.Scenario, key_filter: str,
+                         filters: dict, filename: str) -> dict[
+                                                          str:pd.DataFrame]:
+    """Find all parameters that relate to a technology / a year/ a commodity /
+        ect. given in the filter
 
     :meth:`find_tech_description` does the following:
 
-    1. iterates through the parameter list to identify all parameters related to filters given 
+    1. iterates through the parameter list to identify all parameters related
+        to filters given
     2. outputs the parameter dict to an excel file
 
      Parameters
@@ -43,18 +49,21 @@ def get_tech_description(base: message_ix.Scenario, key_filter: str, filters: di
     base : message_ix.Scenario
         Reference scenario.
     key_filter : str
-        filter key to look for in the database - if this key is not in the idx_names the parameter will be ignored
+        filter key to look for in the database - if this key is not in the
+        idx_names the parameter will be ignored
     filters : dict
         Filters to filter the identified parameters by
     filename : str
         path and name of technology output file
     """
 
-    par_list = [par_name for par_name in base.par_list() if key_filter in base.idx_names(par_name)]
+    par_list = [par_name for par_name in base.par_list() if
+                key_filter in base.idx_names(par_name)]
     par_dict = {}
 
     for par_name in par_list:
-        _filters = {k: v for k, v in filters.items() if k in base.idx_names(par_name)}
+        _filters = {k: v for k, v in filters.items() if
+                    k in base.idx_names(par_name)}
         if len(_filters) > 0:
             _par = base.par(par_name, {**_filters})
             if not _par.empty:
@@ -62,7 +71,8 @@ def get_tech_description(base: message_ix.Scenario, key_filter: str, filters: di
 
     if filename:
         writer = pd.ExcelWriter(f'{filename}.xlsx')
-        dict_to_df(filters).to_excel(writer, sheet_name='applied filters', index=False)
+        dict_to_df(filters).to_excel(writer, sheet_name='applied filters',
+                                     index=False)
         for par_name, df in par_dict.items():
             df.to_excel(writer, par_name, index=False)
         writer.save()

--- a/message_ix/tools/get_tech_data/__init__.py
+++ b/message_ix/tools/get_tech_data/__init__.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Find all parameters related to a technology / commodity / year."""
+# Sections of the code:
+#
+#   I. Required python packages are imported
+#  II. Generic utilities for data manupulation
+# III. The main function, find_tech_description()
+
+
+# %% I) Importing required packages
+
+import pandas as pd
+
+import message_ix
+
+
+# %% II) Utility functions for data manupulation
+def dict_to_df(filter_dict: dict) -> pd.DataFrame:
+    """Transforms the filter (given as a dictionary) into a data frame
+    
+    Parameter
+    ----------
+    filter_dict: dictionary 
+    """
+    if list not in [type(i) for i in filter_dict.values()]:
+        filter_dict = pd.DataFrame.from_dict({k: ([v] if type(v) != list else v) for k, v in filter_dict.items()})
+
+    filter_df = pd.DataFrame.from_dict(filter_dict)
+    return filter_df
+
+
+# %% III) The main function
+def get_tech_description(base: message_ix.Scenario, key_filter: str, filters: dict, filename: str) -> dict[str:pd.DataFrame]:
+    """Find all parameters that relate to a technology / a year/ a commodity / ect. given in the filter
+
+    :meth:`find_tech_description` does the following:
+
+    1. iterates through the parameter list to identify all parameters related to filters given 
+    2. outputs the parameter dict to an excel file
+
+     Parameters
+    -----------
+    base : message_ix.Scenario
+        Reference scenario.
+    key_filter : str
+        filter key to look for in the database - if this key is not in the idx_names the parameter will be ignored
+    filters : dict
+        Filters to filter the identified parameters by
+    filename : str
+        path and name of technology output file
+    """
+
+    par_list = [par_name for par_name in base.par_list() if key_filter in base.idx_names(par_name)]
+    par_dict = {}
+
+    for par_name in par_list:
+        _filters = {k: v for k, v in filters.items() if k in base.idx_names(par_name)}
+        if len(_filters) > 0:
+            _par = base.par(par_name, {**_filters})
+            if not _par.empty:
+                par_dict[par_name] = _par
+
+    if filename:
+        writer = pd.ExcelWriter(f'{filename}.xlsx')
+        dict_to_df(filters).to_excel(writer, sheet_name='applied filters', index=False)
+        for par_name, df in par_dict.items():
+            df.to_excel(writer, par_name, index=False)
+        writer.save()
+
+    return par_dict

--- a/message_ix/tools/get_tech_data/__init__.py
+++ b/message_ix/tools/get_tech_data/__init__.py
@@ -17,10 +17,10 @@ import message_ix
 # %% II) Utility functions for data manupulation
 def dict_to_df(filter_dict: dict) -> pd.DataFrame:
     """Transforms the filter (given as a dictionary) into a data frame
-    
+
     Parameter
     ----------
-    filter_dict: dictionary 
+    filter_dict: dictionary
     """
     if list not in [type(i) for i in filter_dict.values()]:
         filter_dict = pd.DataFrame.from_dict(
@@ -33,8 +33,8 @@ def dict_to_df(filter_dict: dict) -> pd.DataFrame:
 
 # %% III) The main function
 def get_tech_description(base: message_ix.Scenario, key_filter: str,
-                         filters: dict, filename: str) -> dict[
-                                                          str:pd.DataFrame]:
+                         filters: dict, filename: str
+                         ) -> dict[str:pd.DataFrame]:
     """Find all parameters that relate to a technology / a year/ a commodity /
         ect. given in the filter
 

--- a/message_ix/tools/get_tech_data/__main__.py
+++ b/message_ix/tools/get_tech_data/__main__.py
@@ -1,0 +1,33 @@
+"""Get all parameters related to a certain technology/commodity/year ect. from the data base
+
+"""
+from typing import Optional
+
+import ixmp
+import message_ix
+
+from . import get_tech_description
+
+
+def main(model_ref: str, scen_ref: str, filters: dict, filename: str, key_filter:Optional[str] ='technology',
+         version_ref: Optional[int] = None):
+    print('>> message_ix.tools.get_tech_data...')
+
+    # Handle default arguments
+    ref_kw = dict(model=model_ref, scen=scen_ref)
+    if version_ref:
+        ref_kw['version'] = version_ref
+
+    # Load the ixmp Platform
+    mp = ixmp.Platform(dbtype='HSQLDB')
+
+    # Loading the reference scenario
+    base = message_ix.Scenario(mp, **ref_kw)
+
+    # Calling the main function
+    get_tech_description(base=base, key_filter=key_filter, filters=filters, filename=filename)
+
+    mp.close_db()
+
+# Execute the script
+main()

--- a/message_ix/tools/get_tech_data/__main__.py
+++ b/message_ix/tools/get_tech_data/__main__.py
@@ -1,4 +1,5 @@
-"""Get all parameters related to a certain technology/commodity/year ect. from the data base
+"""Get all parameters related to a certain technology/commodity/year ect. from
+the data base
 
 """
 from typing import Optional

--- a/message_ix/tools/get_tech_data/__main__.py
+++ b/message_ix/tools/get_tech_data/__main__.py
@@ -4,12 +4,13 @@
 from typing import Optional
 
 import ixmp
-import message_ix
 
+import message_ix
 from . import get_tech_description
 
 
-def main(model_ref: str, scen_ref: str, filters: dict, filename: str, key_filter:Optional[str] ='technology',
+def main(model_ref: str, scen_ref: str, filters: dict, filename: str,
+         key_filter: Optional[str] = 'technology',
          version_ref: Optional[int] = None):
     print('>> message_ix.tools.get_tech_data...')
 
@@ -25,9 +26,11 @@ def main(model_ref: str, scen_ref: str, filters: dict, filename: str, key_filter
     base = message_ix.Scenario(mp, **ref_kw)
 
     # Calling the main function
-    get_tech_description(base=base, key_filter=key_filter, filters=filters, filename=filename)
+    get_tech_description(base=base, key_filter=key_filter, filters=filters,
+                         filename=filename)
 
     mp.close_db()
+
 
 # Execute the script
 main()


### PR DESCRIPTION
This pull request pulls an additional tool that allows the user to get all parameters related to a certain technology / commodity / year and look at them in a dictionary / excel file.

I added this as a "tool" to the message_ix repo - however it might be more useful as a little call function in the utils section of (I guess) ixmp. Any thoughts on that?

(Optional: write a longer description here to help a reviewer understand the PR in 3–5 minutes.)

**PR checklist:**

- [ ] Tests added.
- [ ] Documentation added.
- [ ] Release notes updated. Add a single line at the top of `RELEASE_NOTES.md` similar to…
  ```
  - [#999](https://github.com/iiasa/message_ix/pull/999) Description from above.
  ```
  …then, delete this sentence to confirm you've understood the instructions.
