### PR TITLE
Adjust to v2.0 deprecations in ixmp

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,8 @@ Next release
 All changes
 -----------
 
+- `#307 <https://github.com/iiasa/message_ix/pull/307>`_: adjust to deprecations in ixmp 2.0.
+
 
 v2.0.0 (2020-01-14)
 ===================

--- a/ci/pip-requirements.txt
+++ b/ci/pip-requirements.txt
@@ -1,5 +1,8 @@
-# Always track ixmp master
-git+git://github.com/iiasa/ixmp.git#egg=ixmp
+## Always track ixmp master
+#git+git://github.com/iiasa/ixmp.git@#egg=ixmp
+
+# Branch for https://github.com/iiasa/ixmp/pull/254
+git+git://github.com/khaeru/ixmp.git@post-2.0-cleanup#egg=ixmp
 
 # pyam-iamc
 # Temporary: see https://github.com/IAMconsortium/pyam/issues/259

--- a/ci/pip-requirements.txt
+++ b/ci/pip-requirements.txt
@@ -1,8 +1,5 @@
-## Always track ixmp master
-#git+git://github.com/iiasa/ixmp.git@#egg=ixmp
-
-# Branch for https://github.com/iiasa/ixmp/pull/254
-git+git://github.com/khaeru/ixmp.git@post-2.0-cleanup#egg=ixmp
+# Always track ixmp master
+git+git://github.com/iiasa/ixmp.git@#egg=ixmp
 
 # pyam-iamc
 # Temporary: see https://github.com/IAMconsortium/pyam/issues/259

--- a/ci/pip-requirements.txt
+++ b/ci/pip-requirements.txt
@@ -1,5 +1,5 @@
 # Always track ixmp master
-git+git://github.com/iiasa/ixmp.git@#egg=ixmp
+git+git://github.com/iiasa/ixmp.git@master#egg=ixmp
 
 # pyam-iamc
 # Temporary: see https://github.com/IAMconsortium/pyam/issues/259

--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -5,7 +5,7 @@ import tempfile
 import zipfile
 
 import click
-from ixmp import config
+import ixmp
 from ixmp.cli import main
 import message_ix
 import message_ix.tools.add_year.cli
@@ -19,6 +19,9 @@ main.help == \
     To view/run the 'nightly' commands, you need the testing dependencies.
     Run `pip install [--editable] .[tests]`.
     """
+
+# Override the class used by the ixmp CLI to load Scenario objects
+ixmp.cli.ScenarioClass = message_ix.Scenario
 
 
 @main.command('copy-model')
@@ -67,8 +70,8 @@ def copy_model(path, overwrite, set_default):
         copyfile(src, dst)
 
     if set_default:
-        config.set('message model dir', path)
-        config.save()
+        ixmp.config.set('message model dir', path)
+        ixmp.config.save()
 
 
 @main.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,9 +31,9 @@ def test_copy_model(message_ix_cli, tmp_path, tmp_env):
 @pytest.mark.parametrize('opts', [
     # During release prep, 'dl' will try to download e.g. v2.0.0, which does
     # not yet exist; so the test fails. Use this line:
-    pytest.param('', marks=pytest.mark.xfail),
+    # pytest.param('', marks=pytest.mark.xfail),
     # Otherwise (normal state on master), use this line:
-    # '',
+    '',
     '--branch=master',
     '--tag=1.2.0',
 ])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,9 +2,9 @@ import os
 
 import ixmp
 import numpy as np
-from numpy import testing as npt
+import numpy.testing as npt
 import pandas as pd
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 import pytest
 
 from message_ix import Scenario

--- a/tutorial/utils/run_scenarios.py
+++ b/tutorial/utils/run_scenarios.py
@@ -8,7 +8,7 @@ import message_ix
 
 
 def check_local_model(model, notebook, shell=False):
-    mp = ixmp.Platform(dbtype='HSQLDB')
+    mp = ixmp.Platform()
     if model in mp.scenario_list().model.unique():
         mp.close_db()
         return
@@ -41,7 +41,7 @@ def make_scenario(platform, country, name, base_scen, scen):
     by = "by 'tutorial/utils/run_scenarios.py:make_scenario()'"
     ds = base_ds.clone(
         name, scen, "scenario generated {}, {} - {}".format(by, name, scen),
-        keep_sol=False)
+        keep_solution=False)
     ds.check_out()
 
     yield ds


### PR DESCRIPTION
Related to iiasa/ixmp#254, this PR removes usage of ixmp features that were marked as deprecated in ixmp 2.0. There were no marked deprecations in message_ix 2.0 itself.

## How to review

Run your own code(s) against this branch to ensure they still work; or make any necessary adjustments.

## PR checklist

- [x] Tests added.
- [x] ~Documentation added.~ N/A
- [x] Release notes updated.