### PR TITLE
Specify units, replace variable names in Reporter.convert_pyam

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- `#323 <https://github.com/iiasa/message_ix/pull/323>`_: Add `units`, `replace_vars` arguments to :meth:`.Reporter.convert_pyam`.
 - `#308 <https://github.com/iiasa/message_ix/pull/308>`_: Expand automatic reporting of add-on technologies.
 - `#313 <https://github.com/iiasa/ixmp/pull/313>`_: Include all tests in the message_ix package.
 - `#307 <https://github.com/iiasa/message_ix/pull/307>`_: adjust to deprecations in ixmp 2.0.

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -243,7 +243,7 @@ class Reporter(IXMPReporter):
         return rep
 
     def convert_pyam(self, quantities, year_time_dim, tag='iamc', drop={},
-                     collapse=None):
+                     collapse=None, unit=None):
         """Add conversion of one or more **quantities** to IAMC format.
 
         Parameters
@@ -265,6 +265,8 @@ class Reporter(IXMPReporter):
             Callback to handle additional dimensions of the quantity. A
             :class:`pandas.DataFrame` is passed as the sole argument to
             `collapse`, which must return a modified dataframe.
+        unit : str or pint.Unit, optional
+            Convert values to these units.
 
         Returns
         -------
@@ -290,7 +292,8 @@ class Reporter(IXMPReporter):
             comp = partial(computations.as_pyam,
                            year_time_dim=year_time_dim,
                            drop=to_drop,
-                           collapse=collapse)
+                           collapse=collapse,
+                           unit=unit)
             self.add(new_key, (comp, 'scenario', qty))
             keys.append(new_key)
         return keys

--- a/message_ix/reporting/pyam.py
+++ b/message_ix/reporting/pyam.py
@@ -4,7 +4,6 @@ from ixmp.reporting.computations import (
     concat as ixmp_concat,
     write_report as ixmp_write_report,
 )
-import pandas as pd
 import pint
 from pyam import IAMC_IDX, IamDataFrame, concat as pyam_concat
 
@@ -12,9 +11,9 @@ from pyam import IAMC_IDX, IamDataFrame, concat as pyam_concat
 log = getLogger(__name__)
 
 
-def as_pyam(scenario, quantities, year_time_dim, drop=[], collapse=None,
+def as_pyam(scenario, quantity, year_time_dim, drop=[], collapse=None,
             unit=None):
-    """Return a :class:`pyam.IamDataFrame` containing *quantities*.
+    """Return a :class:`pyam.IamDataFrame` containing *quantity*.
 
     Warnings are logged if the arguments result in additional, unhandled
     columns in the resulting data frame that are not part of the IAMC spec.
@@ -29,43 +28,30 @@ def as_pyam(scenario, quantities, year_time_dim, drop=[], collapse=None,
     --------
     message_ix.reporting.Reporter.convert_pyam
     """
