### PR TITLE
Update install from source docs to include pip --editable option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ tests/data/testdb/ixmptest.lck
 .pytest_cache
 coverage.xml
 htmlcov
+
+# JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+/**/.idea
+

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -58,12 +58,12 @@ Install |MESSAGEix| from source
 
 6. Open a command prompt in the ``message_ix`` directory and type::
 
-    $ pip install .
+    $ pip install --editable .
 
 7. (Optional) Run the built-in test suite to check that |MESSAGEix| functions
    correctly on your system::
 
-    $ pip install .[tests]
+    $ pip install --editable .[tests]
     $ py.test tests
 
 


### PR DESCRIPTION
PR to include `--edtiable` in _MESSAGEix_ docu to be able to run tests. It is present in _ixmp_ docu but **not** in _MESSAGEix_. I discovered after reinstalling MESSAGEix following the docu with the command `pip install .` and then running the tests: `nightly.py` was not skipped and therefore prompting an interruption error.

Also added in `.gitignore.txt` PyCharm's `/.idea` folder (which is automatically created every time you start a project with it).

Should I add sth in `RELEASE_NOTES.md` ? @khaeru 

- [x] Documentation added.
