### PR TITLE
Bump CI requirement for JPype to 0.7.5

### DIFF
--- a/ci/conda-requirements.txt
+++ b/ci/conda-requirements.txt
@@ -2,10 +2,7 @@ asyncssh
 click
 codecov
 dask
-
-# Temporary exclusions: see iiasa/ixmp#279
-JPype1 != 0.7.2, != 0.7.3, != 0.7.4
-
+JPype1
 jupyter
 jupyter_console >= 6
 matplotlib

--- a/ci/pip-requirements.txt
+++ b/ci/pip-requirements.txt
@@ -1,6 +1,9 @@
 # Always track ixmp master
 git+git://github.com/iiasa/ixmp.git@master#egg=ixmp
 
+# Temporary, while conda-forge lacks this version. See iiasa/ixmp#279.
+JPype1 >= 0.7.5
+
 # pyam-iamc
 # Temporary: see https://github.com/IAMconsortium/pyam/issues/259
 git+git://github.com/IAMconsortium/pyam.git#egg=pyam-iamc


### PR DESCRIPTION
Related to iiasa/ixmp#279

## How to review

- Confirm that CI checks pass.

## PR checklist

- [x] ~Tests added.~ CI changes only
- [x] ~Documentation added.~
- [x] ~Release notes updated.~