### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,8 +2,6 @@ version: 2
 
 python:
   install:
-  # ixmp master must be installed first
-  - requirements: ci/pip-requirements.txt
-  - path: .
-    extra_requirements:
-    - docs
+  - method: pip
+    path: .
+    extra_requirements: [docs]


### PR DESCRIPTION
Fixes RTD builds broken by #361, which relied on the now-removed ci/pip-requirements.txt

## How to review

Check that RTD docs build completes successfully.

## PR checklist

- [x] ~Tests added.~ N/A
- [x] ~Documentation added.~
- [x] ~Release notes updated.~