### PR TITLE
Transfer Excel data I/O to ixmp

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- `#321 <https://github.com/iiasa/message_ix/pull/321>`_: Move :meth:`.Scenario.to_excel`, :meth:`.read_excel` to :class:`ixmp.Scenario`; they continue to work with message_ix.Scenario.
 - `#323 <https://github.com/iiasa/message_ix/pull/323>`_: Add `units`, `replace_vars` arguments to :meth:`.Reporter.convert_pyam`.
 - `#308 <https://github.com/iiasa/message_ix/pull/308>`_: Expand automatic reporting of add-on technologies.
 - `#313 <https://github.com/iiasa/ixmp/pull/313>`_: Include all tests in the message_ix package.

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -55,6 +55,10 @@ Support for R usage of the core classes is provided through the `reticulate`_ pa
    included here for convenience. :class:`message_ix.Scenario` defines
    additional methods specific to |MESSAGEix|:
 
+   .. versionchanged:: 3.0
+
+      :meth:`.read_excel` and :meth:`.to_excel` are now methods of :class:`ixmp.Scenario`, but continue to work with message_ix.Scenario.
+
    .. autosummary::
 
       add_cat
@@ -71,7 +75,6 @@ Support for R usage of the core classes is provided through the `reticulate`_ pa
       var
       vintage_and_active_years
       years_active
-
 
 
 Model classes

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -4,7 +4,7 @@ from itertools import product
 import logging
 
 import ixmp
-from ixmp.utils import as_str_list, pd_read, pd_write, isscalar, logger
+from ixmp.utils import as_str_list, isscalar
 import pandas as pd
 
 
@@ -508,98 +508,3 @@ class Scenario(ixmp.Scenario):
         # commit
         if commit:
             self.commit('Renamed {} using mapping {}'.format(name, mapping))
-
-    def to_excel(self, fname):
-        """Save a scenario as an Excel file. NOTE: Cannot export
-        solution currently (only model data) due to limitations in excel sheet
-        names (cannot have multiple sheet names which are identical except for
-        upper/lower case).
-
-        Parameters
-        ----------
-        fname : string
-            path to file
-        """
-        funcs = {
-            'set': (self.set_list, self.set),
-            'par': (self.par_list, self.par),
-        }
-        ix_name_map = {}
-        dfs = {}
-        for ix_type, (list_func, get_func) in funcs.items():
-            for item in list_func():
-                df = get_func(item)
-                df = pd.Series(df) if isinstance(df, dict) else df
-                if not df.empty:
-                    dfs[item] = df
-                    ix_name_map[item] = ix_type
-
-        # map names to ix types
-        df = pd.Series(ix_name_map).to_frame(name='ix_type')
-        df.index.name = 'item'
-        df = df.reset_index()
-        dfs['ix_type_mapping'] = df
-
-        pd_write(dfs, fname, index=False)
-
-    def read_excel(self, fname, add_units=False, commit_steps=False):
-        """Read Excel file data and load into the scenario.
-
-        Parameters
-        ----------
-        fname : string
-            path to file
-        add_units : bool
-            add missing units, if any,  to the platform instance.
-            default: False
-        commit_steps : bool
-            commit changes after every data addition.
-            default: False
-        """
-        funcs = {
-            'set': self.add_set,
-            'par': self.add_par,
-        }
-
-        logger().info('Reading data from {}'.format(fname))
-        dfs = pd_read(fname, sheet_name=None)
-
-        # get item-type mapping
-        df = dfs['ix_type_mapping']
-        ix_types = dict(zip(df['item'], df['ix_type']))
-
-        # fill in necessary items first (only sets for now)
-        col = 0  # special case for prefill set Series
-
-        def is_prefill(x):
-            return dfs[x].columns[0] == col and len(dfs[x].columns) == 1
-
-        prefill = [x for x in dfs if is_prefill(x)]
-        for name in prefill:
-            data = list(dfs[name][col])
-            if len(data) > 0:
-                ix_type = ix_types[name]
-                logger().info('Loading data for {}'.format(name))
-                funcs[ix_type](name, data)
-        if commit_steps:
-            self.commit('Loaded initial data from {}'.format(fname))
-            self.check_out()
-
-        # fill all other pars and sets, skipping those already done
-        skip_sheets = ['ix_type_mapping'] + prefill
-        for sheet_name, df in dfs.items():
-            if sheet_name not in skip_sheets and not df.empty:
-                logger().info('Loading data for {}'.format(sheet_name))
-                if add_units and 'unit' in df.columns:
-                    # add missing units
-                    units = set(self.platform.units())
-                    missing = set(df['unit'].unique()) - units
-                    for unit in missing:
-                        logger().info('Adding missing unit: {}'.format(unit))
-                        self.platform.add_unit(unit)
-                # load data
-                ix_type = ix_types[sheet_name]
-                funcs[ix_type](sheet_name, df)
-                if commit_steps:
-                    self.commit('Loaded {} from {}'.format(sheet_name, fname))
-                    self.check_out()

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -317,6 +317,12 @@ def test_excel_read_write(message_test_mp, tmp_path):
     scen1.init_par('new_par', idx_sets=['new_set'])
     scen1.add_par('new_par', 'member', 2, '-')
     scen1.commit('new set and parameter added.')
+
+    # Writing to Excel without solving
+    scen1.to_excel(fname)
+
+    # Writing to Excel when scenario has a solution
+    scen1.solve()
     scen1.to_excel(fname)
 
     scen2 = Scenario(message_test_mp, model='foo', scenario='bar',
@@ -338,7 +344,7 @@ def test_excel_read_write(message_test_mp, tmp_path):
 
     scen2.commit('foo')  # must be checked in
     scen2.solve()
-    assert np.isclose(scen2.var('OBJ')['lvl'], 153.675)
+    assert np.isclose(scen2.var('OBJ')['lvl'], scen1.var('OBJ')['lvl'])
 
     os.remove(fname)
 

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -1,5 +1,3 @@
-import os
-
 import ixmp
 import numpy as np
 import numpy.testing as npt
@@ -345,8 +343,6 @@ def test_excel_read_write(message_test_mp, tmp_path):
     scen2.commit('foo')  # must be checked in
     scen2.solve()
     assert np.isclose(scen2.var('OBJ')['lvl'], scen1.var('OBJ')['lvl'])
-
-    os.remove(fname)
 
 
 def test_clone(tmpdir):


### PR DESCRIPTION
This PR removes the `message_ix.Scenario.to_excel()` and `.read_excel()` methods. ~iiasa/ixmp#286~ iiasa/ixmp#289 adds these to `ixmp.Scenario`, so they are available for non-MESSAGE scenarios.

It also incorporates test improvements from #265.

## How to review

- ~Wait for iiasa/ixmp#289 to merge, or check out its branch.~
- Run tests against the updated ixmp code.
- Try with any old Excel exports one has lying around.

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.