### PR TITLE
Adjust models.MESSAGE for iiasa/ixmp#212

### DIFF
--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -38,6 +38,9 @@ class MESSAGE(GAMSModel):
             '--iter="{}"'.format(
                 _template('output', 'MsgIterationReport_{case}.gdx')),
             ],
+        # Disable the feature to put input/output GDX files, list files, etc.
+        # in a temporary directory
+        'use_temp_dir': False,
     }, GAMSModel.defaults)
 
     @classmethod


### PR DESCRIPTION
iiasa/ixmp#212 adds a feature to the `ixmp.model.GAMSModel` class, allowing a temporary directory for input and output GDX files, listing files, etc.

This feature is used for e.g. ixmp's DantzigModel; but it is _not_ desired for MESSAGE models, where the user may want to inspect the GDX files. This PR explicitly disables the feature for MESSAGE, MESSAGE_MACRO, etc.

## How to review

- Confirm CI passes.
- Confirm MESSAGE models can be run with this branch and the branch in iiasa/ixmp#212 (fyi @behnam-zakeri)

## PR checklist

- [x] ~Tests added.~ N/A, no change in behaviour
- [x] ~Documentation added.~ N/A
- [x] ~Release notes updated.~ N/A