### PR TITLE
Add reporting improvements from the 2020 hackathon

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- `#328 <https://github.com/iiasa/message_ix/pull/328>`_: Expand automatic reporting of emissions prices and mapping sets; improve robustness of :meth:`Reporter.convert_pyam`.
 - `#321 <https://github.com/iiasa/message_ix/pull/321>`_: Move :meth:`.Scenario.to_excel`, :meth:`.read_excel` to :class:`ixmp.Scenario`; they continue to work with message_ix.Scenario.
 - `#323 <https://github.com/iiasa/message_ix/pull/323>`_: Add `units`, `replace_vars` arguments to :meth:`.Reporter.convert_pyam`.
 - `#308 <https://github.com/iiasa/message_ix/pull/308>`_: Expand automatic reporting of add-on technologies.

--- a/doc/source/reporting.rst
+++ b/doc/source/reporting.rst
@@ -128,6 +128,7 @@ These include:
 - ``addon in``     = ``input`` × ``addon ACT``,
 - ``addon out``    = ``output`` × ``addon ACT``, and
 - ``addon potential`` = ``addon up`` × ``addon ACT``, the maximum potential activity by add-on technology.
+- ``price emission``, the model variable ``PRICE_EMISSION`` broadcast across emission species (``e``) *and* technologies (``t``) rather than types (``type_emission``, ``type_tec``).
 
 .. tip:: Use :meth:`~.full_key` to retrieve the full-dimensionality
    :class:`Key` for any of these quantities.

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -101,6 +101,7 @@ DERIVED = [
     # Each entry is ('full key', (computation tuple,)). Full keys are not
     # inferred and must be given explicitly.
     ('tom:nl-t-yv-ya', (computations.add, 'fom:nl-t-yv-ya', 'vom:nl-t-yv-ya')),
+
     # Broadcast from type_addon to technology_addon
     ('addon conversion:nl-t-yv-ya-m-h-ta',
      (partial(computations.broadcast_map, rename={'n': 'nl'}),
@@ -111,6 +112,13 @@ DERIVED = [
       'addon_up:n-t-ya-m-h-type_addon',
       'map_addon')),
 
+    # Double broadcast over type_emission, then type_tec, in a nested task
+    ('price emission:n-e-t-y',
+     (computations.broadcast_map,
+      (computations.broadcast_map,
+       'PRICE_EMISSION:n-type_emission-type_tec-y',
+       'map_emission'),
+      'map_tec')),
 ]
 
 #: Quantities to automatically convert to IAMC format using

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -146,11 +146,11 @@ REPORTS = {
 #: This Quantity contains the value 1 at every valid (type_addon, ta) location,
 #: and 0 elsewhere.
 MAPPING_SETS = [
-    'addon',
-    'emission',
+    ('addon', 't'),  # Mapping name, and full target set
+    ('emission', 'e'),
     # 'node',  # Automatic addition fails because 'map_node' is defined
-    'tec',
-    'year',
+    ('tec', 't'),
+    ('year', 'y'),
 ]
 
 
@@ -189,9 +189,10 @@ class Reporter(IXMPReporter):
                                 + list(args[1:])))
 
         # Quantities that represent mapping sets
-        for name in MAPPING_SETS:
+        for name, full_set in MAPPING_SETS:
             put(rep.add, f'map_{name}',
-                (computations.map_as_qty, f'cat_{name}'), strict=True)
+                (computations.map_as_qty, f'cat_{name}', full_set),
+                strict=True)
 
         # Product quantities
         for name, quantities in PRODUCTS:

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -298,12 +298,12 @@ class Reporter(IXMPReporter):
             # Prepare the computation
             comp = [
                 partial(computations.as_pyam,
+                        year_time_dim=year_time_dim,
                         drop=to_drop,
                         collapse=collapse,
                         unit=unit),
                 'scenario',
                 qty,
-                year_time_dim,
             ]
             if replace_vars:
                 comp.append(replace_vars)

--- a/message_ix/reporting/computations.py
+++ b/message_ix/reporting/computations.py
@@ -1,8 +1,9 @@
 # Import other comps so they can be imported from this module
+from ixmp.reporting import RENAME_DIMS
 from ixmp.reporting.computations import *        # noqa: F401, F403
 from ixmp.reporting.computations import product
 from ixmp.reporting.quantity import as_quantity
-from ixmp.reporting.utils import RENAME_DIMS
+import pandas as pd
 
 from .pyam import as_pyam, concat, write_report  # noqa: F401
 
@@ -12,17 +13,20 @@ def add(a, b, fill_value=0.0):
     return a.add(b, fill_value=fill_value).dropna()
 
 
-def map_as_qty(set_df):
-    """Convert *set_df* to a Quantity.
+def map_as_qty(set_df, full_set):
+    """Convert *set_df* to a :class:`.Quantity`.
 
-    For the MESSAGE sets named ``cat_*`` (see
-    :ref:`mapping-sets`) :meth:`ixmp.Scenario.set` returns a
-    :class:`~pandas.DataFrame` with two columns: the *category* set (S1)
-    elements and the *category member* set (S2) elements.
+    For the MESSAGE sets named ``cat_*`` (see :ref:`mapping-sets`)
+    :meth:`ixmp.Scenario.set` returns a :class:`~pandas.DataFrame` with two
+    columns: the *category* set (S1) elements and the *category member* set
+    (S2, also required as the argument `full_set`) elements.
 
-    This computation converts the DataFrame *set_df* into a quantity with two
+    map_as_qty converts such a DataFrame (*set_df*) into a Quantity with two
     dimensions. At the coordinates *(s₁, s₂)*, the value is 1 if *s₂* is a
     mapped from *s₁*; otherwise 0.
