### PR TITLE
Specify jupyter_console conda requirement

### DIFF
--- a/ci/conda-requirements.txt
+++ b/ci/conda-requirements.txt
@@ -4,6 +4,7 @@ codecov
 dask
 JPype1
 jupyter
+jupyter_console>=6
 matplotlib
 numpy
 numpydoc


### PR DESCRIPTION
This PR addresses a CI issue encountered in both #276 and #281.

The build log (e.g. [Travis job #1316.2 at L2425](https://travis-ci.org/iiasa/message_ix/jobs/624034624#L2425)) shows:
```
Collecting package metadata (current_repodata.json): done
Solving environment: - 
Warning: 2 possible package resolutions (only showing differing packages):
  - defaults::jupyter_console-5.2.0-py36_1, defaults::prompt_toolkit-3.0.2-py_0
  - defaults::jupyter_console-6.0.0-py36_0, defaults::prompt_toolkit-2.0.9-py36done
```
and that jupyter_console **5.2.0** and prompt_toolkit **3.0.2** are installed. This leads to the exception:
```
NbConvertApp] Converting notebook /home/travis/build/iiasa/message_ix/tests/../tutorial/Austrian_energy_system/austria.ipynb to notebook

Traceback (most recent call last):
  File "/home/travis/miniconda/envs/testing/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/travis/miniconda/envs/testing/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/miniconda/envs/testing/lib/python3.7/site-packages/ipykernel_launcher.py", line 15, in <module>
    from ipykernel import kernelapp as app
  File "/home/travis/miniconda/envs/testing/lib/python3.7/site-packages/ipykernel/__init__.py", line 2, in <module>
    from .connect import *
  File "/home/travis/miniconda/envs/testing/lib/python3.7/site-packages/ipykernel/connect.py", line 13, in <module>
    from IPython.core.profiledir import ProfileDir
  File "/home/travis/miniconda/envs/testing/lib/python3.7/site-packages/IPython/__init__.py", line 55, in <module>
    from .terminal.embed import embed
  File "/home/travis/miniconda/envs/testing/lib/python3.7/site-packages/IPython/terminal/embed.py", line 16, in <module>
    from IPython.terminal.interactiveshell import TerminalInteractiveShell
  File "/home/travis/miniconda/envs/testing/lib/python3.7/site-packages/IPython/terminal/interactiveshell.py", line 20, in <module>
    from prompt_toolkit.formatted_text import PygmentsTokens
ModuleNotFoundError: No module named 'prompt_toolkit.formatted_text'
```

When conda instead chooses—non-deterministically, apparently, which is super unhelpful—to install jupyter_console jupyter_console **6.0.0** and prompt_toolkit **2.0.9**, the exception does not occur.

Resolved by specifying the minimum version of jupyter_console in ci/conda-requirements.txt

**PR checklist:**

- [x] ~Tests added.~ N/A
- [x] ~Documentation added.~ N/A
- [x] ~Release notes updated.~ N/A; CI-only