### PR TITLE
Adjust to iiasa/ixmp#298

### DIFF
--- a/ci/codecov.yml
+++ b/ci/codecov.yml
@@ -4,6 +4,12 @@ codecov:
 
 coverage:
   precision: 1
+  # PRs can result in small changes of e.g. 0.04 percent; don't let these
+  # prevent a passing check
+  status:
+    project:
+      default:
+        threshold: 0.2%
 
 comment:
   layout: "diff, files"

--- a/message_ix/tests/test_integration.py
+++ b/message_ix/tests/test_integration.py
@@ -13,10 +13,6 @@ from message_ix.testing import (
 )
 
 
-pytestmark = pytest.mark.xfail(
-    reason='https://github.com/iiasa/message_ix/issues/322')
-
-
 def test_run_clone(tmpdir):
     # this test is designed to cover the full functionality of the GAMS API
     # - initialize a new ixmp platform instance

--- a/tutorial/westeros/westeros_report.ipynb
+++ b/tutorial/westeros/westeros_report.ipynb
@@ -422,7 +422,8 @@
     "from ixmp.reporting import configure\n",
     "from message_ix.testing import make_westeros\n",
     "\n",
-    "scen = make_westeros(Platform(), emissions=True, solve=True)"
+    "mp = Platform()\n",
+    "scen = make_westeros(mp, emissions=True, solve=True)"
    ]
   },
   {


### PR DESCRIPTION
- `westeros_report` tutorial is adjusted to assign its Platform() instance to a variable; this prevents it from being cleaned up prematurely by ixmp.
- Also un-xfail some tests that have been fixed.

## PR checklist

- [x] ~Tests added.~ N/A
- [x] ~Documentation added.~
- [x] ~Release notes updated.~