### PR TITLE
update R tutorial and include testing

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -71,6 +71,11 @@ Install |MESSAGEix| from source
     $ pip install --editable .[tests,reporting]
     $ py.test
 
+8. **(Optional for R users)** Run the built-in test suite to check that |MESSAGEix| functions
+   correctly on your system, including use the ``rixmp`` package::
+
+    $ py.test --test-r
+
 Common issues
 -------------
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -68,8 +68,8 @@ Install |MESSAGEix| from source
 7. (Optional) Run the built-in test suite to check that |MESSAGEix| functions
    correctly on your system::
 
-    $ pip install --editable .[tests]
-    $ py.test tests
+    $ pip install --editable .[tests,reporting]
+    $ py.test
 
 Common issues
 -------------

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,20 @@
-
+import pytest
 
 # Use the fixtures test_mp, test_mp_props, and tmp_env from ixmp.testing
 pytest_plugins = ['ixmp.testing']
+
+
+# Hooks
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--test-r',
+        action='store_true',
+        help='also run tests of the ixmp R interface.',
+    )
+
+
+def pytest_runtest_setup(item):
+    if 'rixmp' in item.keywords and \
+       not item.config.getoption('--test-r'):
+        pytest.skip('skipping rixmp test without --test-r flag')

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -22,13 +22,9 @@ There are a number of guides out there, e.g. on docutils_.
 Building the docs on your local machine
 ---------------------------------------
 
-On *nix, from the command line, run::
+From the command line, run::
 
     make html
