### PR TITLE
Adjust to ixmp#317

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -107,7 +107,7 @@ extlinks = {
 
 intersphinx_mapping = {
     'dask': ('https://docs.dask.org/en/stable/', None),
-    'ixmp': ('https://message.iiasa.ac.at/projects/ixmp/en/latest/', None),
+    'ixmp': ('https://docs.messageix.org/projects/ixmp/en/latest/', None),
     # For a local build, uncomment and use the following line with a path to
     # the directory containing built HTML documentation for ixmp:
     # 'ixmp': ('/home/user/path-to-ixmp/doc/build/html', None),

--- a/doc/source/reporting.rst
+++ b/doc/source/reporting.rst
@@ -1,5 +1,5 @@
 Postprocessing and reporting
-============================
+****************************
 
 The |ixmp| provides powerful features to perform calculations and other postprocessing after a :class:`message_ix.Scenario` has been solved by the associated model. The |MESSAGEix| framework uses these features to provide zero-configuration reporting of models built on the framework.
 
@@ -18,8 +18,9 @@ Contents:
    :local:
    :depth: 3
 
+
 Terminology
------------
+===========
 
 :mod:`ixmp.reporting` handles numerical **quantities**, which are scalar (0-dimensional) or array (1 or more dimensions) data with optional associated units.
 *ixmp* parameters, scalars, equations, and time-series data all become quantities for the purpose of reporting.
@@ -30,10 +31,11 @@ Non-model [1]_ quantities and reports are produced by **computations**, which ar
 
 .. [1] i.e. quantities that do not exist within the mathematical formulation of the model itself, and do not affect its solution.
 
-Basic usage
------------
 
-A basic reporting workflow has the following steps:
+Basic usage
+===========
+
+A reporting workflow has the following steps:
 
 1. Obtain a :class:`message_ix.Scenario` object from an :class:`ixmp.Platform`.
 2. Use :meth:`from_scenario() <message_ix.reporting.Reporter.from_scenario>` to
@@ -61,7 +63,7 @@ A basic reporting workflow has the following steps:
 
 
 Customization
--------------
+=============
 
 A Reporter prepared with :meth:`from_scenario()
 <message_ix.reporting.Reporter.from_scenario>` always contains a key
@@ -87,8 +89,8 @@ Reporter, however, such calculations can be instead composed from atomic (i.e.
 small, indivisible) computations.
 
 
-Reporters
----------
+Reporter, Key, and Quantity classes
+===================================
 
 .. currentmodule:: message_ix.reporting
 
@@ -99,6 +101,7 @@ Reporters
    message_ix.reporting.Reporter
    ixmp.reporting.Reporter
    ixmp.reporting.Key
+   ixmp.reporting.Quantity
 
 The :meth:`ixmp.Reporter <ixmp.reporting.Reporter.from_scenario>` automatically adds keys based on the contents of the :class:`ixmp.Scenario` argument.
 The :class:`message_ix.reporting.Reporter` adds additional keys for **derived quantities** specific to the MESSAGEix model framework.
@@ -330,16 +333,34 @@ These automatic features of :class:`~message_ix.reporting.Reporter` are controll
    <foo:a-b-c>
 
 
+.. autodata:: ixmp.reporting.Quantity(data, *args, **kwargs)
+   :annotation:
+
+The :data:`.Quantity` constructor converts its arguments to an internal, :class:`xarray.DataArray`-like data format:
+
+.. code-block:: python
+
+   # Existing data
+   data = pd.Series(...)
+
+   # Convert to a Quantity for use in reporting calculations
+   qty = Quantity(data, name="Quantity name", units="kg")
+   rep.add("new_qty", qty)
+
+
 Computations
-------------
+============
+
+Defined by :mod:`message_ix`
+----------------------------
 
 .. currentmodule:: message_ix.reporting
 
 .. automodule:: message_ix.reporting.computations
-   :members: add, as_pyam, broadcast_map, concat, map_as_qty, write_report
+   :members: as_pyam, broadcast_map, concat, map_as_qty, write_report
 
-Computations from ixmp
-~~~~~~~~~~~~~~~~~~~~~~
+Inherited from ixmp
+-------------------
 
 .. currentmodule:: ixmp.reporting
 
@@ -353,10 +374,13 @@ Computations from ixmp
    Calculations:
 
    .. autosummary::
+      add
       aggregate
+      apply_units
       disaggregate_shares
       product
       ratio
+      select
       sum
 
    Input and output:
@@ -372,7 +396,7 @@ Computations from ixmp
 
 
 Configuration
--------------
+=============
 
 .. autosummary::
 
@@ -401,13 +425,17 @@ Configuration
 
 
 Utilities
----------
+=========
 
-.. autoclass:: ixmp.reporting.quantity.AttrSeries
+.. currentmodule:: ixmp.reporting.quantity
+
+.. automodule:: ixmp.reporting.quantity
+   :members: assert_quantity
+
 
 .. automodule:: ixmp.reporting.utils
    :members:
-   :exclude-members: AttrSeries, RENAME_DIMS, REPLACE_UNITS
+   :exclude-members: RENAME_DIMS, REPLACE_UNITS
 
 .. automodule:: message_ix.reporting.pyam
    :members: collapse_message_cols

--- a/message_ix/reporting/computations.py
+++ b/message_ix/reporting/computations.py
@@ -1,8 +1,7 @@
 # Import other comps so they can be imported from this module
-from ixmp.reporting import RENAME_DIMS
+from ixmp.reporting import RENAME_DIMS, Quantity
 from ixmp.reporting.computations import *        # noqa: F401, F403
 from ixmp.reporting.computations import product
-from ixmp.reporting.quantity import as_quantity
 import pandas as pd
 
 from .pyam import as_pyam, concat, write_report  # noqa: F401
@@ -46,7 +45,7 @@ def map_as_qty(set_df, full_set):
 
     return set_df.set_index([set_from, set_to])['value'] \
                  .rename_axis(index=names) \
-                 .pipe(as_quantity)
+                 .pipe(Quantity)
 
 
 def broadcast_map(quantity, map, rename={}):

--- a/message_ix/reporting/computations.py
+++ b/message_ix/reporting/computations.py
@@ -1,15 +1,24 @@
 # Import other comps so they can be imported from this module
 from ixmp.reporting import RENAME_DIMS, Quantity
-from ixmp.reporting.computations import *        # noqa: F401, F403
-from ixmp.reporting.computations import product
+from ixmp.reporting.computations import *  # noqa: F401, F403
+from ixmp.reporting.computations import add, product
 import pandas as pd
 
 from .pyam import as_pyam, concat, write_report  # noqa: F401
 
 
-def add(a, b, fill_value=0.0):
-    """Sum of *a* and *b*."""
-    return a.add(b, fill_value=fill_value).dropna()
+__all__ = [
+    # Defined here
+    "broadcast_map",
+    "map_as_qty",
+    # In .pyam
+    "as_pyam",
+    "concat",
+    "write_report",
+    # in ixmp
+    "add",
+    "product",
+]
 
 
 def map_as_qty(set_df, full_set):

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -52,11 +52,8 @@ def test_reporter(message_test_mp):
 
     # NB the call to squeeze() drops the length-1 dimensions c-l-y-h
     obs = rep.get('demand:n-c-l-y-h').squeeze(drop=True)
-    # TODO: Squeeze on AttrSeries still returns full index, whereas xarray
-    # drops everything except node
-    obs = obs.reset_index(['c', 'l', 'y', 'h'], drop=True)
     # check_attrs False because we don't get the unit addition in bare xarray
-    assert_qty_equal(obs.sort_index(), demand, check_attrs=False)
+    assert_qty_equal(obs, demand, check_attrs=False)
 
     # ixmp.Reporter pre-populated with only model quantities and aggregates
     assert len(rep_ix.graph) == 5223
@@ -71,11 +68,11 @@ def test_reporter(message_test_mp):
     assert vom_key == 'vom:nl-t-yv-ya-m-h'
 
     # …and expected values
-    vom = (
-        rep.get(rep.full_key('ACT')) * rep.get(rep.full_key('var_cost'))
-    ).dropna()
+    var_cost = rep.get(rep.full_key('var_cost'))
+    ACT = rep.get(rep.full_key('ACT'))
+    vom = computations.product(var_cost, ACT)
     # check_attrs false because `vom` multiply above does not add units
-    assert_qty_equal(vom, rep.get(vom_key), check_attrs=False)
+    assert_qty_equal(vom, rep.get(vom_key))
 
 
 def test_reporter_from_dantzig(test_mp):

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -4,7 +4,7 @@ from functools import partial
 from logging import WARNING
 from pathlib import Path
 
-from ixmp.reporting import Reporter as ixmp_Reporter, as_quantity
+from ixmp.reporting import Reporter as ixmp_Reporter, Quantity
 from ixmp.testing import assert_qty_equal
 from numpy.testing import assert_allclose
 import pandas as pd
@@ -48,7 +48,7 @@ def test_reporter(message_test_mp):
 
     # Quantities contain expected data
     dims = dict(coords=['chicago new-york topeka'.split()], dims=['n'])
-    demand = as_quantity(xr.DataArray([300, 325, 275], **dims), name='demand')
+    demand = Quantity(xr.DataArray([300, 325, 275], **dims), name='demand')
 
     # NB the call to squeeze() drops the length-1 dimensions c-l-y-h
     obs = rep.get('demand:n-c-l-y-h').squeeze(drop=True)

--- a/tutorial/westeros/westeros_report.ipynb
+++ b/tutorial/westeros/westeros_report.ipynb
@@ -775,7 +775,7 @@
     "\n",
     "def as_tidy_data(qty):\n",
     "    \"\"\"Convert *qty* to a tidy data frame, as expected by plotnine.\"\"\"\n",
-    "    return qty.to_frame().reset_index().rename(columns={0: 'value'})\n",
+    "    return qty.to_series().rename('value').reset_index()\n",
     "\n",
     "def my_plot(data):\n",
     "    \"\"\"Computation that returns a plotnine plot object.\"\"\"\n",


### PR DESCRIPTION
iiasa/ixmp#317 cleans up the reporting.Quantity semantics/API so that they are completely agnostic with respect to the internal data format. That's to make it easier to later swap `ixmp.reporting.attrseries` (a wrapped pd.Series) for `ixmp.reporting.sparsedataarray` (an xr.DataArray with pydata/sparse storage).

This PR adjusts `message_ix.reporting` to avoid calling pd.Series-specific methods, and instead use the general Quantity API.

## How to review

- First, merge iiasa/ixmp#317.
- Confirm CI checks pass.

## PR checklist

- [x] Tests adjusted.
- [x] Documentation added.
- [x] ~Release notes updated.~ N/A; no UX changes.