### PR TITLE
cleanup inconsistency between in gams documentation and equation (OBJ)

### DIFF
--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -298,7 +298,7 @@ Equations
 * relaxations of dynamic constraints
 *
 * .. math::
-*    OBJ = \sum_{n,y \in Y^{M}} df\_year_{y} \cdot COST\_NODAL_{n,y}
+*    OBJ = \sum_{n,y \in Y^{M}} df\_period_{y} \cdot COST\_NODAL_{n,y}
 *
 ***
 OBJECTIVE..


### PR DESCRIPTION
The documentation of the OBJ function stated that _df_year_ is used to calculate the discounting. However, in the equation _df_period_  is used instead.

## How to review
Just a change in the documentation. However, maybe reconsider which parameter was intended to be used? 

## PR checklist
- ~Tests added.~ No change in behavior, simply refactoring.
- [x] Documentation added.
- ~Release notes updated.~
