### PR TITLE
Update Travis CI configuration and scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 cache:
   # Travis ensures these directories are created if they do not already exist
   directories:
-  # - $HOME/miniconda/pkgs
+  # - $HOME/miniconda/pkgs  # see https://github.com/iiasa/message_ix/pull/295
   - $HOME/.conda/pkgs
   - $HOME/.cache/message_ix
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 cache:
   # Travis ensures these directories are created if they do not already exist
   directories:
-  - $HOME/miniconda/pkgs
+  # - $HOME/miniconda/pkgs
   - $HOME/.conda/pkgs
   - $HOME/.cache/message_ix
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,12 @@ cache:
   - $HOME/.cache/message_ix
 
 addons:
+  apt:
+    packages:
+    - graphviz
   homebrew:
-    update: true
+    packages:
+    - graphviz
 
 before_install:
   # Set other environment variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ cache:
   - $HOME/.conda/pkgs
   - $HOME/.cache/message_ix
 
+addons:
+  homebrew:
+    update: true
+
 before_install:
   # Set other environment variables
   - . ci/env.sh

--- a/ci/travis-before_install.sh
+++ b/ci/travis-before_install.sh
@@ -12,11 +12,3 @@ maybe_download () {
 
 maybe_download $GAMSURL $GAMSFNAME
 maybe_download $CONDAURL $CONDAFNAME
-
-
-# Install graphiz on OS X (requires updating homebrew)
-if [ `uname` = "Darwin" ];
-then
-  brew update
-  brew install graphviz
-fi

--- a/ci/travis-before_install.sh
+++ b/ci/travis-before_install.sh
@@ -12,3 +12,21 @@ maybe_download () {
 
 maybe_download $GAMSURL $GAMSFNAME
 maybe_download $CONDAURL $CONDAFNAME
+
+# # Install graphiz on OS X
+# if [ `uname` = "Darwin" ];
+# then
+#   # NB 'brew update' is triggered in .travis.yml
+#
+#   brew config
+#
+#   # Install graphviz' dependencies, but avoid installing 'python', which fails
+#   # and causes the build to error. See
+#   # https://github.com/iiasa/message_ix/pull/295.
+#   brew install gd
+#   brew upgrade glib  # depends on python
+#   brew install netpbm
+#   brew install --ignore-dependencies gts # depends on glib
+#
+#   brew install --ignore-dependencies graphviz
+# fi

--- a/ci/travis-before_install.sh
+++ b/ci/travis-before_install.sh
@@ -12,21 +12,3 @@ maybe_download () {
 
 maybe_download $GAMSURL $GAMSFNAME
 maybe_download $CONDAURL $CONDAFNAME
-
-# # Install graphiz on OS X
-# if [ `uname` = "Darwin" ];
-# then
-#   # NB 'brew update' is triggered in .travis.yml
-#
-#   brew config
-#
-#   # Install graphviz' dependencies, but avoid installing 'python', which fails
-#   # and causes the build to error. See
-#   # https://github.com/iiasa/message_ix/pull/295.
-#   brew install gd
-#   brew upgrade glib  # depends on python
-#   brew install netpbm
-#   brew install --ignore-dependencies gts # depends on glib
-#
-#   brew install --ignore-dependencies graphviz
-# fi

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -12,17 +12,20 @@ which gams
 # -u: update existing installation
 # -p: install prefix
 $CACHE/$CONDAFNAME -b -u -p $HOME/miniconda
-conda update --yes conda pip
 
-# Search conda-forge in addition to the default channels, for e.g. JPype
-conda config --append channels conda-forge
+# - Less noisy output
+# - Search conda-forge in addition to the default channels, for e.g. JPype
+# conda config --set quiet true
+conda config --set always_yes true \
+             --append channels conda-forge
 
-# Create and activate named environment
-conda create --yes --name testing python=$PYVERSION pip
+# Create, update, and activate named environment
+conda create --name testing python=$PYVERSION pip
+conda update --name testing conda
 . activate testing
 
 # Install dependencies
-conda install --yes --name testing --file ci/conda-requirements.txt
+conda install --name testing --file ci/conda-requirements.txt
 pip install --requirement ci/pip-requirements.txt
 
 # Temporary: see https://github.com/IAMconsortium/pyam/issues/281

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -34,13 +34,13 @@ conda info --all
 # Install graphiz on OS X
 if [ `uname` = "Darwin" ];
 then
-  brew --verbose info graphviz
-  brew --verbose deps graphviz
-  brew --verbose info glib
-  brew --verbose deps glib
-  brew --verbose install --ignore-dependencies gd
-  brew --verbose upgrade --ignore-dependencies glib
-  brew --verbose install --ignore-dependencies netpbm
-  brew --verbose install --ignore-dependencies gts
-  brew --verbose install --ignore-dependencies graphviz
+  brew info    --verbose graphviz
+  brew deps    --verbose graphviz
+  brew info    --verbose glib
+  brew deps    --verbose glib
+  brew install --verbose --ignore-dependencies gd
+  brew upgrade --verbose --ignore-dependencies glib
+  brew install --verbose --ignore-dependencies netpbm
+  brew install --verbose --ignore-dependencies gts
+  brew install --verbose --ignore-dependencies graphviz
 fi

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -30,3 +30,6 @@ pip install "matplotlib>3.0.2"
 
 # Show information
 conda info --all
+
+# Install graphiz on OS X
+if [ `uname` = "Darwin" ]; then brew install graphviz; fi

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -30,17 +30,3 @@ pip install "matplotlib>3.0.2"
 
 # Show information
 conda info --all
-
-# Install graphiz on OS X
-if [ `uname` = "Darwin" ];
-then
-  brew info    --verbose graphviz
-  brew deps    --verbose graphviz
-  brew info    --verbose glib
-  brew deps    --verbose glib
-  brew install --verbose --ignore-dependencies gd
-  brew upgrade --verbose --ignore-dependencies glib
-  brew install --verbose --ignore-dependencies netpbm
-  brew install --verbose --ignore-dependencies gts
-  brew install --verbose --ignore-dependencies graphviz
-fi

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -14,14 +14,14 @@ which gams
 $CACHE/$CONDAFNAME -b -u -p $HOME/miniconda
 
 # - Less noisy output
-# - Search conda-forge in addition to the default channels, for e.g. JPype
 # conda config --set quiet true
-conda config --set always_yes true \
-             --append channels conda-forge
+conda config --set always_yes true
+# - Search conda-forge in addition to the default channels, for e.g. JPype
+conda config --append channels conda-forge
+conda update --name base conda
 
-# Create, update, and activate named environment
+# Create and activate named environment
 conda create --name testing python=$PYVERSION pip
-conda update --name testing conda
 . activate testing
 
 # Install dependencies

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -34,10 +34,13 @@ conda info --all
 # Install graphiz on OS X
 if [ `uname` = "Darwin" ];
 then
-  brew info graphviz
-  brew deps graphviz
-  brew info glib
-  brew deps glib
-  brew install --ignore-dependencies glib
-  brew install graphviz
+  brew --verbose info graphviz
+  brew --verbose deps graphviz
+  brew --verbose info glib
+  brew --verbose deps glib
+  brew --verbose install --ignore-dependencies gd
+  brew --verbose upgrade --ignore-dependencies glib
+  brew --verbose install --ignore-dependencies netpbm
+  brew --verbose install --ignore-dependencies gts
+  brew --verbose install --ignore-dependencies graphviz
 fi

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -32,4 +32,12 @@ pip install "matplotlib>3.0.2"
 conda info --all
 
 # Install graphiz on OS X
-if [ `uname` = "Darwin" ]; then brew install graphviz; fi
+if [ `uname` = "Darwin" ];
+then
+  brew info graphviz
+  brew deps graphviz
+  brew info glib
+  brew deps glib
+  brew install --ignore-dependencies glib
+  brew install graphviz
+fi

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -1,26 +1,27 @@
 # Installation script for Linux/macOS CI on Travis
 
-# Install GAMS
+# GAMS: install
 $CACHE/$GAMSFNAME > install.out
 
 # Show location
 which gams
 
 
-# Install and update conda
+# Miniconda: install
 # -b: run in batch mode with no user input
 # -u: update existing installation
 # -p: install prefix
 $CACHE/$CONDAFNAME -b -u -p $HOME/miniconda
 
-# - Less noisy output
-# conda config --set quiet true
+# Configure: give --yes for every command; search conda-forge in addition to
+# the default channels, for e.g. JPype
 conda config --set always_yes true
-# - Search conda-forge in addition to the default channels, for e.g. JPype
 conda config --append channels conda-forge
-conda update --name base conda
 
-# Create and activate named environment
+# Update conda and packages in the base environment
+conda update --quiet --name base conda
+
+# Create and activate a named environment for testing message_ix
 conda create --name testing python=$PYVERSION pip
 . activate testing
 


### PR DESCRIPTION
Around 23 December, the [Travis CRON builds of message_ix](https://travis-ci.org/iiasa/message_ix/builds) began to fail. There seem to be *different* failure modes by OS, as described below. This PR is to debug & fix both.

## Linux
See e.g. [job #1363.1 @ L383](https://travis-ci.org/iiasa/message_ix/jobs/628779524#L383). Anaconda fails to download packages needed to install, so the build errors:
```
Downloading and Extracting Packages
openssl-1.1.1d       | 2.5 MB    |            |   0% 
wheel-0.33.6         | 42 KB     |            |   0% 
sqlite-3.30.0        | 1.1 MB    |            |   0% 
pip-19.3.1           | 1.6 MB    |            |   0% 
asn1crypto-1.2.0     | 166 KB    |            |   0% 
cryptography-2.8     | 553 KB    |            |   0% 
setuptools-41.4.0    | 510 KB    |            |   0% 
pysocks-1.7.1        | 31 KB     |            |   0% 
certifi-2019.9.11    | 151 KB    |            |   0% 
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/linux-64/openssl-1.1.1d-h7b6447c_3.conda\nThis command is using a remote connection in offline mode.\n')
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/linux-64/wheel-0.33.6-py37_0.conda\nThis command is using a remote connection in offline mode.\n')
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.30.0-h7b6447c_0.conda\nThis command is using a remote connection in offline mode.\n')
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/linux-64/pip-19.3.1-py37_0.conda\nThis command is using a remote connection in offline mode.\n')
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/linux-64/asn1crypto-1.2.0-py37_0.conda\nThis command is using a remote connection in offline mode.\n')
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/linux-64/cryptography-2.8-py37h1ba5d50_0.conda\nThis command is using a remote connection in offline mode.\n')
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/linux-64/setuptools-41.4.0-py37_0.conda\nThis command is using a remote connection in offline mode.\n')
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/linux-64/pysocks-1.7.1-py37_0.conda\nThis command is using a remote connection in offline mode.\n')
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/linux-64/certifi-2019.9.11-py37_0.conda\nThis command is using a remote connection in offline mode.\n')
```
- Clearing the Travis build caches seems to fix this issue.
- But, after a build successfully completes and a new cache is uploaded, the failure returns.
- Despite the text “This command is using a remote connection in offline mode.”, we are not using the `--offline` flag anywhere in the Travis CI script.
- ci/travis-install.sh is modified a little following [this example, from pandas](https://github.com/pandas-dev/pandas/blob/master/ci/setup_env.sh).
- However, the **fix** seems to be to disable caching of `$HOME/miniconda/pkgs`.
  - Having this directory already present/populated seems to offend miniconda.sh, even when the `-u / -f` installation flag is given.
  - Removing this cache does not noticeable slow the build; in any case, the Linux build is several minutes faster than the macOS build, and so not the rate-limiting step.

## macOS
Compare jobs [#1367.2 @ L536](https://travis-ci.org/iiasa/message_ix/jobs/630046318#L536) and [#1368.2 @ L606](https://travis-ci.org/iiasa/message_ix/jobs/630360945#L606) (one day apart). In response to `brew install graphviz`, Homebrew now tries to install a new copy of Python; but this fails, and causes the build to error.

- [Here](https://www.mail-archive.com/qemu-devel@nongnu.org/msg669122.html), in a different project, it is suggested to use `brew link --override python`.
- In 30c7da5 / [job #1388.2 @ L92](https://travis-ci.org/iiasa/message_ix/jobs/634660461#L92), this is **fixed** by using .travis.yml to trigger installation of the package.
  - This matches what is done in ixmp.
  - In message_ix, `brew install graphviz` was called from the before_install script, resulting in different behaviour. It's still unclear why this differs.