-    # TODO, this should check for any viable container
-    if not isinstance(quantities, list):
-        quantities = [quantities]
-
-    # If collapse is not provided, it is a pass-through
-    collapse = collapse or (lambda df: df)
-
-    # Renamed automatically
-    IAMC_columns = {
+    rename_cols = {
+        # Renamed automatically
         'n': 'region',
         'nl': 'region',
+        # Column to set as year or time dimension
+        year_time_dim: 'year' if year_time_dim.startswith('y') else 'time',
     }
 
-    # Convert each of *quantities* individually
-    dfs = []
-    for qty in quantities:
-        df = qty.to_series() \
-                .rename('value') \
-                .reset_index() \
-                .rename(columns=IAMC_columns)
-        df['variable'] = qty.name
-        df['unit'] = qty.attrs.get('_unit', '')
-
-        dfs.append(df)
-
-    # Combine DataFrames
-    df = pd.concat(dfs)
-    # Set model and scenario columns
-    df['model'] = scenario.model
-    df['scenario'] = scenario.scenario
-
-    # Set one column as 'year' or 'time' (long IAMC format); drop any other
-    # columns
-    year_or_time = 'year' if year_time_dim.startswith('y') else 'time'
-    df = df.rename(columns={year_time_dim: year_or_time}) \
-           .pipe(collapse) \
-           .drop(drop, axis=1)
+    # - Convert to pd.DataFrame
+    # - Rename one dimension to 'year' or 'time'
+    # - Fill variable, unit, model, and scenario columns
+    # - Apply the collapse callback, if given
+    # - Drop any unwanted columns
+    df = quantity.to_series() \
+        .rename('value') \
+        .reset_index() \
+        .rename(columns=rename_cols) \
+        .assign(
+            variable=quantity.name,
+            unit=quantity.attrs.get('_unit', ''),
+            model=scenario.model,
+            scenario=scenario.scenario) \
+        .pipe(collapse or (lambda df: df)) \
+        .drop(drop, axis=1)
 
     # Raise exception for non-unique data
     duplicates = df.duplicated(subset=set(df.columns) - {'value'})
@@ -77,7 +63,7 @@ def as_pyam(scenario, quantities, year_time_dim, drop=[], collapse=None,
     if unit:
         from_unit = df['unit'].unique()
         if len(from_unit) > 1:
-            raise ValueError(f"cannot convert non-unique units {from_unit!r}")
+            raise ValueError(f'cannot convert non-unique units {from_unit!r}')
         q = pint.Quantity(df['value'].values, from_unit[0]).to(unit)
         df['value'] = q.magnitude
         df['unit'] = unit
@@ -85,8 +71,8 @@ def as_pyam(scenario, quantities, year_time_dim, drop=[], collapse=None,
     # Warn about extra columns
     extra = sorted(set(df.columns) - set(IAMC_IDX + ['year', 'time', 'value']))
     if extra:
-        log.warning('Extra columns {!r} when converting {} to IAMC format'
-                    .format(extra, [q.name for q in quantities]))
+        log.warning(f'Extra columns {extra!r} when converting '
+                    f'{quantity.name!r} to IAMC format')
 
     return IamDataFrame(df)
 

--- a/message_ix/reporting/pyam.py
+++ b/message_ix/reporting/pyam.py
@@ -11,8 +11,8 @@ from pyam import IAMC_IDX, IamDataFrame, concat as pyam_concat
 log = getLogger(__name__)
 
 
-def as_pyam(scenario, quantity, year_time_dim, drop=[], collapse=None,
-            unit=None):
+def as_pyam(scenario, quantity, year_time_dim, replace_vars=None,
+            drop=[], collapse=None, unit=None):
     """Return a :class:`pyam.IamDataFrame` containing *quantity*.
 
     Warnings are logged if the arguments result in additional, unhandled
@@ -40,6 +40,7 @@ def as_pyam(scenario, quantity, year_time_dim, drop=[], collapse=None,
     # - Rename one dimension to 'year' or 'time'
     # - Fill variable, unit, model, and scenario columns
     # - Apply the collapse callback, if given
+    # - Replace values in the variable column
     # - Drop any unwanted columns
     df = quantity.to_series() \
         .rename('value') \
@@ -51,6 +52,7 @@ def as_pyam(scenario, quantity, year_time_dim, drop=[], collapse=None,
             model=scenario.model,
             scenario=scenario.scenario) \
         .pipe(collapse or (lambda df: df)) \
+        .replace(dict(variable=replace_vars or dict())) \
         .drop(drop, axis=1)
 
     # Raise exception for non-unique data
@@ -84,7 +86,7 @@ def as_pyam(scenario, quantity, year_time_dim, drop=[], collapse=None,
 # Computations that operate on pyam.IamDataFrame inputs
 
 def concat(*args):
-    """Concatenate *args*, which must be :class:`pyam.IamDataFrame`."""
+    """Concatenate *args*, which must all be :class:`pyam.IamDataFrame`."""
     if isinstance(args[0], IamDataFrame):
         return pyam_concat(args)
     else:

--- a/message_ix/reporting/pyam.py
+++ b/message_ix/reporting/pyam.py
@@ -68,6 +68,10 @@ def as_pyam(scenario, quantity, year_time_dim, drop=[], collapse=None,
         df['value'] = q.magnitude
         df['unit'] = unit
 
+    if not isinstance(df.loc[0, 'unit'], str):
+        # Convert pint.Unit to string
+        df['unit'] = f"{df.loc[0, 'unit']:~}"
+
     # Warn about extra columns
     extra = sorted(set(df.columns) - set(IAMC_IDX + ['year', 'time', 'value']))
     if extra:

--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -57,7 +57,8 @@ def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
         scenario has the single year 1963.
     """
     # add custom units and region for timeseries data
-    mp.add_unit('USD_per_km')
+    mp.add_unit('USD/case')
+    mp.add_unit('case')
     mp.add_region('DantzigLand', 'country')
 
     # initialize a new (empty) instance of an `ixmp.Scenario`
@@ -91,13 +92,13 @@ def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
               'value': [325, 300, 275]}
     par['demand'] = make_df(
         pd.DataFrame.from_dict(demand), commodity='cases', level='consumption',
-        time='year', unit='cases', year=1963)
+        time='year', unit='case', year=1963)
 
     b_a_u = {'node_loc': ['seattle', 'san-diego'],
              'value': [350, 600]}
     par['bound_activity_up'] = make_df(
         pd.DataFrame.from_dict(b_a_u), mode='production',
-        technology='canning_plant', time='year', unit='cases', year_act=1963)
+        technology='canning_plant', time='year', unit='case', year_act=1963)
     par['ref_activity'] = par['bound_activity_up'].copy()
 
     input = pd.DataFrame([
@@ -110,7 +111,7 @@ def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
     ], columns=['mode', 'node_loc', 'node_origin', 'technology'])
     par['input'] = make_df(
         input, commodity='cases', level='supply', time='year',
-        time_origin='year', unit='%', value=1, year_act=1963,
+        time_origin='year', unit='case', value=1, year_act=1963,
         year_vtg=1963)
 
     output = pd.DataFrame([
@@ -124,9 +125,11 @@ def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
         ['consumption', 'to_topeka', 'topeka', 'san-diego', t[2]],
     ], columns=['level', 'mode', 'node_dest', 'node_loc', 'technology'])
     par['output'] = make_df(
-        output, commodity='cases', time='year', time_dest='year', unit='%',
+        output, commodity='cases', time='year', time_dest='year', unit='case',
         value=1, year_act=1963, year_vtg=1963)
 
