### PR TITLE
Update Platform semantics in nightly tests

### DIFF
--- a/ci/appveyor-install.ps1
+++ b/ci/appveyor-install.ps1
@@ -59,14 +59,17 @@ $env:PATH = $CR + ';' + $CR + '\Scripts;' + $CR + '\Library\bin;' + $env:PATH
 # TODO test and possibly remove once reticulate 1.14 is released
 $env:RETICULATE_PYTHON = $CR + '\python.exe'
 
-Progress 'Update conda'
-# Search conda-forge in addition to the default channels, for e.g. JPype
+# Configure:
+# - give --yes for every command
+# - search conda-forge in addition to the default channels, for e.g. JPype
+Exec { conda config --set always_yes true }
 Exec { conda config --append channels conda-forge }
 
 # The installed conda on Appveyor workers is 4.5.x, while the latest is >4.7.
 # --quiet here and below suppresses progress bars, which show up as many lines
 # in the Appveyor build logs.
-Exec { conda update --yes --quiet conda pip }
+Progress 'Update conda'
+Exec { conda update --quiet --name base conda }
 
 # NB at the corresponding location, travis-install.sh creates a new conda
 #    environment, and later activates it. This was attempted for Windows/
@@ -75,7 +78,7 @@ Exec { conda update --yes --quiet conda pip }
 #    dependencies are installed into the base conda environment.
 
 Progress 'Install dependencies'
-Exec { conda install --yes --file ci/conda-requirements.txt }
+Exec { conda install --file ci/conda-requirements.txt }
 Exec { pip install --requirement ci/pip-requirements.txt }
 
 # Temporary: see https://github.com/IAMconsortium/pyam/issues/281

--- a/ci/appveyor-install.ps1
+++ b/ci/appveyor-install.ps1
@@ -60,13 +60,13 @@ $env:PATH = $CR + ';' + $CR + '\Scripts;' + $CR + '\Library\bin;' + $env:PATH
 $env:RETICULATE_PYTHON = $CR + '\python.exe'
 
 Progress 'Update conda'
+# Search conda-forge in addition to the default channels, for e.g. JPype
+Exec { conda config --append channels conda-forge }
+
 # The installed conda on Appveyor workers is 4.5.x, while the latest is >4.7.
 # --quiet here and below suppresses progress bars, which show up as many lines
 # in the Appveyor build logs.
 Exec { conda update --yes --quiet conda pip }
-
-# Search conda-forge in addition to the default channels, for e.g. JPype
-Exec { conda config --append channels conda-forge }
 
 # NB at the corresponding location, travis-install.sh creates a new conda
 #    environment, and later activates it. This was attempted for Windows/

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -13,8 +13,9 @@ which gams
 # -p: install prefix
 $CACHE/$CONDAFNAME -b -u -p $HOME/miniconda
 
-# Configure: give --yes for every command; search conda-forge in addition to
-# the default channels, for e.g. JPype
+# Configure:
+# - give --yes for every command
+# - search conda-forge in addition to the default channels, for e.g. JPype
 conda config --set always_yes true
 conda config --append channels conda-forge
 

--- a/message_ix/testing/nightly.py
+++ b/message_ix/testing/nightly.py
@@ -95,7 +95,8 @@ def iter_scenarios():
 
 
 def make_db(path):
-    mp = ixmp.Platform(dbprops=path / 'scenarios', dbtype='HSQLDB')
+    mp = ixmp.Platform(backend='jdbc', driver='hsqldb',
+                       path=path / 'scenarios')
     for id, data in iter_scenarios():
         scen = message_ix.Scenario(mp, data['model'], data['scenario'],
                                    version='new')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [tool:pytest]
+# Disable faulthandler plugin on Windows to prevent spurious console noise
 addopts = --cov=message_ix --cov-config=ci/coveragerc
     --cov-report term-missing --cov-report xml
+    -p no:faulthandler
 testpaths = tests

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,11 +1,10 @@
-import pytest
-import numpy as np
-from numpy import testing as npt
-import pandas.util.testing as pdt
-
 from ixmp import Platform
-from message_ix import Scenario
+from numpy import testing as npt
+import numpy as np
+import pandas.testing as pdt
+import pytest
 
