### PR TITLE
Addition of parameter definitions in MESSAGEix documentation

### DIFF
--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -1174,6 +1174,8 @@ TOTAL_CAPACITY_BOUND_LO(node,inv_tec,year)$( is_bound_total_capacity_lo(node,inv
 ;
 
 ***
+* .. _activity_bound_up:
+* 
 * Equation ACTIVITY_BOUND_UP
 * """"""""""""""""""""""""""
 * This constraint provides upper bounds by mode of a technology activity, summed over all vintages.
@@ -1214,6 +1216,8 @@ ACTIVITY_BOUND_ALL_MODES_UP(node,tec,year,time)$( is_bound_activity_up(node,tec,
 ;
 
 ***
+* .. _acitvity_bound_lo:
+* 
 * Equation ACTIVITY_BOUND_LO
 * """"""""""""""""""""""""""
 * This constraint provides lower bounds by mode of a technology activity, summed over
@@ -1258,6 +1262,8 @@ ACTIVITY_BOUND_ALL_MODES_LO(node,tec,year,time)$( bound_activity_lo(node,tec,yea
 
 *----------------------------------------------------------------------------------------------------------------------*
 ***
+* .. _share_constraints:
+* 
 * Constraints on shares of technologies and commodities
 * -----------------------------------------------------
 * This section allows to include upper and lower bounds on the shares of modes used by a technology

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -73,6 +73,11 @@ Parameters
 * Parameters of the `Resources` section
 * -------------------------------------
 *
+* The quantity of the resources in MESSAGEix is represented by two parameters: ``resource_volume`` and ``resource_remaining``.
+* The first parameter is the volume of resources at the start of the model horizon while the second is the maximum extraction relative
+* to remaining resources by year. The maximum extraction of the resources (by grade) in a year is constrained by the parameter
+* ``bound_extraction_up``. Extraction costs for resources are represented by ``resource_cost parameter``. 
+*
 * .. list-table::
 *    :widths: 25 75
 *    :header-rows: 1
@@ -92,8 +97,8 @@ Parameters
 *    * - historical_extraction [#hist]_
 *      - ``node`` | ``commodity`` | ``grade`` | ``year``
 *
-* .. [#stock] This parameter allows (exogenous) additions to the commodity stock over the model horizon,
-*    e.g., precipitation that replenishes the water table.
+* .. [#stock] Commodity stock refers to an exogenous (initial) quantity of commodity in stock. This parameter allows
+*    (exogenous) additions to the commodity stock over the model horizon, e.g., precipitation that replenishes the water table.
 *
 * .. [#hist] Historical values of new capacity and activity can be used for parametrising the vintage structure
 *    of existing capacity and implement dynamic constraints in the first model period.
@@ -130,8 +135,9 @@ Parameter
 *    as an auxiliary reporting variable; it equals ``demand_fixed`` in a `MESSAGE`-standalone run and reports
 *    the final demand including the price response in an iterative `MESSAGE-MACRO` solution.
 *
-* .. [#peakload] The parameters ``peak_load_factor`` and ``reliability_factor`` are based on the formulation proposed
-*    by Sullivan et al., 2013 :cite:`sullivan_VRE_2013`. It is used in :ref:`reliability_constraint`.
+* .. [#peakload] The parameters ``peak_load_factor`` (maximum peak load factor for reliability constraint of firm capacity) and
+*    ``reliability_factor`` (reliability of a technology (per rating)) are based on the formulation proposed by Sullivan et al., 2013 :cite:`sullivan_VRE_2013`.
+*    It is used in :ref:`reliability_constraint`.
 *
 ***
 
@@ -148,64 +154,46 @@ Parameter
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
 * .. list-table::
-*    :widths: 25 50 60
+*    :widths: 25 60
 *    :header-rows: 1
 *
 *    * - Parameter name
-*      - Explanatory comments
 *      - Index Dimensions 
 *    * - input [#tecvintage]_
-*      - relative share of input per unit of activity
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` |
 *        ``node_origin`` | ``commodity`` | ``level`` | ``time`` | ``time_origin``
 *    * - output [#tecvintage]_
-*      - relative share of output per unit of activity
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` |
 *        ``node_dest`` | ``commodity`` | ``level`` | ``time`` | ``time_dest``
 *    * - inv_cost [#tecvintage]_
-*      - investment costs (per unit of new capacity)
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - fix_cost [#tecvintage]_
-*      - fixed costs per year (per unit of capacity maintained)
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
 *    * - var_cost [#tecvintage]_
-*      - variable costs of operation (per unit of capacity maintained)
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``time``
 *    * - levelized_cost [#levelizedcost]_
-*      - levelized costs (per unit of new capacity)
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``time``
 *    * - construction_time [#construction]_ 
-*      - duration of construction of new capacity (in years)
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - technical_lifetime
-*      - maximum technical lifetime (from year of construction)
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - capacity_factor [#tecvintage]_
-*      - capacity factor by subannual time slice
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``time``
 *    * - operation_factor [#tecvintage]_
-*      - yearly total operation factor
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
 *    * - min_utilization_factor [#tecvintage]_
-*      - yearly minimum utilization factor
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
 *    * - rating_bin [#rating]_
-*      - maximum share of technology in commodity use per rating
 *      - ``node`` | ``technology`` | ``year_act`` | ``commodity`` | ``level`` | ``time`` | ``rating``
 *    * - reliability_factor [#peakload]_
-*      - reliability of a technology (per rating)
 *      - ``node`` | ``technology`` | ``year_act`` | ``commodity`` | ``level`` | ``time`` | ``rating``
-*    * - flexibility_factor
-*      - contribution of technologies towards operation flexibility constraint
+*    * - flexibility_factor [#flexfactor]_
 *      - ``node_loc`` | ``technology`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``commodity`` | ``level`` | ``time`` | ``rating``
-*    * - renewable_capacity_factor
-*      - quality of renewable potential grade (>= 1)
+*    * - renewable_capacity_factor [#renewables]_ 
 *      - ``node_loc`` | ``commodity`` | ``grade`` | ``level`` | ``year``
-*    * - renewable_potential
-*      - size of renewable potential per grade
+*    * - renewable_potential [#renewables]_ 
 *      - ``node`` | ``commodity`` | ``grade`` | ``level`` | ``year``
 *    * - emission_factor
-*      - emission intensity of activity
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``emission``
 *
 * .. [#tecvintage] Fixed and variable cost parameters and technical specifications are indexed over both
@@ -221,89 +209,11 @@ Parameter
 * .. [#rating] Maximum share of technology in commodity use per rating. The upper bound of a contribution by any technology to the constraints on system reliability
 *    (:ref:`reliability_constraint`) and flexibility (:ref:`flexibility_constraint`) can depend on the share of the technology output in the total commodity use at
 *    a specific level.
-***
-
-***
-* Parameters of the `Technology` section Option 2
-* -----------------------------------------------
 *
-* Input/output mapping, costs and engineering specifications
-* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* .. [#flexfactor] Contribution of technologies towards operation flexibility constraint. It is used in :ref:`flexibility_constraint`.
 *
-* .. list-table::
-*    :widths: 25 50 75
-*    :header-rows: 1
+* .. [#renewables] ``renewable_capacity_factor`` refers to the quality of renewable potential by grade and ``renewable_potential`` refers to the size of the renewable potential per grade. 
 *
-*    * - Parameter name
-*      - Index names
-*      - Explanatory comments
-*    * - input [#tecvintage2]_
-*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` |
-*        ``node_origin`` | ``commodity`` | ``level`` | ``time`` | ``time_origin``
-*      - relative share of input per unit of activity
-*    * - output [#tecvintage2]_
-*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` |
-*        ``node_dest`` | ``commodity`` | ``level`` | ``time`` | ``time_dest``
-*      - relative share of output per unit of activity
-*    * - inv_cost [#tecvintage2]_
-*      - ``node_loc`` | ``tec`` | ``year_vtg``
-*      - investment costs (per unit of new capacity)
-*    * - fix_cost [#tecvintage2]_
-*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
-*      - fixed costs per year (per unit of capacity maintained)
-*    * - var_cost [#tecvintage2]_
-*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``time``
-*      - variable costs of operation (per unit of capacity maintained)
-*    * - levelized_cost [#levelizedcost2]_
-*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``time``
-*      - levelized costs (per unit of new capacity)
-*    * - construction_time [#construction2]_
-*      - ``node_loc`` | ``tec`` | ``year_vtg``
-*      - duration of construction of new capacity (in years)
-*    * - technical_lifetime
-*      - ``node_loc`` | ``tec`` | ``year_vtg``
-*      - maximum technical lifetime (from year of construction)
-*    * - capacity_factor [#tecvintage2]_
-*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``time``
-*      - capacity factor by subannual time slice
-*    * - operation_factor [#tecvintage2]_
-*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
-*      - yearly total operation factor
-*    * - min_utilization_factor [#tecvintage2]_
-*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
-*      - yearly minimum utilization factor
-*    * - rating_bin [#rating2]_
-*      - ``node`` | ``technology`` | ``year_act`` | ``commodity`` | ``level`` | ``time`` | ``rating``
-*      - maximum share of technology in commodity use per rating
-*    * - reliability_factor [#peakload]_
-*      - ``node`` | ``technology`` | ``year_act`` | ``commodity`` | ``level`` | ``time`` | ``rating``
-*      - reliability of a technology (per rating)
-*    * - flexibility_factor
-*      - ``node_loc`` | ``technology`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``commodity`` | ``level`` | ``time`` | ``rating``
-*      - contribution of technologies towards operation flexibility constraint
-*    * - renewable_capacity_factor
-*      - ``node_loc`` | ``commodity`` | ``grade`` | ``level`` | ``year``
-*      - quality of renewable potential grade (>= 1)
-*    * - renewable_potential
-*      - ``node`` | ``commodity`` | ``grade`` | ``level`` | ``year``
-*      - size of renewable potential per grade
-*    * - emission_factor
-*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``emission``
-*      - emission intensity of activity
-*
-* .. [#tecvintage2] Fixed and variable cost parameters and technical specifications are indexed over both
-*    the year of construction (vintage) and the year of operation (actual).
-*    This allows to represent changing technology characteristics depending on the age of the plant.
-*
-* .. [#levelizedcost2] The parameter ``levelized_cost`` is computed in the GAMS pre-processing under the assumption of
-*    full capacity utilization until the end of the technical lifetime.
-*
-* .. [#construction2] The construction time only has an effect on the investment costs; in |MESSAGEix|,
-*    each unit of new-built capacity is available instantaneously at the beginning of the model period.
-*
-* .. [#rating2] The upper bound of a contribution by any technology to the constraints on system reliability
-*    (:ref:`reliability_constraint`) and flexibility (:ref:`flexibility_constraint`) can depend on the share
-*    of the technology output in the total commodity use at a specific level.
 ***
 
 Parameters
@@ -333,72 +243,28 @@ Parameters
 * Bounds on capacity and activity
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
-* The following parameters specify upper and lower bounds on new capacity, total installed capacity, and activity.
+* The following parameters specify upper and lower bounds on new capacity, total installed capacity, and activity. The bounds
+* on activity are implemented as the aggregate over all vintages in a specific period (:ref:`activity_bound_up` and :ref:`acitvity_bound_lo`).
 *
 * .. list-table::
-*    :widths: 25 50 60
-*    :header-rows: 1
-*
-*    * - Parameter name
-*      - Explanatory comments
-*      - Index names
-*    * - bound_new_capacity_up
-*      - upper bound on new capacity
-*      - ``node_loc`` | ``tec`` | ``year_vtg``
-*    * - bound_new_capacity_lo
-*      - lower bound on new capacity
-*      - ``node_loc`` | ``tec`` | ``year_vtg``
-*    * - bound_total_capacity_up
-*      - upper bound on total installed capacity
-*      - ``node_loc`` | ``tec`` | ``year_act``
-*    * - bound_total_capacity_lo
-*      - lower bound on total installed capacity
-*      - ``node_loc`` | ``tec`` | ``year_act``
-*    * - bound_activity_up
-*      - upper bound on activity (aggregated over all vintages)
-*      - ``node_loc`` | ``tec`` | ``year_act`` | ``mode`` | ``time``
-*    * - bound_activity_lo
-*      - lower bound on activity
-*      - ``node_loc`` | ``tec`` | ``year_act`` | ``mode`` | ``time``
-*
-* The bounds on activity are implemented as the aggregate over all vintages in a specific period
-* (cf. Equation ``ACTIVITY_BOUND_UP`` and ``ACTIVITY_BOUND_LO``).
-***
-
-***
-* Bounds on capacity and activity Option 2
-* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-*
-* The following parameters specify upper and lower bounds on new capacity, total installed capacity, and activity.
-*
-* .. list-table::
-*    :widths: 20 30 50
+*    :widths: 25 60
 *    :header-rows: 1
 *
 *    * - Parameter name
 *      - Index names
-*      - Explanatory comments
 *    * - bound_new_capacity_up
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
-*      - upper bound on new capacity
 *    * - bound_new_capacity_lo
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
-*      - lower bound on new capacity
 *    * - bound_total_capacity_up
 *      - ``node_loc`` | ``tec`` | ``year_act``
-*      - upper bound on total installed capacity
 *    * - bound_total_capacity_lo
 *      - ``node_loc`` | ``tec`` | ``year_act``
-*      - lower bound on total installed capacity
 *    * - bound_activity_up
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``mode`` | ``time``
-*      - upper bound on activity (aggregated over all vintages)
 *    * - bound_activity_lo
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``mode`` | ``time``
-*      - lower bound on activity
 *
-* The bounds on activity are implemented as the aggregate over all vintages in a specific period
-* (cf. Equation ``ACTIVITY_BOUND_UP`` and ``ACTIVITY_BOUND_LO``).
 ***
 
 Parameters
@@ -426,31 +292,34 @@ Parameters
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - growth_new_capacity_up [#mpx]_
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
-*    * - soft_new_capacity_up [#mpx]_
+*    * - soft_new_capacity_up [#mpx]_ [#soft]_
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - initial_new_capacity_lo
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - growth_new_capacity_lo [#mpx]_
 *      - ``node_loc`` | ``tec_actual`` | ``year_vtg``
-*    * - soft_new_capacity_lo [#mpx]_
+*    * - soft_new_capacity_lo [#mpx]_ [#soft]_
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - initial_activity_up [#mpa]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
 *    * - growth_activity_up [#mpx]_ [#mpa]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
-*    * - soft_activity_up [#mpx]_
+*    * - soft_activity_up [#mpx]_ [#soft]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
 *    * - initial_activity_lo [#mpa]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
 *    * - growth_activity_lo [#mpx]_ [#mpa]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
-*    * - soft_activity_lo [#mpx]_
+*    * - soft_activity_lo [#mpx]_ [#soft]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
 *
 * .. [#mpx] All parameters related to the dynamic constraints are understood as the bound on the rate
 *    of growth/decrease, not as in percentage points and not as (1+growth rate).
 *
 * .. [#mpa] The dynamic constraints are not indexed over modes in the |MESSAGEix| implementation.
+*
+* .. [#soft] The implementation of |MESSAGEix| includes the functionality for 'soft' relaxations of dynamic constraints on
+*            new-built capacity and activity (see Keppo and Strubegger, 2010 :cite:`keppo_short_2010`). Refer to the section :ref:`dynamic_constraints`
 *
 ***
 
@@ -587,28 +456,27 @@ Parameters
 ***
 * Auxiliary investment cost parameters and multipliers
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+*
+* Auxilary investment cost parameters include the remaining technical lifetime at the end of model horizon in addition to the
+* different scaling factors and  multipliers as listed below. These factors account for remaining capacity or construction time of new capcaity, 
+* the value of investment at the end of mdoel horizon or the discount factor of remaining lifetime beyond model horizon. 
+* 
 * .. list-table::
-*    :widths: 35 65 50
+*    :widths: 35 50
 *    :header-rows: 1
 *
 *    * - Parameter name
 *      - Index names
-*      - Explanatory comments 
 *    * - construction_time_factor
 *      - ``node`` | ``tec`` | ``year_all``
-*      - scaling factor to account for construction time of new capacity
 *    * -  remaining_capacity
 *      - ``node`` | ``tec`` | ``year_all`` 
-*      - scaling factor to account for remaining capacity in period 
 *    * - end_of_horizon_factor
 *      - ``node`` | ``tec`` | ``year_all`` 
-*      - multiplier for value of investment at end of model horizon
 *    * - beyond_horizon_lifetime
 *      - ``node`` | ``tec`` | ``year_all`` 
-*      - remaining technical lifetime at the end of model horizon
 *    * - beyond_horizon_factor
 *      - ``node`` | ``tec`` | ``year_all``
-*      - discount factor of remaining lifetime beyond model horizon 
 *
 *
 ***
@@ -670,7 +538,7 @@ Parameters
 *
 * The implementation of |MESSAGEix| includes a land-use model emulator, which draws on exogenous land-use scenarios
 * (provided by another model) to derive supply of commodities (e.g., biomass) and emissions
-* from agriculture and forestry.
+* from agriculture and forestry. The parameters listed below refer to the assigned land scenario. 
 *
 * .. list-table::
 *    :widths: 25 75
@@ -740,7 +608,8 @@ Parameters
 * Parameters of the `Share Constraints` section
 * ---------------------------------------------
 *
-* Share constraints define the share of a given commodity to be active on a certain level
+* Share constraints define the share of a given commodity/mode to be active on a certain level. For the mathematical
+* formulation refer to :ref:`share_constraints`. 
 *
 * .. list-table::
 *    :widths: 25 75
@@ -774,7 +643,7 @@ Parameters
 * Parameters of the `Relations` section
 * -------------------------------------
 *
-* Generic linear relations are implemented in |MESSAGEix|.This feature is intended for development and testing only - all new features
+* Generic linear relations are implemented in |MESSAGEix|. This feature is intended for development and testing only - all new features
 * should be implemented as specific new mathematical formulations and associated sets & parameters. For the formulation of the relations
 * refer to  :ref:`section_of_generic_relations`. 
 *

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -510,7 +510,7 @@ Parameters
 *    * - Parameter name
 *      - Index dimensions
 *    * - historical_emission [#hist]_
-*      - ``node`` | ``emission`` | ``type_tec`` | ``year``
+*      - ``node`` | ``type_emission`` | ``type_tec`` | ``year``
 *    * - emission_scaling [#em_scaling]_
 *      - ``type_emission`` | ``emission``
 *    * - bound_emission

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -148,46 +148,64 @@ Parameter
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
 * .. list-table::
-*    :widths: 25 75
+*    :widths: 25 50 60
 *    :header-rows: 1
 *
 *    * - Parameter name
-*      - Index names
+*      - Explanatory comments
+*      - Index Dimensions 
 *    * - input [#tecvintage]_
+*      - relative share of input per unit of activity
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` |
 *        ``node_origin`` | ``commodity`` | ``level`` | ``time`` | ``time_origin``
 *    * - output [#tecvintage]_
+*      - relative share of output per unit of activity
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` |
 *        ``node_dest`` | ``commodity`` | ``level`` | ``time`` | ``time_dest``
 *    * - inv_cost [#tecvintage]_
+*      - investment costs (per unit of new capacity)
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - fix_cost [#tecvintage]_
+*      - fixed costs per year (per unit of capacity maintained)
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
 *    * - var_cost [#tecvintage]_
+*      - variable costs of operation (per unit of capacity maintained)
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``time``
 *    * - levelized_cost [#levelizedcost]_
+*      - levelized costs (per unit of new capacity)
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``time``
-*    * - construction_time
+*    * - construction_time [#construction]_ 
+*      - duration of construction of new capacity (in years)
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - technical_lifetime
+*      - maximum technical lifetime (from year of construction)
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - capacity_factor [#tecvintage]_
+*      - capacity factor by subannual time slice
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``time``
 *    * - operation_factor [#tecvintage]_
+*      - yearly total operation factor
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
 *    * - min_utilization_factor [#tecvintage]_
+*      - yearly minimum utilization factor
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
 *    * - rating_bin [#rating]_
+*      - maximum share of technology in commodity use per rating
 *      - ``node`` | ``technology`` | ``year_act`` | ``commodity`` | ``level`` | ``time`` | ``rating``
 *    * - reliability_factor [#peakload]_
+*      - reliability of a technology (per rating)
 *      - ``node`` | ``technology`` | ``year_act`` | ``commodity`` | ``level`` | ``time`` | ``rating``
 *    * - flexibility_factor
+*      - contribution of technologies towards operation flexibility constraint
 *      - ``node_loc`` | ``technology`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``commodity`` | ``level`` | ``time`` | ``rating``
 *    * - renewable_capacity_factor
+*      - quality of renewable potential grade (>= 1)
 *      - ``node_loc`` | ``commodity`` | ``grade`` | ``level`` | ``year``
 *    * - renewable_potential
+*      - size of renewable potential per grade
 *      - ``node`` | ``commodity`` | ``grade`` | ``level`` | ``year``
 *    * - emission_factor
+*      - emission intensity of activity
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``emission``
 *
 * .. [#tecvintage] Fixed and variable cost parameters and technical specifications are indexed over both
@@ -200,7 +218,90 @@ Parameter
 * .. [#construction] The construction time only has an effect on the investment costs; in |MESSAGEix|,
 *    each unit of new-built capacity is available instantaneously at the beginning of the model period.
 *
-* .. [#rating] The upper bound of a contribution by any technology to the constraints on system reliability
+* .. [#rating] Maximum share of technology in commodity use per rating. The upper bound of a contribution by any technology to the constraints on system reliability
+*    (:ref:`reliability_constraint`) and flexibility (:ref:`flexibility_constraint`) can depend on the share of the technology output in the total commodity use at
+*    a specific level.
+***
+
+***
+* Parameters of the `Technology` section Option 2
+* -----------------------------------------------
+*
+* Input/output mapping, costs and engineering specifications
+* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+*
+* .. list-table::
+*    :widths: 25 50 75
+*    :header-rows: 1
+*
+*    * - Parameter name
+*      - Index names
+*      - Explanatory comments
+*    * - input [#tecvintage2]_
+*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` |
+*        ``node_origin`` | ``commodity`` | ``level`` | ``time`` | ``time_origin``
+*      - relative share of input per unit of activity
+*    * - output [#tecvintage2]_
+*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` |
+*        ``node_dest`` | ``commodity`` | ``level`` | ``time`` | ``time_dest``
+*      - relative share of output per unit of activity
+*    * - inv_cost [#tecvintage2]_
+*      - ``node_loc`` | ``tec`` | ``year_vtg``
+*      - investment costs (per unit of new capacity)
+*    * - fix_cost [#tecvintage2]_
+*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
+*      - fixed costs per year (per unit of capacity maintained)
+*    * - var_cost [#tecvintage2]_
+*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``time``
+*      - variable costs of operation (per unit of capacity maintained)
+*    * - levelized_cost [#levelizedcost2]_
+*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``time``
+*      - levelized costs (per unit of new capacity)
+*    * - construction_time [#construction2]_
+*      - ``node_loc`` | ``tec`` | ``year_vtg``
+*      - duration of construction of new capacity (in years)
+*    * - technical_lifetime
+*      - ``node_loc`` | ``tec`` | ``year_vtg``
+*      - maximum technical lifetime (from year of construction)
+*    * - capacity_factor [#tecvintage2]_
+*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``time``
+*      - capacity factor by subannual time slice
+*    * - operation_factor [#tecvintage2]_
+*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
+*      - yearly total operation factor
+*    * - min_utilization_factor [#tecvintage2]_
+*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act``
+*      - yearly minimum utilization factor
+*    * - rating_bin [#rating2]_
+*      - ``node`` | ``technology`` | ``year_act`` | ``commodity`` | ``level`` | ``time`` | ``rating``
+*      - maximum share of technology in commodity use per rating
+*    * - reliability_factor [#peakload]_
+*      - ``node`` | ``technology`` | ``year_act`` | ``commodity`` | ``level`` | ``time`` | ``rating``
+*      - reliability of a technology (per rating)
+*    * - flexibility_factor
+*      - ``node_loc`` | ``technology`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``commodity`` | ``level`` | ``time`` | ``rating``
+*      - contribution of technologies towards operation flexibility constraint
+*    * - renewable_capacity_factor
+*      - ``node_loc`` | ``commodity`` | ``grade`` | ``level`` | ``year``
+*      - quality of renewable potential grade (>= 1)
+*    * - renewable_potential
+*      - ``node`` | ``commodity`` | ``grade`` | ``level`` | ``year``
+*      - size of renewable potential per grade
+*    * - emission_factor
+*      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``emission``
+*      - emission intensity of activity
+*
+* .. [#tecvintage2] Fixed and variable cost parameters and technical specifications are indexed over both
+*    the year of construction (vintage) and the year of operation (actual).
+*    This allows to represent changing technology characteristics depending on the age of the plant.
+*
+* .. [#levelizedcost2] The parameter ``levelized_cost`` is computed in the GAMS pre-processing under the assumption of
+*    full capacity utilization until the end of the technical lifetime.
+*
+* .. [#construction2] The construction time only has an effect on the investment costs; in |MESSAGEix|,
+*    each unit of new-built capacity is available instantaneously at the beginning of the model period.
+*
+* .. [#rating2] The upper bound of a contribution by any technology to the constraints on system reliability
 *    (:ref:`reliability_constraint`) and flexibility (:ref:`flexibility_constraint`) can depend on the share
 *    of the technology output in the total commodity use at a specific level.
 ***
@@ -235,23 +336,66 @@ Parameters
 * The following parameters specify upper and lower bounds on new capacity, total installed capacity, and activity.
 *
 * .. list-table::
-*    :widths: 20 80
+*    :widths: 25 50 60
+*    :header-rows: 1
+*
+*    * - Parameter name
+*      - Explanatory comments
+*      - Index names
+*    * - bound_new_capacity_up
+*      - upper bound on new capacity
+*      - ``node_loc`` | ``tec`` | ``year_vtg``
+*    * - bound_new_capacity_lo
+*      - lower bound on new capacity
+*      - ``node_loc`` | ``tec`` | ``year_vtg``
+*    * - bound_total_capacity_up
+*      - upper bound on total installed capacity
+*      - ``node_loc`` | ``tec`` | ``year_act``
+*    * - bound_total_capacity_lo
+*      - lower bound on total installed capacity
+*      - ``node_loc`` | ``tec`` | ``year_act``
+*    * - bound_activity_up
+*      - upper bound on activity (aggregated over all vintages)
+*      - ``node_loc`` | ``tec`` | ``year_act`` | ``mode`` | ``time``
+*    * - bound_activity_lo
+*      - lower bound on activity
+*      - ``node_loc`` | ``tec`` | ``year_act`` | ``mode`` | ``time``
+*
+* The bounds on activity are implemented as the aggregate over all vintages in a specific period
+* (cf. Equation ``ACTIVITY_BOUND_UP`` and ``ACTIVITY_BOUND_LO``).
+***
+
+***
+* Bounds on capacity and activity Option 2
+* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+*
+* The following parameters specify upper and lower bounds on new capacity, total installed capacity, and activity.
+*
+* .. list-table::
+*    :widths: 20 30 50
 *    :header-rows: 1
 *
 *    * - Parameter name
 *      - Index names
+*      - Explanatory comments
 *    * - bound_new_capacity_up
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
+*      - upper bound on new capacity
 *    * - bound_new_capacity_lo
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
+*      - lower bound on new capacity
 *    * - bound_total_capacity_up
 *      - ``node_loc`` | ``tec`` | ``year_act``
+*      - upper bound on total installed capacity
 *    * - bound_total_capacity_lo
 *      - ``node_loc`` | ``tec`` | ``year_act``
+*      - lower bound on total installed capacity
 *    * - bound_activity_up
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``mode`` | ``time``
+*      - upper bound on activity (aggregated over all vintages)
 *    * - bound_activity_lo
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``mode`` | ``time``
+*      - lower bound on activity
 *
 * The bounds on activity are implemented as the aggregate over all vintages in a specific period
 * (cf. Equation ``ACTIVITY_BOUND_UP`` and ``ACTIVITY_BOUND_LO``).
@@ -337,9 +481,11 @@ Parameters
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
 * The implementation of |MESSAGEix| includes the functionality to introduce "add-on technologies" that are specifically
-* linked to parent technologies. This feature can be used to model mitigation options (scrubber, cooling).
-* Note, that no default addon_conversion is set, to avoid default conversion factors of 1 being set for technologies
-* with mutiple modes, of which only a single mode should be linked to the add-on technology.
+* linked to parent technologies. This feature can be used to model mitigation options (scrubber, cooling).Note, that no
+* default addon_conversion factor (conversion factor between add-on and parent technology activity) is set, to avoid
+* default conversion factors of 1 being set for technologies with mutiple modes, of which only a single mode should be
+* linked to the add-on technology. Upper and lower bounds of add on technologies are defined relative to the parent
+* technology. 
 *
 * .. list-table::
 *    :widths: 20 80
@@ -354,7 +500,6 @@ Parameters
 *    * - addon_lo
 *      - ``node`` | ``tec`` | ``vintage`` | ``year`` | ``mode`` | ``time`` | ``type_addon``
 *
-* The upper bound of
 ***
 
 Parameters
@@ -373,7 +518,8 @@ Parameters
 *
 * The implementation of |MESSAGEix| includes the functionality for 'soft' relaxations of dynamic constraints on
 * new-built capacity and activity (see Keppo and Strubegger, 2010 :cite:`keppo_short_2010`).
-* Refer to the section :ref:`dynamic_constraints`.
+* Refer to the section :ref:`dynamic_constraints`. Absolute cost and levelized cost multipliers are used
+* for the relaxation of upper and lower bounds. 
 *
 * .. list-table::
 *    :widths: 20 80
@@ -441,7 +587,30 @@ Parameters
 ***
 * Auxiliary investment cost parameters and multipliers
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* Documentation not yet included.
+* .. list-table::
+*    :widths: 35 65 50
+*    :header-rows: 1
+*
+*    * - Parameter name
+*      - Index names
+*      - Explanatory comments 
+*    * - construction_time_factor
+*      - ``node`` | ``tec`` | ``year_all``
+*      - scaling factor to account for construction time of new capacity
+*    * -  remaining_capacity
+*      - ``node`` | ``tec`` | ``year_all`` 
+*      - scaling factor to account for remaining capacity in period 
+*    * - end_of_horizon_factor
+*      - ``node`` | ``tec`` | ``year_all`` 
+*      - multiplier for value of investment at end of model horizon
+*    * - beyond_horizon_lifetime
+*      - ``node`` | ``tec`` | ``year_all`` 
+*      - remaining technical lifetime at the end of model horizon
+*    * - beyond_horizon_factor
+*      - ``node`` | ``tec`` | ``year_all``
+*      - discount factor of remaining lifetime beyond model horizon 
+*
+*
 ***
 
 Parameters
@@ -479,8 +648,9 @@ Parameters
 *    * - tax_emission
 *      - ``node`` | ``type_emission`` | ``type_tec`` | ``type_year``
 *
-* .. [#em_scaling] The parameters ``emission_scaling`` allows to efficiently aggregate different emissions/pollutants
-*    and set bounds or taxes on various categories.
+* .. [#em_scaling] The parameter ``emission_scaling`` is the scaling factor to harmonize bounds or taxes across types of
+*    emisisons. It allows to efficiently aggregate different emissions/pollutants and set bounds or taxes on various categories.
+* 
 ***
 
 Parameters
@@ -604,9 +774,9 @@ Parameters
 * Parameters of the `Relations` section
 * -------------------------------------
 *
-* Generic linear relations are implemented in |MESSAGEix|.
-* This feature is intended for development and testing only - all new features should be implemented
-* as specific new mathematical formulations and associated sets & parameters.
+* Generic linear relations are implemented in |MESSAGEix|.This feature is intended for development and testing only - all new features
+* should be implemented as specific new mathematical formulations and associated sets & parameters. For the formulation of the relations
+* refer to  :ref:`section_of_generic_relations`. 
 *
 * .. list-table::
 *    :widths: 25 75

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -510,7 +510,7 @@ Parameters
 *    * - Parameter name
 *      - Index dimensions
 *    * - historical_emission [#hist]_
-*      - ``node`` | ``type_emission`` | ``type_tec`` | ``year``
+*      - ``node`` | ``emission`` | ``type_tec`` | ``year``
 *    * - emission_scaling [#em_scaling]_
 *      - ``type_emission`` | ``emission``
 *    * - bound_emission

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -73,10 +73,10 @@ Parameters
 * Parameters of the `Resources` section
 * -------------------------------------
 *
-* The quantity of the resources in MESSAGEix is represented by two parameters: ``resource_volume`` and ``resource_remaining``.
+* The quantity of the resources in |MESSAGEix| is represented by two parameters: ``resource_volume`` and ``resource_remaining``.
 * The first parameter is the volume of resources at the start of the model horizon while the second is the maximum extraction relative
 * to remaining resources by year. The maximum extraction of the resources (by grade) in a year is constrained by the parameter
-* ``bound_extraction_up``. Extraction costs for resources are represented by ``resource_cost parameter``. 
+* ``bound_extraction_up``. Extraction costs for resources are represented by ``resource_cost`` parameter.
 *
 * .. list-table::
 *    :widths: 25 75
@@ -131,7 +131,7 @@ Parameter
 *      - ``node`` | ``commodity`` | ``year``
 *
 * .. [#demand] The parameter ``demand`` in a ``MESSAGE``-scheme ``ixmp``.Scenario is translated
-*    to the parameter ``demand_fixed`` in the MESSAGE implementation in GAMS. The variable ``DEMAND`` is introduced
+*    to the parameter ``demand_fixed`` in the |MESSAGEix| implementation in GAMS. The variable ``DEMAND`` is introduced
 *    as an auxiliary reporting variable; it equals ``demand_fixed`` in a `MESSAGE`-standalone run and reports
 *    the final demand including the price response in an iterative `MESSAGE-MACRO` solution.
 *
@@ -158,7 +158,7 @@ Parameter
 *    :header-rows: 1
 *
 *    * - Parameter name
-*      - Index Dimensions 
+*      - Index dimensions
 *    * - input [#tecvintage]_
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` |
 *        ``node_origin`` | ``commodity`` | ``level`` | ``time`` | ``time_origin``
@@ -173,7 +173,7 @@ Parameter
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``time``
 *    * - levelized_cost [#levelizedcost]_
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``time``
-*    * - construction_time [#construction]_ 
+*    * - construction_time [#construction]_
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - technical_lifetime
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
@@ -189,9 +189,9 @@ Parameter
 *      - ``node`` | ``technology`` | ``year_act`` | ``commodity`` | ``level`` | ``time`` | ``rating``
 *    * - flexibility_factor [#flexfactor]_
 *      - ``node_loc`` | ``technology`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``commodity`` | ``level`` | ``time`` | ``rating``
-*    * - renewable_capacity_factor [#renewables]_ 
+*    * - renewable_capacity_factor [#renewables]_
 *      - ``node_loc`` | ``commodity`` | ``grade`` | ``level`` | ``year``
-*    * - renewable_potential [#renewables]_ 
+*    * - renewable_potential [#renewables]_
 *      - ``node`` | ``commodity`` | ``grade`` | ``level`` | ``year``
 *    * - emission_factor
 *      - ``node_loc`` | ``tec`` | ``year_vtg`` | ``year_act`` | ``mode`` | ``emission``
@@ -212,7 +212,7 @@ Parameter
 *
 * .. [#flexfactor] Contribution of technologies towards operation flexibility constraint. It is used in :ref:`flexibility_constraint`.
 *
-* .. [#renewables] ``renewable_capacity_factor`` refers to the quality of renewable potential by grade and ``renewable_potential`` refers to the size of the renewable potential per grade. 
+* .. [#renewables] ``renewable_capacity_factor`` refers to the quality of renewable potential by grade and ``renewable_potential`` refers to the size of the renewable potential per grade.
 *
 ***
 
@@ -350,11 +350,13 @@ Parameters
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
 * The implementation of |MESSAGEix| includes the functionality to introduce "add-on technologies" that are specifically
-* linked to parent technologies. This feature can be used to model mitigation options (scrubber, cooling).Note, that no
-* default addon_conversion factor (conversion factor between add-on and parent technology activity) is set, to avoid
-* default conversion factors of 1 being set for technologies with mutiple modes, of which only a single mode should be
-* linked to the add-on technology. Upper and lower bounds of add on technologies are defined relative to the parent
-* technology. 
+* linked to parent technologies. This feature can be used to model mitigation options (scrubber, cooling). Upper and
+* lower bounds of add-on technologies are defined relative to the parent: ``addon_up`` and ``addon_lo``, respectively.
+*
+* .. note::
+*    No default ``addon_conversion`` factor (conversion factor between add-on and parent technology activity) is set.
+*    This is to avoid default conversion factors of 1 being set for technologies with multiple modes, of which only a
+*    single mode should be linked to the add-on technology.
 *
 * .. list-table::
 *    :widths: 20 80
@@ -388,7 +390,7 @@ Parameters
 * The implementation of |MESSAGEix| includes the functionality for 'soft' relaxations of dynamic constraints on
 * new-built capacity and activity (see Keppo and Strubegger, 2010 :cite:`keppo_short_2010`).
 * Refer to the section :ref:`dynamic_constraints`. Absolute cost and levelized cost multipliers are used
-* for the relaxation of upper and lower bounds. 
+* for the relaxation of upper and lower bounds.
 *
 * .. list-table::
 *    :widths: 20 80
@@ -450,17 +452,17 @@ Parameters
 
 Parameters
     historical_new_capacity(node,tec,year_all)           historical new capacity
-    historical_activity(node,tec,year_all,mode,time)     historical acitivity
+    historical_activity(node,tec,year_all,mode,time)     historical activity
 ;
 
 ***
 * Auxiliary investment cost parameters and multipliers
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
-* Auxilary investment cost parameters include the remaining technical lifetime at the end of model horizon in addition to the
-* different scaling factors and  multipliers as listed below. These factors account for remaining capacity or construction time of new capcaity, 
-* the value of investment at the end of mdoel horizon or the discount factor of remaining lifetime beyond model horizon. 
-* 
+* Auxiliary investment cost parameters include the remaining technical lifetime at the end of model horizon (``beyond_horizon_lifetime``) in addition to the
+* different scaling factors and multipliers as listed below. These factors account for remaining capacity (``remaining_capacity``) or construction time of new capacity (``construction_time_factor``),
+* the value of investment at the end of model horizon (``end_of_horizon_factor``) or the discount factor of remaining lifetime beyond model horizon (``beyond_horizon_factor``).
+*
 * .. list-table::
 *    :widths: 35 50
 *    :header-rows: 1
@@ -470,11 +472,11 @@ Parameters
 *    * - construction_time_factor
 *      - ``node`` | ``tec`` | ``year_all``
 *    * -  remaining_capacity
-*      - ``node`` | ``tec`` | ``year_all`` 
+*      - ``node`` | ``tec`` | ``year_all``
 *    * - end_of_horizon_factor
-*      - ``node`` | ``tec`` | ``year_all`` 
+*      - ``node`` | ``tec`` | ``year_all``
 *    * - beyond_horizon_lifetime
-*      - ``node`` | ``tec`` | ``year_all`` 
+*      - ``node`` | ``tec`` | ``year_all``
 *    * - beyond_horizon_factor
 *      - ``node`` | ``tec`` | ``year_all``
 *
@@ -499,7 +501,7 @@ Parameters
 *
 * The implementation of |MESSAGEix| includes a flexible and versatile accounting of emissions across different
 * categories and species, with the option to define upper bounds and taxes on various (aggregates of) emissions
-* and pollutants), (sets of) technologies, and (sets of) years.
+* and pollutants, (sets of) technologies, and (sets of) years.
 *
 * .. list-table::
 *    :widths: 25 75
@@ -517,13 +519,13 @@ Parameters
 *      - ``node`` | ``type_emission`` | ``type_tec`` | ``type_year``
 *
 * .. [#em_scaling] The parameter ``emission_scaling`` is the scaling factor to harmonize bounds or taxes across types of
-*    emisisons. It allows to efficiently aggregate different emissions/pollutants and set bounds or taxes on various categories.
-* 
+*    emissions. It allows to efficiently aggregate different emissions/pollutants and set bounds or taxes on various categories.
+*
 ***
 
 Parameters
     historical_emission(node,emission,type_tec,year_all)    historical emissions by technology type (including land)
-    emission_scaling(type_emission,emission)                scaling factor to harmonize bounds or taxes across tpes
+    emission_scaling(type_emission,emission)                scaling factor to harmonize bounds or taxes across types
     bound_emission(node,type_emission,type_tec,type_year)   upper bound on emissions
     tax_emission(node,type_emission,type_tec,type_year)     emission tax
 ;
@@ -538,7 +540,7 @@ Parameters
 *
 * The implementation of |MESSAGEix| includes a land-use model emulator, which draws on exogenous land-use scenarios
 * (provided by another model) to derive supply of commodities (e.g., biomass) and emissions
-* from agriculture and forestry. The parameters listed below refer to the assigned land scenario. 
+* from agriculture and forestry. The parameters listed below refer to the assigned land scenario.
 *
 * .. list-table::
 *    :widths: 25 75
@@ -609,7 +611,7 @@ Parameters
 * ---------------------------------------------
 *
 * Share constraints define the share of a given commodity/mode to be active on a certain level. For the mathematical
-* formulation refer to :ref:`share_constraints`. 
+* formulation, refer to :ref:`share_constraints`.
 *
 * .. list-table::
 *    :widths: 25 75
@@ -644,8 +646,8 @@ Parameters
 * -------------------------------------
 *
 * Generic linear relations are implemented in |MESSAGEix|. This feature is intended for development and testing only - all new features
-* should be implemented as specific new mathematical formulations and associated sets & parameters. For the formulation of the relations
-* refer to  :ref:`section_of_generic_relations`. 
+* should be implemented as specific new mathematical formulations and associated *sets* & *parameters*. For the formulation of the relations,
+* refer to :ref:`section_of_generic_relations`.
 *
 * .. list-table::
 *    :widths: 25 75
@@ -687,7 +689,7 @@ Parameters
 *
 * The following parameters allow to set variable values to a specific value.
 * The value is usually taken from a solution of another model instance
-* (e.g., scenarios where a shock sets in later to mimick imperfect foresight).
+* (e.g., scenarios where a shock sets in later to mimic imperfect foresight).
 *
 * The fixed values do not override any upper or lower bounds that may be defined,
 * so fixing variables to values outside of that range will yield an infeasible model.

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -73,10 +73,11 @@ Parameters
 * Parameters of the `Resources` section
 * -------------------------------------
 *
-* The quantity of the resources in |MESSAGEix| is represented by two parameters: ``resource_volume`` and ``resource_remaining``.
-* The first parameter is the volume of resources at the start of the model horizon while the second is the maximum extraction relative
-* to remaining resources by year. The maximum extraction of the resources (by grade) in a year is constrained by the parameter
-* ``bound_extraction_up``. Extraction costs for resources are represented by ``resource_cost`` parameter.
+* In |MESSAGEix|, the volume of resources at the start of the model horizon is defined by ``resource_volume``. The quantity of the
+* resources that are extracted per year is dependent on two parameters. The first is ``bound_extraction_up``, which constraints
+* the maximum extraction of the resources (by grade) in a year. The second is ``resource_remaining``, which is the maximum
+* extraction of the remaining resources in a certain year, as a percentage. Extraction costs for resources are represented by
+* ``resource_cost`` parameter.
 *
 * .. list-table::
 *    :widths: 25 75
@@ -282,7 +283,9 @@ Parameters
 * Dynamic constraints on capacity and activity
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
-* The following parameters specify constraints on the growth of new capacity and activity, i.e., market penetration.
+* The following parameters specify constraints on the growth of new capacity and activity, i.e., market penetration. The implementation of |MESSAGEix|
+* includes the functionality for 'soft' relaxations of dynamic constraints on new-built capacity and activity (see Keppo and Strubegger, 2010
+* :cite:`keppo_short_2010`). For more information, please refer to the equations in section :ref:`dynamic_constraints` of the mathematical formulation.
 *
 * .. list-table::
 *    :widths: 30 70
@@ -294,34 +297,31 @@ Parameters
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - growth_new_capacity_up [#mpx]_
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
-*    * - soft_new_capacity_up [#mpx]_ [#soft]_
+*    * - soft_new_capacity_up [#mpx]_
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - initial_new_capacity_lo
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - growth_new_capacity_lo [#mpx]_
 *      - ``node_loc`` | ``tec_actual`` | ``year_vtg``
-*    * - soft_new_capacity_lo [#mpx]_ [#soft]_
+*    * - soft_new_capacity_lo [#mpx]_
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - initial_activity_up [#mpa]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
 *    * - growth_activity_up [#mpx]_ [#mpa]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
-*    * - soft_activity_up [#mpx]_ [#soft]_
+*    * - soft_activity_up [#mpx]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
 *    * - initial_activity_lo [#mpa]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
 *    * - growth_activity_lo [#mpx]_ [#mpa]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
-*    * - soft_activity_lo [#mpx]_ [#soft]_
+*    * - soft_activity_lo [#mpx]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``time``
 *
 * .. [#mpx] All parameters related to the dynamic constraints are understood as the bound on the rate
 *    of growth/decrease, not as in percentage points and not as (1+growth rate).
 *
 * .. [#mpa] The dynamic constraints are not indexed over modes in the |MESSAGEix| implementation.
-*
-* .. [#soft] The implementation of |MESSAGEix| includes the functionality for 'soft' relaxations of dynamic constraints on
-*            new-built capacity and activity (see Keppo and Strubegger, 2010 :cite:`keppo_short_2010`). Refer to the section :ref:`dynamic_constraints`
 *
 ***
 


### PR DESCRIPTION
Closes #260.
Two other issues that are related and might also be addressed in this PR: #241 and #51.

This PR updates the parameter documentation and adds explanations for the parameters that are not self-explanatory. The parameter explanations are based on the definitions provided in `parameter_def.gms` file. 

Even though the initial idea was to add the definitions in the tables for every parameter, after a discussion with @volker-krey , we agreed that it is better to add these definitions only for parameters that are not clear since most of the parameters are already self-explanatory (e.g. bound_activity_up, construction_time etc.) and the tables look exhaustive (especially in the `pdf` version of the documentation) when all the definitions are added. 

The additional information and related links are added to the footnotes and to the explanation paragraphs for the parameters/sections that might require more explanation. (e.g. rating_bin, add-on technologies, cost parameters for ‘soft’ relaxations of dynamic constraints, auxiliary investment cost parameters and multipliers, emission scaling, relations, resources). 

These additions are based on the `parameter_def.gms` file which includes only basic definitions of the parameters. The reviewers could suggest changes to the explanations in case they are not clear enough (Especially for the section of **"Auxiliary investment cost parameters and multipliers"**).   

The documentation page can be built by using the command: `sphinx-build [source-directory] [output-directory]`

source-directory: `C:\....\message_ix\doc\source`  
output directory: `C:\....\message_ix\doc\build`