### PR TITLE
Only unlink GAMS CPLEX options file if it exists

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- `#340 <https://github.com/iiasa/message_ix/pull/340>`_: Allow cplex.opt to be used by message_ix from multiple processes.
 - `#328 <https://github.com/iiasa/message_ix/pull/328>`_: Expand automatic reporting of emissions prices and mapping sets; improve robustness of :meth:`Reporter.convert_pyam`.
 - `#321 <https://github.com/iiasa/message_ix/pull/321>`_: Move :meth:`.Scenario.to_excel`, :meth:`.read_excel` to :class:`ixmp.Scenario`; they continue to work with message_ix.Scenario.
 - `#323 <https://github.com/iiasa/message_ix/pull/323>`_: Add `units`, `replace_vars` arguments to :meth:`.Reporter.convert_pyam`.

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -131,6 +131,11 @@ Model classes
 
    .. autoattribute:: name
 
+.. autoclass:: GAMSModel
+   :members:
+   :exclude-members: defaults
+   :show-inheritance:
+
 
 .. _utils:
 

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -76,14 +76,18 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
         GAMSModel creates a file named ``cplex.opt`` in the model directory
         containing the options in :obj:`DEFAULT_CPLEX_OPTIONS`, or any
         overrides passed to :meth:`~message_ix.Scenario.solve`.
+
+        .. warning:: GAMSModel can solve Scenarios in two or more Python
+           processes simultaneously; but using *different* CPLEX options in
+           each process may produced unexpected results.
         """
-        # This is not safe against race conditions; if two runs are kicked off
-        # simulatenously with the same dp.model_path, then they will try to
-        # write/unlink the same optfile.
+        # If two runs are kicked off simulatenously with the same
+        # self.model_dir, then they will try to write the same optfile, and may
+        # write different contents.
         #
-        # TODO enhance GAMSModel (in ixmp) to run GAMS in a temporary
-        #      directory, copying source and GDX files if needed. Then the
-        #      cplex.opt file will be specific to that directory.
+        # TODO Re-enable the 'use_temp_dir' feature from ixmp.GAMSModel
+        #      (disabled above). Then cplex.opt will be specific to that
+        #      directory.
 
         # Write CPLEX options into an options file
         optfile = self.model_dir / 'cplex.opt'

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -94,8 +94,12 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
             result = super().run(scenario)
         finally:
             # Remove the optfile regardless of whether the run completed
-            # without error
-            optfile.unlink()
+            # without error. The file may have been removed already by another
+            # run (in a separate process) that completed before this one.
+            # py37 compat: check for existence instead of using
+            # unlink(missing_ok=True)
+            if optfile.exists():
+                optfile.unlink()
 
         return result
 


### PR DESCRIPTION
Closes #222.

## How to review

- Re-run any multi-process parallel run code that triggered the original issue; confirm it does not recur.
- Confirm that CI checks pass.

## PR checklist

- [x] ~Tests added.~ We don't have test infrastructure for runs in parallel processes, nor bandwidth to add it.
- [x] Documentation added.
- [x] Release notes updated.