### PR TITLE
Add test for cat_list()

### DIFF
--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -159,7 +159,7 @@ class Scenario(ixmp.Scenario):
         name : str
             Name of the set.
         """
-        return self._backend('get_cat_list', name)
+        return self._backend('cat_list', name)
 
     def add_cat(self, name, cat, keys, is_unique=False):
         """Map elements from *keys* to category *cat* within set *name*.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -160,11 +160,10 @@ def test_cat_all(test_mp):
 
 def test_cat_list(test_mp):
     scen = Scenario(test_mp, *msg_args, version='new')
-    years = [2000, 2010, 2020]
-    scen.add_horizon({'year': years, 'firstmodelyear': 2010})
-    obs = scen.cat_list('year')
-    exp = pd.DataFrame({'firstmodelyear': (2010)})
-    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    # cat_list() returns default 'year' categories in a new message_ix.Scenario
+    exp = ['firstmodelyear', 'lastmodelyear', 'initializeyear_macro']
+    assert all(exp == scen.cat_list('year'))
 
 
 def test_add_cat(test_mp):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -158,6 +158,15 @@ def test_cat_all(test_mp):
                                 'transport_from_san-diego'])
 
 
+def test_cat_list(test_mp):
+    scen = Scenario(test_mp, *msg_args, version='new')
+    years = [2000, 2010, 2020]
+    scen.add_horizon({'year': years, 'firstmodelyear': 2010})
+    obs = scen.cat_list('year')
+    exp = pd.DataFrame({'firstmodelyear': (2010)})
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+
 def test_add_cat(test_mp):
     scen = Scenario(test_mp, *msg_args)
     scen2 = scen.clone(keep_solution=False)


### PR DESCRIPTION
This PR closes #293.

Added a test to check if the error found in #293 is solved.

Basically, the _JDBCBackend_ does not have an attribute called `get_cat_list`. The Backend method is named `cat_list` instead:

[](https://github.com/iiasa/ixmp/blob/39e900dea02950bcea69e273e79002b5748551b4/ixmp/backend/base.py#L715-L717)

[](https://github.com/iiasa/ixmp/blob/39e900dea02950bcea69e273e79002b5748551b4/ixmp/backend/jdbc.py#L674-L675)

This problem can ideally be solved by somebody with experience in _JDBCBackend_.