-
-On Windows, from the command line, run::
-
-    ./make.bat
 
 You can then view the site by::
 

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -69,24 +69,25 @@ R_tutorials = [
 # Short, readable IDs for the R tests
 R_ids = [arg[0][-1] for arg in R_tutorials]
 
+
 @pytest.fixture
-def nb_path(request, tutorial_path):
+def nb_R_path(request, tutorial_path):
     # Combine the filename parts with the tutorial_path fixture
     yield Path(tutorial_path, *request.param).with_suffix('.ipynb')
 
 
 # Parametrize the first 3 arguments using variables *R_tutorial* and *R_ids*.
-# Argument 'nb_path' is indirect so that the above fixture can modify it.
-@pytest.mark.parametrize('nb_path,cell_values', R_tutorials, ids=R_ids,
-                         indirect=['nb_path'])
+# Argument 'nb_R_path' is indirect so that the above fixture can modify it.
+@pytest.mark.parametrize('nb_R_path,cell_values', R_tutorials, ids=R_ids,
+                         indirect=['nb_R_path'])
 @pytest.mark.rixmp
-def test_R_tutorial(nb_path, cell_values, tmp_path, tmp_env):
+def test_R_tutorial(nb_R_path, cell_values, tmp_path, tmp_env):
     """Test tutorial in the IPython notebook at *fname*.
 
     If *cell_values* are given, values in the specified cells are tested.
     """
     # The notebook can be run without errors
-    nb, errors = run_notebook(nb_path, tmp_path, tmp_env, kernel='IR')
+    nb, errors = run_notebook(nb_R_path, tmp_path, tmp_env, kernel='IR')
     assert errors == []
 
     for cell, value in cell_values:

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -36,7 +36,6 @@ tutorials = [
 # Short, readable IDs for the tests
 ids = [arg[0][-1] for arg in tutorials]
 
-
 @pytest.fixture
 def nb_path(request, tutorial_path):
     # Combine the filename parts with the tutorial_path fixture
@@ -54,6 +53,33 @@ def test_tutorial(nb_path, cell_values, tmp_path, tmp_env):
     """
     # The notebook can be run without errors
     nb, errors = run_notebook(nb_path, tmp_path, tmp_env)
+    assert errors == []
+
+    for cell, value in cell_values:
+        # Cell identified by name or index has a particular value
+        assert np.isclose(get_cell_output(nb, cell), value)
+
+# R tutorials, using rixmp
+R_tutorials = [
+    ((AT, 'R_austria'), []),
+    ((AT, 'R_austria_load_scenario'), []),
+]
+
+# Short, readable IDs for the R tests
+R_ids = [arg[0][-1] for arg in R_tutorials]
+
+# Parametrize the first 3 arguments using the variables *R_tutorial* and *R_ids*.
+# Argument 'nb_path' is indirect so that the above fixture can modify it.
+@pytest.mark.parametrize('nb_path,cell_values', R_tutorials, ids=R_ids,
+                         indirect=['nb_path'])
+@pytest.mark.rixmp
+def test_R_tutorial(nb_path, cell_values, tmp_path, tmp_env):
+    """Test tutorial in the IPython notebook at *fname*.
+
+    If *cell_values* are given, values in the specified cells are tested.
+    """
+    # The notebook can be run without errors
+    nb, errors = run_notebook(nb_path, tmp_path, tmp_env, kernel='IR')
     assert errors == []
 
     for cell, value in cell_values:

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -59,6 +59,7 @@ def test_tutorial(nb_path, cell_values, tmp_path, tmp_env):
         # Cell identified by name or index has a particular value
         assert np.isclose(get_cell_output(nb, cell), value)
 
+
 # R tutorials, using rixmp
 R_tutorials = [
     ((AT, 'R_austria'), []),
@@ -68,7 +69,13 @@ R_tutorials = [
 # Short, readable IDs for the R tests
 R_ids = [arg[0][-1] for arg in R_tutorials]
 
-# Parametrize the first 3 arguments using the variables *R_tutorial* and *R_ids*.
+@pytest.fixture
+def nb_path(request, tutorial_path):
+    # Combine the filename parts with the tutorial_path fixture
+    yield Path(tutorial_path, *request.param).with_suffix('.ipynb')
+
+
+# Parametrize the first 3 arguments using variables *R_tutorial* and *R_ids*.
 # Argument 'nb_path' is indirect so that the above fixture can modify it.
 @pytest.mark.parametrize('nb_path,cell_values', R_tutorials, ids=R_ids,
                          indirect=['nb_path'])

--- a/tutorial/Austrian_energy_system/R_austria.ipynb
+++ b/tutorial/Austrian_energy_system/R_austria.ipynb
@@ -82,11 +82,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# load required packages \n",
-    "library(retixmp)\n",
+    "library(rixmp)\n",
     "library(dplyr)\n",
     "ixmp <- import('ixmp')\n",
     "message_ix <- import('message_ix')"
@@ -114,7 +116,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "model <- \"Austrian energy model\"\n",
@@ -450,7 +454,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "base_technical_lifetime = data.frame(\n",
@@ -737,7 +743,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "base_capacity = data.frame(\n",
@@ -867,45 +875,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Plotting Results, not working yet on R"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import('itertools')\n",
-    "pd <- import('pandas')\n",
-    "\n",
-    "plt <- import('matplotlib.pyplot')\n",
-    "# %matplotlib inline\n",
-    "# plt.style.use('ggplot')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tools = import('tools')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "p = tools$Plots(scenario, country)"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -913,85 +882,7 @@
    },
    "outputs": [],
    "source": [
-    "p.plot_new_capacity(baseyear=True, subset=plants)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "p.plot_new_capacity(baseyear=True, subset=lights)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "p.plot_capacity(baseyear=True, subset=plants)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "p.plot_capacity(baseyear=True, subset=lights)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "p.plot_demand(light_demand, elec_demand)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "p.plot_activity(baseyear=True, subset=plants)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "p.plot_activity(baseyear=True, subset=lights)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "p.plot_prices(baseyear=False, subset=['light', 'other_electricity'])"
+    "scenario$var('OBJ')['lvl']"
    ]
   },
   {

--- a/tutorial/Austrian_energy_system/R_austria_load_scenario.ipynb
+++ b/tutorial/Austrian_energy_system/R_austria_load_scenario.ipynb
@@ -108,6 +108,17 @@
    },
    "outputs": [],
    "source": [
+    "scenario$remove_solution()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "scenario$solve('MESSAGE')"
    ]
   },

--- a/tutorial/Austrian_energy_system/R_austria_load_scenario.ipynb
+++ b/tutorial/Austrian_energy_system/R_austria_load_scenario.ipynb
@@ -29,7 +29,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# load required packages \n",
@@ -53,7 +55,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# launch the IX modeling platform using the local default database                                                                                                                       \n",
@@ -81,7 +85,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "scenario$par('input')"
@@ -103,6 +109,17 @@
    "outputs": [],
    "source": [
     "scenario$solve('MESSAGE')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "scenario$var('OBJ')['lvl']"
    ]
   },
   {

--- a/tutorial/README.rst
+++ b/tutorial/README.rst
@@ -93,7 +93,7 @@ Austrian energy system
 This tutorial demonstrates a stylized representation of a national electricity
 sector model, with several fossil and renewable power plant types.
 
-#. Prepare the base model version, in `Python <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_reticulate.ipynb>`__.
-#. Plot results, in `Python <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_load_scenario.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_load_scenario_R.ipynb>`__.
+#. Prepare the base model version, in `Python <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/R_austria.ipynb>`__.
+#. Plot results, in `Python <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_load_scenario.ipynb>`__ or in `R <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/R_austria_load_scenario.ipynb>`__ (only loads scenarios).
 #. `Run a single policy scenario <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_single_policy.ipynb>`_.
 #. Run multiple policy scenarios. This tutorial has two notebooks: `an introduction with some exercises <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_multiple_policies.ipynb>`_ and `completed code for the exercises <https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_multiple_policies-answers.ipynb>`_.


### PR DESCRIPTION
I updated the name and some parts of the Austrian R tutorials and updated the documentation with new links. I also added some code that run the R tutorial while testing if the flag option `--test-r` is used.

## How to review

- Build the documentation and check the installation part and the tutorial page related to R
- run the tests including the R tutorials, as described in the documentation `py.test --test-r`


