### PR TITLE
 Convert 'year'-indexed items to 'int' columns

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 
 ## All changes
 
+- [#269](https://github.com/iiasa/message_ix/pull/269): Enforce 'year'-indexed columns as integers.
 - [#256](https://github.com/iiasa/message_ix/pull/256): Update to use :obj:`ixmp.config` and improve CLI.
 - [#255](https://github.com/iiasa/message_ix/pull/249): Add :mod:`message_ix.testing.nightly` and `nightly` CLI command group for slow-running tests.
 - [#249](https://github.com/iiasa/message_ix/pull/249),

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -62,10 +62,13 @@ Support for R usage of the core classes is provided through the `reticulate`_ pa
       add_spatial_sets
       cat
       cat_list
+      equ
       firstmodelyear
+      par
       read_excel
       rename
       to_excel
+      var
       vintage_and_active_years
       years_active
 

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -46,7 +46,7 @@ class Scenario(ixmp.Scenario):
             return df
 
     # Override ixmp methods to convert 'year'-indexed columns to int
-    def equ(self, name, *args, **kwargs):
+    def equ(self, name, filters=None):
         """Return equation data.
 
         Same as :meth:`ixmp.Scenario.equ`, except columns indexed by the
@@ -64,9 +64,9 @@ class Scenario(ixmp.Scenario):
         pd.DataFrame
             Filtered elements of the equation.
         """
-        return self._year_as_int(name, super().equ(name, *args, **kwargs))
+        return self._year_as_int(name, super().equ(name, filters))
 
-    def par(self, name, *args, **kwargs):
+    def par(self, name, filters=None):
         """Return parameter data.
 
         Same as :meth:`ixmp.Scenario.par`, except columns indexed by the
@@ -84,9 +84,35 @@ class Scenario(ixmp.Scenario):
         pd.DataFrame
             Filtered elements of the parameter.
         """
-        return self._year_as_int(name, super().par(name, *args, **kwargs))
+        return self._year_as_int(name, super().par(name, filters))
 
-    def var(self, name, *args, **kwargs):
+    def set(self, name, filters=None):
+        """Return elements of a set.
+
+        Same as :meth:`ixmp.Scenario.set`, except columns for multi-dimensional
+        sets indexed by the |MESSAGEix| set ``year`` are returned with
+        :obj:`int` dtype.
+
+        Parameters
+        ----------
+        name : str
+            Name of the set.
+        filters : dict (str -> list of str), optional
+            Mapping of `dimension_name` → `elements`, where `dimension_name`
+            is one of the `idx_names` given when the set was initialized (see
+            :meth:`init_set`), and `elements` is an iterable of labels to
+            include in the return value.
+
+        Returns
+        -------
+        pd.Series
+            If *name* is an index set.
+        pd.DataFrame
+            If *name* is a set defined over one or more other, index sets.
+        """
+        return self._year_as_int(name, super().set(name, filters))
+
+    def var(self, name, filters=None):
         """Return variable data.
 
         Same as :meth:`ixmp.Scenario.var`, except columns indexed by the
@@ -104,7 +130,7 @@ class Scenario(ixmp.Scenario):
         pd.DataFrame
             Filtered elements of the variable.
         """
-        return self._year_as_int(name, super().var(name, *args, **kwargs))
+        return self._year_as_int(name, super().var(name, filters))
 
     def cat_list(self, name):
         """Return a list of all categories for a mapping set.

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -35,7 +35,7 @@ class Scenario(ixmp.Scenario):
         return list(filter(
             lambda e: e[0] == 'year',
             zip(self.idx_sets(name), self.idx_names(name))
-            ))
+        ))
 
     def _year_as_int(self, name, df):
         """Convert 'year'-indexed columns of *df* to int dtypes."""

--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -43,7 +43,7 @@ TS_DF_SHIFT = TS_DF.copy()
 TS_DF_SHIFT.loc[0, 1964] = np.nan
 
 
-def make_dantzig(mp, solve=False, multi_year=False):
+def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
     """Return an :class:`message_ix.Scenario` for Dantzig's canning problem.
 
     Parameters
@@ -143,11 +143,18 @@ def make_dantzig(mp, solve=False, multi_year=False):
         scen.add_par('technical_lifetime', ['seattle', 'canning_plant', 1964],
                      3, 'y')
 
+    if solve:
+        # Always read one equation. Used by test_core.test_year_int.
+        scen.init_equ('COMMODITY_BALANCE_GT',
+                      ['node', 'commodity', 'level', 'year', 'time'])
+        solve_opts['equ_list'] = solve_opts.get('equ_list', []) \
+            + ['COMMODITY_BALANCE_GT']
+
     scen.commit('Created a MESSAGE-scheme version of the transport problem.')
     scen.set_as_default()
 
     if solve:
-        scen.solve()
+        scen.solve(**solve_opts)
 
     scen.check_out(timeseries_only=True)
     scen.add_timeseries(HIST_DF, meta=True)

--- a/message_ix/tools/add_year/cli.py
+++ b/message_ix/tools/add_year/cli.py
@@ -25,7 +25,6 @@ from functools import partial
 from timeit import default_timer as timer
 
 import click
-import ixmp
 import message_ix
 
 from . import add_year
@@ -84,12 +83,20 @@ def main(context, model_new, scen_new, create_new, years_new, firstyear_new,
 
     try:
         sc_ref = context.get('scen', None)  # AttributeError if context is None
-        if not isinstance(sc_ref, ixmp.Scenario):
+        if not sc_ref:
             raise AttributeError
     except AttributeError:
         raise click.UsageError('add-years requires a base scenario; use'
                                '--url or --platform, --model, --scenario, and '
                                'optionally --version')
+    else:
+        # the ixmp CLI pre-loads sc_ref as an ixmp.Scenario;
+        # convert to a message_ix.Scenario
+        sc_ref = message_ix.Scenario(
+            mp=context['mp'],
+            model=sc_ref.model,
+            scenario=sc_ref.scenario,
+            version=sc_ref.version)
 
     start = timer()
     print('>> message_ix.tools.add_year...')

--- a/message_ix/tools/add_year/cli.py
+++ b/message_ix/tools/add_year/cli.py
@@ -25,6 +25,7 @@ from functools import partial
 from timeit import default_timer as timer
 
 import click
+import ixmp
 import message_ix
 
 from . import add_year
@@ -79,11 +80,11 @@ def main(context, model_new, scen_new, create_new, years_new, firstyear_new,
          lastyear_new, macro, baseyear_macro, parameter, region, rewrite,
          unit_check, extrapol_neg, bound_extend, dry_run):
     # The reference scenario is loaded according to the options given to
-    # the top-level message-ix (=ixmp) CLI:
-
+    # the top-level message-ix (=ixmp) CLI
     try:
-        sc_ref = context.get('scen', None)  # AttributeError if context is None
-        if not sc_ref:
+        # AttributeError if context is None
+        sc_ref = context.get('scen', None)
+        if not issubclass(sc_ref, ixmp.Scenario):
             raise AttributeError
     except AttributeError:
         raise click.UsageError('add-years requires a base scenario; use'

--- a/message_ix/tools/add_year/cli.py
+++ b/message_ix/tools/add_year/cli.py
@@ -84,7 +84,7 @@ def main(context, model_new, scen_new, create_new, years_new, firstyear_new,
     try:
         # AttributeError if context is None
         sc_ref = context.get('scen', None)
-        if not issubclass(sc_ref, ixmp.Scenario):
+        if not issubclass(type(sc_ref), ixmp.Scenario):
             raise AttributeError
     except AttributeError:
         raise click.UsageError('add-years requires a base scenario; use'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,8 +17,8 @@ msg_multiyear_args = ('canning problem (MESSAGE scheme)', 'multi-year')
 def test_year_int(test_mp):
     scen = make_dantzig(test_mp, solve=True, multi_year=True)
 
-    # Dimensions indexed by 'year' are returned as integers for 'equ', 'par',
-    # and 'var'
+    # Dimensions indexed by 'year' are returned as integers for all item types
+    assert scen.set('cat_year').dtypes['year'] == 'int'
     assert scen.par('demand').dtypes['year'] == 'int'
     assert scen.par('bound_activity_up').dtypes['year_act'] == 'int'
     assert scen.var('ACT').dtypes['year_vtg'] == 'int'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,10 +7,22 @@ import pandas as pd
 import pandas.util.testing as pdt
 
 from message_ix import Scenario
+from message_ix.testing import make_dantzig
 
 
 msg_args = ('canning problem (MESSAGE scheme)', 'standard')
 msg_multiyear_args = ('canning problem (MESSAGE scheme)', 'multi-year')
+
+
+def test_year_int(test_mp):
+    scen = make_dantzig(test_mp, solve=True, multi_year=True)
+
+    # Dimensions indexed by 'year' are returned as integers for 'equ', 'par',
+    # and 'var'
+    assert scen.par('demand').dtypes['year'] == 'int'
+    assert scen.par('bound_activity_up').dtypes['year_act'] == 'int'
+    assert scen.var('ACT').dtypes['year_vtg'] == 'int'
+    assert scen.equ('COMMODITY_BALANCE_GT').dtypes['year'] == 'int'
 
 
 def test_add_spatial_single(test_mp):

--- a/tutorial/utils/plotting.py
+++ b/tutorial/utils/plotting.py
@@ -28,7 +28,8 @@ class Plots(object):
                       values='value')
         return df
 
-    def model_data(self, var, year_col='year_act', baseyear=False, subset=None):
+    def model_data(self, var, year_col='year_act', baseyear=False,
+                   subset=None):
         df = self.ds.var(var)
         if subset is not None:
             df = df[df['technology'].isin(subset)]

--- a/tutorial/utils/run_scenarios.py
+++ b/tutorial/utils/run_scenarios.py
@@ -24,7 +24,7 @@ def check_local_model(model, notebook, shell=False):
 def read_scenario(platform, name, scen):
     mp = platform
     mp.open_db()
-    ds = mp.Scenario(name, scen)
+    ds = message_ix.Scenario(mp, name, scen)
 
     yield ds
 


### PR DESCRIPTION
Closes #268 and iiasa/ixmp#218.

- Adds test_core.test_year_int for the behaviour described in #268.
  - `pytest -k year_int` with only the first commit (b7a8428) should fail.
- Overrides Scenario.equ, .par, .set, and .var to provide the desired behaviour.
- Adjusts other code in `tools.add_year` and tutorials/utils/run_scenarios.py.

See also #254.

**PR checklist:**

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.