### PR TITLE
Add JAVA_HOME env variable construction to installation page

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -38,11 +38,6 @@ from source code (next section).
 
     $ conda install -c conda-forge message-ix
 
-.. note:: If you get an error containing ``No JVM shared library file (jvm.dll)
-          found.`` when running ``mp = ix.Platform(dbtype='HSQLDB')``, it is
-          likely that you need to set the `JAVA_HOME` environment variable (for
-          instructions, see for example `Java Tutorial`_).
-
 Install |MESSAGEix| from source
 -------------------------------
 
@@ -70,14 +65,20 @@ Install |MESSAGEix| from source
     $ pip install .[tests]
     $ py.test tests
 
-.. note:: If you get an error containing ``No JVM shared library file (jvm.dll)
-          found.`` when running ``mp = ix.Platform(dbtype='HSQLDB')``, it is
-          likely that you need to set the `JAVA_HOME` environment variable (for
-          instructions, see for example `Java Tutorial`_).
+Common issues
+-------------
+
+No JVM shared library file (jvm.dll) found
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you get an error containing ``No JVM shared library file (jvm.dll) found.``
+when running ``mp = ix.Platform(dbtype='HSQLDB')``, it is likely that you need
+to set the `JAVA_HOME` environment variable (for instructions, see for example
+`these instructions`_).
 
 .. _`GAMS`: http://www.gams.com
 .. _`Anaconda`: https://www.anaconda.com/distribution/#download-section
 .. _`ixmp`: https://github.com/iiasa/ixmp
 .. _`Github Desktop`: https://desktop.github.com
 .. _`README`: https://github.com/iiasa/message_ix#install-from-source-advanced-users
-.. _`Java Tutorial`: https://javatutorial.net/set-java-home-windows-10
+.. _`these instructions`: https://javatutorial.net/set-java-home-windows-10

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -71,10 +71,7 @@ Common issues
 No JVM shared library file (jvm.dll) found
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you get an error containing ``No JVM shared library file (jvm.dll) found.``
-when running ``mp = ix.Platform(dbtype='HSQLDB')``, it is likely that you need
-to set the `JAVA_HOME` environment variable (for instructions, see for example
-`these instructions`_).
+If you get an error containing “No JVM shared library file (jvm.dll) found” when creating a :class:`Platform` object (e.g. ``mp = ix.Platform(driver='HSQLDB')``), it is likely that you need to set the ``JAVA_HOME`` environment variable (see for example `these instructions`_).
 
 .. _`GAMS`: http://www.gams.com
 .. _`Anaconda`: https://www.anaconda.com/distribution/#download-section

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -38,6 +38,10 @@ from source code (next section).
 
     $ conda install -c conda-forge message-ix
 
+.. note:: If you get an error containing ``No JVM shared library file (jvm.dll)
+          found.`` when running ``mp = ix.Platform(dbtype='HSQLDB')``, it is
+          likely that you need to set the `JAVA_HOME` environment variable (for
+          instructions, see for example `Java Tutorial`_).
 
 Install |MESSAGEix| from source
 -------------------------------
@@ -66,9 +70,14 @@ Install |MESSAGEix| from source
     $ pip install .[tests]
     $ py.test tests
 
+.. note:: If you get an error containing ``No JVM shared library file (jvm.dll)
+          found.`` when running ``mp = ix.Platform(dbtype='HSQLDB')``, it is
+          likely that you need to set the `JAVA_HOME` environment variable (for
+          instructions, see for example `Java Tutorial`_).
 
 .. _`GAMS`: http://www.gams.com
 .. _`Anaconda`: https://www.anaconda.com/distribution/#download-section
 .. _`ixmp`: https://github.com/iiasa/ixmp
 .. _`Github Desktop`: https://desktop.github.com
 .. _`README`: https://github.com/iiasa/message_ix#install-from-source-advanced-users
+.. _`Java Tutorial`: https://javatutorial.net/set-java-home-windows-10


### PR DESCRIPTION
This adds a note about the need to add JAVA_HOME to the environment variables when JVM is not found. 

Since multiple (new) users got stuck when first running MESSAGE_ix (see issue #35 ), a note with one example linking instructions on how to properly set the JAVA_HOME variable are added to the installation instructions.