### PR TITLE
Drop support for Python 2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ See [PEP-0373](https://legacy.python.org/dev/peps/pep-0373/) and https://python3
 
 ## All changes
 
+- [#285](https://github.com/iiasa/message_ix/pull/285): Drop support for Python 2.
 - [#281](https://github.com/iiasa/message_ix/pull/281): Test and improve logic of `years_active` and `vintage_and_active_years`.
 - [#269](https://github.com/iiasa/message_ix/pull/269): Enforce 'year'-indexed columns as integers.
 - [#256](https://github.com/iiasa/message_ix/pull/256): Update to use :obj:`ixmp.config` and improve CLI.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,10 @@
 
 ## Migrating
 
+**Support for Python 2.7 is dropped** as it has reached end-of-life, meaning no further releases will be made even to fix bugs.
+See [PEP-0373](https://legacy.python.org/dev/peps/pep-0373/) and https://python3statement.org.
+``message_ix`` users must upgrade to Python 3.
+
 **Command-line interface (CLI).** Use `message-ix` as the program for all command-line operations:
 - `message-ix copy-model` replaces `messageix-config`.
 - `message-ix dl` replaces `messageix-dl`.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-
 import os
 import re
 

--- a/tests/test_feature_price_emission.py
+++ b/tests/test_feature_price_emission.py
@@ -1,6 +1,3 @@
-# for Py2 compatibility - to be removed as part of release 2.0
-from __future__ import division
-
 from message_ix import Scenario
 import numpy.testing as npt
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -2,10 +2,7 @@ import pytest
 
 from functools import partial
 from logging import WARNING
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
+from pathlib import Path
 
 from ixmp.reporting import Reporter as ixmp_Reporter
 from ixmp.testing import assert_qty_equal

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -1,18 +1,8 @@
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
-import sys
+from pathlib import Path
 
 from ixmp.testing import run_notebook, get_cell_output
 import numpy as np
 import pytest
-
-
-# Skip the entire file on Python 2
-if sys.version_info[0] == 2:
-    py2_deprecated = 'Python 2 is deprecated in the tutorials'
-    pytestmark = pytest.mark.skip(reason=py2_deprecated)
 
 
 AT = 'Austrian_energy_system'
@@ -27,9 +17,6 @@ AT = 'Austrian_energy_system'
 tutorials = [
     (('westeros', 'westeros_baseline'),
      [('solve-objective-value', 238193.291167)]),
-
-    # on Python 2:
-    # 'solve-objective-value', 187445.953125),
     (('westeros', 'westeros_emissions_bounds'), []),
     (('westeros', 'westeros_emissions_taxes'), []),
     (('westeros', 'westeros_firm_capacity'), []),

--- a/tutorial/utils/plotting.py
+++ b/tutorial/utils/plotting.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import pandas as pd
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
Closes #177 by removing remaining Python 2 compatibility code.

See also iiasa/ixmp#239.

**PR checklist:**

- [x] ~Tests added.~ N/A
- [x] Documentation added.
- [x] Release notes updated.