+
+    An category named 'all', containing all elements of `full_set`, is added
+    automatically.
 
     See also
     --------
@@ -30,6 +34,12 @@ def map_as_qty(set_df):
     """
     set_from, set_to = set_df.columns
     names = [RENAME_DIMS.get(c, c) for c in set_df.columns]
+
+    # Add an 'all' mapping
+    set_df = pd.concat([
+        set_df,
+        pd.DataFrame([('all', e) for e in full_set], columns=set_df.columns),
+    ])
 
     # Add a value column
     set_df['value'] = 1

--- a/message_ix/reporting/pyam.py
+++ b/message_ix/reporting/pyam.py
@@ -11,7 +11,7 @@ from pyam import IAMC_IDX, IamDataFrame, concat as pyam_concat
 log = getLogger(__name__)
 
 
-def as_pyam(scenario, quantity, year_time_dim, replace_vars=None,
+def as_pyam(scenario, quantity, replace_vars=None, year_time_dim=None,
             drop=[], collapse=None, unit=None):
     """Return a :class:`pyam.IamDataFrame` containing *quantity*.
 

--- a/message_ix/reporting/pyam.py
+++ b/message_ix/reporting/pyam.py
@@ -62,7 +62,7 @@ def as_pyam(scenario, quantity, replace_vars=None, year_time_dim=None,
                          + str(df[duplicates]))
 
     # Convert units
-    if unit:
+    if len(df) and unit:
         from_unit = df['unit'].unique()
         if len(from_unit) > 1:
             raise ValueError(f'cannot convert non-unique units {from_unit!r}')
@@ -70,7 +70,8 @@ def as_pyam(scenario, quantity, replace_vars=None, year_time_dim=None,
         df['value'] = q.magnitude
         df['unit'] = unit
 
-    if not isinstance(df.loc[0, 'unit'], str):
+    # Ensure units are a string, for pyam
+    if len(df) and not isinstance(df.loc[0, 'unit'], str):
         # Convert pint.Unit to string
         df['unit'] = f"{df.loc[0, 'unit']:~}"
 

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -133,6 +133,17 @@ def dantzig_reporter(message_test_mp):
     yield Reporter.from_scenario(scen)
 
 
+def test_as_pyam(dantzig_reporter):
+    rep = dantzig_reporter
+
+    # Quantities for 'ACT' variable at full resolution
+    qty = rep.get(rep.full_key('ACT'))
+
+    # Call as_pyam() with an empty quantity
+    p = computations.as_pyam(scen, qty[0:0], year_time_dim='ya')
+    assert isinstance(p, pyam.IamDataFrame)
+
+
 def test_reporter_convert_pyam(dantzig_reporter, caplog, tmp_path):
     rep = dantzig_reporter
 

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -63,7 +63,7 @@ def test_reporter(message_test_mp):
 
     # message_ix.Reporter pre-populated with additional, derived quantities
     # This is the same value as in test_tutorials.py
-    assert len(rep.graph) == 12537
+    assert len(rep.graph) == 12553
 
     # Derived quantities have expected dimensions
     vom_key = rep.full_key('vom')

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -133,8 +133,11 @@ def dantzig_reporter(message_test_mp):
     yield Reporter.from_scenario(scen)
 
 
-def test_as_pyam(dantzig_reporter):
-    rep = dantzig_reporter
+def test_as_pyam(message_test_mp):
+    scen = Scenario(message_test_mp, **SCENARIO['dantzig'])
+    if not scen.has_solution():
+        scen.solve()
+    rep = Reporter.from_scenario(scen)
 
     # Quantities for 'ACT' variable at full resolution
     qty = rep.get(rep.full_key('ACT'))

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -4,7 +4,7 @@ from functools import partial
 from logging import WARNING
 from pathlib import Path
 
-from ixmp.reporting import Reporter as ixmp_Reporter
+from ixmp.reporting import Reporter as ixmp_Reporter, as_quantity
 from ixmp.testing import assert_qty_equal
 from numpy.testing import assert_allclose
 import pandas as pd
@@ -48,7 +48,7 @@ def test_reporter(message_test_mp):
 
     # Quantities contain expected data
     dims = dict(coords=['chicago new-york topeka'.split()], dims=['n'])
-    demand = xr.DataArray([300, 325, 275], **dims)
+    demand = as_quantity(xr.DataArray([300, 325, 275], **dims), name='demand')
 
     # NB the call to squeeze() drops the length-1 dimensions c-l-y-h
     obs = rep.get('demand:n-c-l-y-h').squeeze(drop=True)

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -25,7 +25,7 @@ tutorials = [
     (('westeros', 'westeros_flexible_generation'), []),
     (('westeros', 'westeros_report'),
      # NB this is the same value as in test_reporter()
-     [('len-rep-graph', 12537)]),
+     [('len-rep-graph', 12553)]),
     ((AT, 'austria'), [('solve-objective-value', 133105.109375)]),
     ((AT, 'austria_single_policy'), [('solve-objective-value', 525474464.0)]),
     ((AT, 'austria_multiple_policies'), []),


### PR DESCRIPTION
- `Reporter.convert_pyam()`
  - The argument *year_time_dim* is passed as a keyword argument. If passed as a string positional argument ('y'), the Reporter internally interpreted it as a reference to the key, 'y', that yields the list of years. This list is supplied to `as_pyam()`, which is expecting just the string 'y'.
  - Avoid manipulating units if the pd.DataFrame is empty.
- Add auto-reported `price emission` quantity = `PRICE_EMISSION` broadcast across
- `computations.map_as_qty` now automatically adds a map from 'all' to all elements in the target set, e.g. of all technologies, `t`. This exists in GDX and Java but isn't returned by the standard methods, for some reason.

## How to review

- Note that CI checks pass.

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.