### PR TITLE
Update domain for RTD docs in README, release notes, and tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/message_ix.svg)](https://pypi.python.org/pypi/message_ix/)
 [![Anaconda version](https://img.shields.io/conda/vn/conda-forge/message-ix)](https://anaconda.org/conda-forge/message-ix)
-[![Documentation build](https://readthedocs.com/projects/iiasa-energy-program-message-ix/badge/?version=master)](https://message.iiasa.ac.at/en/master/)
+[![Documentation build](https://readthedocs.com/projects/iiasa-energy-program-message-ix/badge/?version=master)](https://docs.messageix.org/en/master/)
 [![Build status](https://github.com/iiasa/message_ix/workflows/pytest/badge.svg)](https://github.com/iiasa/message_ix/actions?query=workflow:pytest)
 [![Test coverage](https://codecov.io/gh/iiasa/message_ix/branch/master/graph/badge.svg)](https://codecov.io/gh/iiasa/message_ix)
 
@@ -43,7 +43,7 @@ Please refer to the [NOTICE](NOTICE.rst) for details and user guidelines.
 
 ### Documentation
 
-[Documentation of the MESSAGEix framework](https://message.iiasa.ac.at/),
+[Documentation of the MESSAGEix framework](https://docs.messageix.org/),
 including the complete mathematical formulation and associated files, is
 automatically created from mark-up comments in the GAMS, Python, and R code.
 The online documentation is synchronized with the contents of the master branch
@@ -55,13 +55,13 @@ See `doc/README.md` for further details.
 
 ### Installation
 
-See [‘Installation’ in the documentation](https://message.iiasa.ac.at/en/stable/getting_started.html) or the file `INSTALL.rst`.
+See [‘Installation’ in the documentation](https://docs.messageix.org/en/stable/getting_started.html) or the file `INSTALL.rst`.
 
 
 ### Tutorials
 
 Several introductory tutorials are provided.
-See [‘Tutorials’ in the documentation](https://message.iiasa.ac.at/en/stable/tutorials.html) or the file
+See [‘Tutorials’ in the documentation](https://docs.messageix.org/en/stable/tutorials.html) or the file
 `tutorial/README.rst`.
 
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -20,7 +20,7 @@ When loading a Scenario created with a version of `message_ix` older than 3.0.0,
 
 See also the `migration notes for ixmp 3.0.0`_.
 
-.. _migration notes for ixmp 3.0.0: https://message.iiasa.ac.at/projects/ixmp/en/latest/whatsnew.html#v3-0-0-2020-06-05
+.. _migration notes for ixmp 3.0.0: https://docs.messageix.org/projects/ixmp/en/latest/whatsnew.html#v3-0-0-2020-06-05
 
 
 All changes

--- a/rmessageix/DESCRIPTION
+++ b/rmessageix/DESCRIPTION
@@ -23,7 +23,6 @@ Depends:
     R (>= 3.3.0),
     reticulate
 Suggests:
-    rixmp,
     testthat
 License: Apache License 2.0
 URL: https://github.com/iiasa/message_ix/

--- a/tutorial/Austrian_energy_system/austria.ipynb
+++ b/tutorial/Austrian_energy_system/austria.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Austrian energy system Tutorial Part 1: Building an Energy Model\n",
     "\n",
-    "For information on how to install *MESSAGEix*, please refer to [Installation page](https://message.iiasa.ac.at/en/stable/getting_started.html) and for getting *MESSAGEix* tutorials, please follow the steps mentioned in [Tutorials](https://message.iiasa.ac.at/en/stable/tutorials.html).\n",
+    "For information on how to install *MESSAGEix*, please refer to [Installation page](https://docs.messageix.org/en/stable/getting_started.html) and for getting *MESSAGEix* tutorials, please follow the steps mentioned in [Tutorials](https://docs.messageix.org/en/stable/tutorials.html).\n",
     "\n",
     "Please refer to the [user guidelines](https://github.com/iiasa/message_ix/blob/master/NOTICE.rst)\n",
     "for additional information on using *MESSAGEix*, including the recommended citation and how to name new models.\n",
@@ -621,7 +621,7 @@
     "- `initial_activity_up`\n",
     "- `growth_activity_up`\n",
     "\n",
-    "As stated in the **Introduction**, a full list of parameters can be found in the *MESSAGEix* documentation. Specifically for this list, please refer to the section [Bounds on capacity and activity](https://message.iiasa.ac.at/en/master/model/MESSAGE/parameter_def.html#bounds-on-capacity-and-activity)"
+    "As stated in the **Introduction**, a full list of parameters can be found in the *MESSAGEix* documentation. Specifically for this list, please refer to the section [Bounds on capacity and activity](https://docs.messageix.org/en/stable/model/MESSAGE/parameter_def.html#bounds-on-capacity-and-activity)"
    ]
   },
   {

--- a/tutorial/westeros/westeros_baseline.ipynb
+++ b/tutorial/westeros/westeros_baseline.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "### *Integrated Assessment Modeling for the 21st Century*\n",
     "\n",
-    "For information on how to install *MESSAGEix*, please refer to [Installation page](https://message.iiasa.ac.at/en/stable/getting_started.html) and for getting *MESSAGEix* tutorials, please follow the steps mentioned in [Tutorials](https://message.iiasa.ac.at/en/stable/tutorials.html).\n",
+    "For information on how to install *MESSAGEix*, please refer to [Installation page](https://docs.messageix.org/en/stable/getting_started.html) and for getting *MESSAGEix* tutorials, please follow the steps mentioned in [Tutorials](https://docs.messageix.org/en/stable/tutorials.html).\n",
     "\n",
     "Please refer to the [user guidelines](https://github.com/iiasa/message_ix/blob/master/NOTICE.rst)\n",
     "for additional information on using *MESSAGEix*, including the recommended citation and how to name new models.\n",
@@ -62,7 +62,7 @@
    "source": [
     "## Online documentation\n",
     "\n",
-    "The full framework documentation is available at [https://message.iiasa.ac.at](https://message.iiasa.ac.at)\n",
+    "The full framework documentation is available at [https://docs.messageix.org](https://docs.messageix.org)\n",
     "    \n",
     "<img src='_static/doc_page.png'>"
    ]
@@ -363,7 +363,7 @@
    "source": [
     "The `COMMODITY_BALANCE_GT` and `COMMODITY_BALANCE_LT` equations ensure that `demand` for each `commodity` is met at each `level` in the energy system.\n",
     "The equation is copied below in this tutorial notebook, but every model equation is available for reference in\n",
-    "the [Mathematical formulation](https://message.iiasa.ac.at/en/stable/model/MESSAGE/model_core.html#) section of the *MESSAGEix* documentation.\n",
+    "the [Mathematical formulation](https://docs.messageix.org/en/stable/model/MESSAGE/model_core.html) section of the *MESSAGEix* documentation.\n",
     "\n",
     "$\\sum_{\\substack{n^L,t,m \\\\ y^V \\leq y}} \\text{output}_{n^L,t,y^V,y,m,n,c,l} \\cdot \\text{ACT}_{n^L,t,y^V,y,m}$\n",
     "$- \\sum_{\\substack{n^L,t,m, \\\\ y^V \\leq y}} \\text{input}_{n^L,t,y^V,y,m,n,c,l} \\cdot \\text{ACT}_{n^L,t,m,y}$  \n",

--- a/tutorial/westeros/westeros_flexible_generation.ipynb
+++ b/tutorial/westeros/westeros_flexible_generation.ipynb
@@ -198,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we could see, the need for flexibility is added by negative values to the parameter `flexibility_factor`, while the provision of flexibility is specified by positive values. For more information please refer to the [mathematical specification of flexibility](https://message.iiasa.ac.at/en/stable/model/MESSAGE/model_core.html#system-reliability-and-flexibility-requirements) in the model."
+    "As we could see, the need for flexibility is added by negative values to the parameter `flexibility_factor`, while the provision of flexibility is specified by positive values. For more information please refer to the [mathematical specification of flexibility](https://docs.messageix.org/en/stable/model/MESSAGE/model_core.html#system-reliability-and-flexibility-requirements) in the model."
    ]
   },
   {

--- a/tutorial/westeros/westeros_report.ipynb
+++ b/tutorial/westeros/westeros_report.ipynb
@@ -16,7 +16,7 @@
     "- You have the *MESSAGEix* framework installed and working\n",
     "- Complete tutorial Part 1 (``westeros_baseline.ipynb``)\n",
     "  - Understand the following MESSAGEix terms: ‘variable’, ‘parameter’\n",
-    "- Open the [‘Reporting’ page in the MESSAGEix documentation](https://message.iiasa.ac.at/en/stable/reporting.html); bookmark it or keep it open in a tab.\n",
+    "- Open the [‘Reporting’ page in the MESSAGEix documentation](https://docs.messageix.org/en/stable/reporting.html); bookmark it or keep it open in a tab.\n",
     "  Some text in this tutorial is drawn from that page, and it provides a concise reference for concepts explained below."
    ]
   },
@@ -52,7 +52,7 @@
    "source": [
     "## Reporting features in MESSAGEix\n",
     "\n",
-    "The reporting features in ``ixmp`` and ``message_ix`` are developed to support the complicated reporting and multiple workflows required by the IIASA Energy program for research projects involving large, detailed models such as the [MESSAGE-GLOBIOM global model](https://message.iiasa.ac.at/global/).\n",
+    "The reporting features in ``ixmp`` and ``message_ix`` are developed to support the complicated reporting and multiple workflows required by the IIASA Energy program for research projects involving large, detailed models such as the [MESSAGE-GLOBIOM global model](https://docs.messageix.org/global/).\n",
     "While powerful enough for this purpose, they are also intended to be user-friendly, flexible, and customizable.\n",
     "\n",
     "The core class used for reporting is ``message_ix.Reporter``, inherits from ``ixmp.Reporter``.\n",
@@ -517,7 +517,7 @@
     "We can see:\n",
     "- The Reporter will call a function named `data_for_quantity()`.\n",
     "\n",
-    "  This (and all built-in computations) are [described in the MESSAGEix documentation](https://message.iiasa.ac.at/en/stable/reporting.html#ixmp.reporting.utils.data_for_quantity).\n",
+    "  This (and all built-in computations) are [described in the MESSAGEix documentation](https://docs.messageix.org/en/stable/reporting.html#ixmp.reporting.utils.data_for_quantity).\n",
     "- The function gets some direct arguments: `'var', 'ACT', 'lvl'`.\n",
     "\n",
     "  From the documentation, we can see this indicates the level (rather than marginal) of an ixmp `'var'`iable (rather than parameter) named `'ACT'`.\n",
@@ -549,7 +549,7 @@
     "\n",
     "For example: the $\\text{ACT}$ for various technologies $t$ is a dimensionless quantity.\n",
     "The specific commodities produced by $t$, with units, are given by the product of $\\text{ACT}$ and $\\text{output}$.\n",
-    "This product is given the name ‘out’ (the documentation contains [the names for all automatic quantities](https://message.iiasa.ac.at/en/latest/reporting.html#message_ix.reporting.Reporter.from_scenario)):"
+    "This product is given the name ‘out’ (the documentation contains [the names for all automatic quantities](https://docs.messageix.org/en/latest/reporting.html#message_ix.reporting.Reporter.from_scenario)):"
    ]
   },
   {
@@ -668,7 +668,7 @@
     "\n",
     "### Converting to pyam representation\n",
     "\n",
-    "Here, we'll use the [`Reporter.convert_pyam()`](https://message.iiasa.ac.at/en/latest/reporting.html#message_ix.reporting.Reporter.convert_pyam) method.\n",
+    "Here, we'll use the [`Reporter.convert_pyam()`](https://docs.messageix.org/en/latest/reporting.html#message_ix.reporting.Reporter.convert_pyam) method.\n",
     "\n",
     "This adds a conversion to the `IamDataFrame` class from the [`pyam`](https://pyam-iamc.readthedocs.io) package.\n",
     "(`pyam` is built around the [data file format](https://data.ene.iiasa.ac.at/database/) used by the [Integrated Assessment Modeling Consortium](http://www.globalchange.umd.edu/iamc/) (IAMC), and offers plotting and further calculation features.)"
@@ -846,7 +846,7 @@
     "### Additional features\n",
     "\n",
     "The message_ix reporting code offers other features not covered by this tutorial.\n",
-    "See the [documentation](https://message.iiasa.ac.at/en/latest/reporting.html) to learn how to:\n",
+    "See the [documentation](https://docs.messageix.org/en/stable/reporting.html) to learn how to:\n",
     "- Add exogenous (non-model) data to be used in other calculations, with `Reporter.add_file()`.\n",
     "- Use a function to add many nodes at once, with `Reporter.apply()`.\n",
     "- Generate a visual representation of the graph, with `Reporter.visualize()`.\n",


### PR DESCRIPTION
As noted by @OFR-IIASA, some links to the RTD documentation had not been updated to the current domain `docs.messageix.org`. I searched/replaced all occurrences throughout the codebase.

Parallel to iiasa/ixmp#356.

## How to review

Check that the docs link in the README file on this PR branch (i.e. https://github.com/iiasa/message_ix/tree/85374675e3f7db4ffde7b8984aca9f16e491261d) works.

## PR checklist

- ~Add or expand tests.~ N/A, docs only
- [x] Add, expand, or update documentation.
- ~Update release notes.~