+    # Variable cost: cost per kilometre × distance (neither parametrized
+    # explicitly)
     var_cost = pd.DataFrame([
         ['to_new-york', 'seattle', 'transport_from_seattle', 0.225],
         ['to_chicago', 'seattle', 'transport_from_seattle', 0.153],
@@ -136,7 +139,7 @@ def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
         ['to_topeka', 'san-diego', 'transport_from_san-diego', 0.126],
     ], columns=['mode', 'node_loc', 'technology', 'value'])
     par['var_cost'] = make_df(
-        var_cost, time='year', unit='USD', year_act=1963, year_vtg=1963)
+        var_cost, time='year', unit='USD/case', year_act=1963, year_vtg=1963)
 
     for name, value in par.items():
         scen.add_par(name, value)

--- a/message_ix/tests/test_integration.py
+++ b/message_ix/tests/test_integration.py
@@ -13,6 +13,10 @@ from message_ix.testing import (
 )
 
 
+pytestmark = pytest.mark.xfail(
+    reason='https://github.com/iiasa/message_ix/issues/322')
+
+
 def test_run_clone(tmpdir):
     # this test is designed to cover the full functionality of the GAMS API
     # - initialize a new ixmp platform instance

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -155,7 +155,7 @@ def test_reporter_convert_pyam(dantzig_reporter, caplog, tmp_path):
     assert idf1['variable'].unique() == 'ACT'
 
     # Warning was logged because of extra columns
