### PR TITLE
Update doctring message-ix-dl

### DIFF
--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -84,6 +84,10 @@ def copy_model(path, overwrite, set_default):
               help='Repository tag to download from (e.g., v1.0.0).')
 @click.argument('path', type=click.Path())
 def dl(branch, tag, path):
+    """Download MESSAGEix tutorial notebooks and extract to PATH.
+
+    PATH is a local directory where to store the tutorial notebooks.
+    """
     if tag and branch:
         raise click.BadOptionUsage('Can only provide one of `tag` or `branch`')
     elif branch:


### PR DESCRIPTION
Added _Docstring_ for the `message-ix dl` command is appropriate, before it was missing.

Notes: **second tentative**, since in https://github.com/iiasa/message_ix/pull/353 I forced-pushed the revert of the only commit in that PR so Git automatically closed it. 