### PR TITLE
Track ixmp 2.0.x branch for CI of message_ix 2.0.x

### DIFF
--- a/ci/pip-requirements.txt
+++ b/ci/pip-requirements.txt
@@ -1,5 +1,5 @@
-# Always track ixmp master
-git+git://github.com/iiasa/ixmp.git#egg=ixmp
+# message_ix 2.0.x branch tracks ixmp 2.0.x branch
+git+git://github.com/iiasa/ixmp.git@2.0.x#egg=ixmp
 
 # pyam-iamc
 # Temporary: see https://github.com/IAMconsortium/pyam/issues/259


### PR DESCRIPTION
Adjust CI configuration for AppVeyor and Travis so that the message_ix `2.0.x` branch builds using the ixmp `2.0.x` branch.

This avoids failing builds caused by API changes on ixmp `master` towards ixmp `3.x`. There is no plan to make ixmp `3.x` compatible with message_ix `2.x`.

## How to review

Ensure that CI checks pass.

## PR checklist

- [x] ~Tests added.~ N/A; changes to CI configuration only
- [x] ~Documentation added.~ N/A
- [x] ~Release notes updated.~ N/A