-    w = "Extra columns ['h', 'm', 't'] when converting ['ACT'] to IAMC format"
+    w = "Extra columns ['h', 'm', 't'] when converting 'ACT' to IAMC format"
     assert ('message_ix.reporting.pyam', WARNING, w) in caplog.record_tuples
 
     # Repeat, using the message_ix.Reporter convenience function

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -8,7 +8,7 @@ from ixmp.reporting import Reporter as ixmp_Reporter
 from ixmp.testing import assert_qty_equal
 from numpy.testing import assert_allclose
 import pandas as pd
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 import pyam
 import xarray as xr
 
@@ -125,11 +125,16 @@ def test_reporter_from_westeros(test_mp):
     assert_allclose(obs, exp)
 
 
-def test_reporter_convert_pyam(message_test_mp, caplog, tmp_path):
+@pytest.fixture
+def dantzig_reporter(message_test_mp):
     scen = Scenario(message_test_mp, **SCENARIO['dantzig'])
     if not scen.has_solution():
         scen.solve()
-    rep = Reporter.from_scenario(scen)
+    yield Reporter.from_scenario(scen)
+
+
+def test_reporter_convert_pyam(dantzig_reporter, caplog, tmp_path):
+    rep = dantzig_reporter
 
     # Key for 'ACT' variable at full resolution
     ACT = rep.full_key('ACT')
@@ -154,15 +159,13 @@ def test_reporter_convert_pyam(message_test_mp, caplog, tmp_path):
     assert ('message_ix.reporting.pyam', WARNING, w) in caplog.record_tuples
 
     # Repeat, using the message_ix.Reporter convenience function
-    def m_t(df):
+    def add_tm(df, name='Activity'):
         """Callback for collapsing ACT columns."""
-        # .pop() removes the named column from the returned row
-        df['variable'] = 'Activity|' + df['t'] + '|' + df['m']
-        df.drop(['t', 'm'], axis=1, inplace=True)
-        return df
+        df['variable'] = f'{name}|' + df['t'] + '|' + df['m']
+        return df.drop(['t', 'm'], axis=1)
 
     # Use the convenience function to add the node
-    keys = rep.convert_pyam(ACT, 'ya', collapse=m_t)
+    keys = rep.convert_pyam(ACT, 'ya', collapse=add_tm)
 
     # Keys of added node(s) are returned
     assert len(keys) == 1
@@ -200,3 +203,20 @@ def test_reporter_convert_pyam(message_test_mp, caplog, tmp_path):
     # File contents are as expected
     expected = Path(__file__).parent / 'data' / 'report-pyam-write.csv'
     assert path.read_text() == expected.read_text()
+
+    # Now convert variable cost
+    cb = partial(add_tm, name='Variable cost')
+    key3 = rep.convert_pyam('var_cost', 'ya', collapse=cb).pop()
+    df3 = rep.get(key3).as_pandas().drop(['model', 'scenario'], axis=1)
+
+    # Results have the expected units
+    assert all(df3['unit'] == 'USD / case')
+
+    # Also change units
+    key4 = rep.convert_pyam('var_cost', 'ya', collapse=cb,
+                            unit='centiUSD / case').pop()
+    df4 = rep.get(key4).as_pandas().drop(['model', 'scenario'], axis=1)
+
+    # Results have the expected units
+    assert all(df4['unit'] == 'centiUSD / case')
+    assert_series_equal(df3['value'], df4['value'] / 100.)


### PR DESCRIPTION
Adds two features needed for the MESSAGEix-GLOBIOM reporting (in `message_data`) to `reporting.computations.as_pyam()` and `Reporter.convert_pyam()`:

- *units* argument, specifying the desired units in the resulting pyam.IamDataFrame.
- *replace_vars* argument. This specifies the name of a different key—e.g. `'activity variables'` in the tests—that produces a dict with name mappings. Entries in the 'Variable' column are replaced according to this dict.

## How to review

Confirm that CI passes.

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.