+from message_ix import Scenario
 from message_ix.testing import (
     make_dantzig,
     models,

--- a/tests/test_nightly.py
+++ b/tests/test_nightly.py
@@ -41,8 +41,9 @@ def downloaded_scenarios(tmp_path_factory):
     yield dict(
         # TODO repack the archive without a 'db' directory, and remove from the
         #      path here
-        dbprops=path / 'db' / 'scenarios',
-        dbtype='HSQLDB',
+        backend='jdbc',
+        driver='hsqldb',
+        path=path / 'db' / 'scenarios',
     )
 
 

--- a/tests/test_nightly.py
+++ b/tests/test_nightly.py
@@ -12,16 +12,16 @@ import numpy as np  # noqa: F401
 import pytest
 
 
-pytestmark = pytest.mark.skipif(
-    os.environ.get('TRAVIS_EVENT_TYPE', '') != 'cron'
-    or os.environ.get('TRAVIS_OS_NAME', '') == 'osx',
-    reason="Nightly scenario tests only run on Travis 'cron' events.")
+# pytestmark = pytest.mark.skipif(
+#     os.environ.get('TRAVIS_EVENT_TYPE', '') != 'cron'
+#     or os.environ.get('TRAVIS_OS_NAME', '') == 'osx',
+#     reason="Nightly scenario tests only run on Travis 'cron' events.")
 
 # For development/debugging, uncomment the following
-# pytestmark = pytest.mark.skipif(
-#     'TRAVIS_EVENT_TYPE' not in os.environ
-#     or os.environ.get('TRAVIS_OS_NAME', '') == 'osx',
-#     reason='Run on all Travis jobs, for debugging.')
+pytestmark = pytest.mark.skipif(
+    'TRAVIS_EVENT_TYPE' not in os.environ
+    or os.environ.get('TRAVIS_OS_NAME', '') == 'osx',
+    reason='Run on all Travis jobs, for debugging.')
 
 
 # Information about nightly scenarios to run

--- a/tests/test_nightly.py
+++ b/tests/test_nightly.py
@@ -12,16 +12,16 @@ import numpy as np  # noqa: F401
 import pytest
 
 
-# pytestmark = pytest.mark.skipif(
-#     os.environ.get('TRAVIS_EVENT_TYPE', '') != 'cron'
-#     or os.environ.get('TRAVIS_OS_NAME', '') == 'osx',
-#     reason="Nightly scenario tests only run on Travis 'cron' events.")
-
-# For development/debugging, uncomment the following
 pytestmark = pytest.mark.skipif(
-    'TRAVIS_EVENT_TYPE' not in os.environ
+    os.environ.get('TRAVIS_EVENT_TYPE', '') != 'cron'
     or os.environ.get('TRAVIS_OS_NAME', '') == 'osx',
-    reason='Run on all Travis jobs, for debugging.')
+    reason="Nightly scenario tests only run on Travis 'cron' events.")
+
+# # For development/debugging, uncomment the following
+# pytestmark = pytest.mark.skipif(
+#     'TRAVIS_EVENT_TYPE' not in os.environ or
+#     os.environ.get('TRAVIS_OS_NAME', '') == 'osx',
+#     reason='Run on all Travis jobs, for debugging.')
 
 
 # Information about nightly scenarios to run

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,22 +1,21 @@
+import pandas as pd
+import pandas.testing as pdt
 import pytest
 
-import pandas as pd
-
 from message_ix import Scenario
-import message_ix.utils as utils
+import message_ix.utils
 import message_ix.testing
-import pandas.util.testing as pdt
 
 
 def test_make_df():
     base = {'foo': 'bar'}
     exp = pd.DataFrame({'foo': 'bar', 'baz': [42, 42]})
-    obs = utils.make_df(base, baz=[42, 42])
+    obs = message_ix.utils.make_df(base, baz=[42, 42])
     pdt.assert_frame_equal(obs, exp)
 
 
 def test_make_df_raises():
-    pytest.raises(ValueError, utils.make_df, 42, baz=[42, 42])
+    pytest.raises(ValueError, message_ix.utils.make_df, 42, baz=[42, 42])
 
 
 def test_testing_make_scenario(test_mp):


### PR DESCRIPTION
Update `message_ix.testing.nightly` and the nightly tests to use the `path=` rather than `dbprops=` argument for the path to a HyperSQL JDBC database. Since the old, deprecated argument was removed by iiasa/ixmp#254, this is necessary for the Travis nightly/cron CI checks to pass.

Other changes
- Adjust imports of pandas.util.testing to pandas.testing; the former is deprecated.
- Adjust CI scripts to align better between AppVeyor/Travis, and with ixmp.
- Copy a fix from iiasa/ixmp#247 to avoid noise in CI logs from the pytest `faulthandler` plugin.

## How to review

1. Confirm that the nightly tests run and pass for this branch.
2. Revert the changes to `pytestmark` in test_nightly.py.

## PR checklist

- [x] Tests added.
- [x] ~Documentation added.~ N/A
- [x] ~Release notes updated.~ N/A; CI only, not a user-facing change.