### PR TITLE
Fix Codecov status checks and Python 3.6 build

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,6 +30,11 @@ jobs:
         #      availalable.
         # - '3.9.0-rc.1' # Development version
 
+        exclude:
+        # See https://github.com/iiasa/ixmp/issues/360
+        - os: windows-latest
+          python-version: '3.6'
+
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -135,6 +135,18 @@ jobs:
       shell: Rscript {0}
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v1
-      with:
-        file: message_ix/coverage.xml
+
+      # NB would prefer to use Codecov's Action here, but it does not support
+      #    checkouts where 'path:' is used. See
+      #    https://github.com/codecov/codecov-action/pull/110
+      # uses: codecov/codecov-action@v1
+      # with:
+      #   working-directory: message_ix
+
+      # Manually download and run the codecov script in the message_ix directory
+      run: |
+        curl -o codecov.sh https://codecov.io/bash
+        chmod +x codecov.sh
+        ./codecov.sh
+      working-directory: message_ix
+      shell: bash

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,8 +20,15 @@ jobs:
         - ubuntu-latest
         - windows-latest
         python-version:
-        - '3.6' # Earliest supported by ixmp
-        - '3.8' # Latest available
+        - '3.6'        # Earliest supported by message_ix
+        - '3.8'        # Latest release
+        # Currently disabled: compiled binary packages are not available for
+        # some dependencies, e.g. llvmlite, numpy, pandas. Compiling these on
+        # the job runner requires a more elaborate build environment, currently
+        # out of scope.
+        # TODO enable once Python 3.9 is released and binary packages are
+        #      availalable.
+        # - '3.9.0-rc.1' # Development version
 
       fail-fast: false
 
@@ -129,10 +136,10 @@ jobs:
     - name: Run R CMD check
       run: |
         rcmdcheck::rcmdcheck(
-            "rmessageix",
-            args = c("--no-manual", "--as-cran", "--no-multiarch"),
-            error_on = "warning",
-            check_dir = "check"
+          "rmessageix",
+          args = c("--no-manual", "--as-cran", "--no-multiarch"),
+          error_on = "warning",
+          check_dir = "check"
         )
       working-directory: message_ix
       shell: Rscript {0}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,6 +49,9 @@ jobs:
       shell: bash
 
     - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - uses: r-lib/actions/setup-r@master
 
     - name: Use OpenJDK 14 (macOS only)

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,9 +4,9 @@ Next release
 All changes
 -----------
 
-- :pull:`286`: Set ``duration_period`` in :meth:`.add_horizon`; add documentation of :doc:`time`.
+- :pull:`286`, :pull:`381`: Set ``duration_period`` in :meth:`.add_horizon`; add documentation of :doc:`time`.
 - :pull:`377`: Improve the :doc:`rmessageix <rmessageix>` R package, tutorials, and expand documentation and installation instructions.
-- :pull:`382`: Update discountfactor from `df-year` to `df-period` in the documentation of the objective function to match the function.
+- :pull:`382`: Update discount factor from ``df_year`` to ``df_period`` in documentation of the objective function to match the GAMS formulation.
 
 v3.0.0 (2020-06-07)
 ===================

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -278,7 +278,7 @@ class Scenario(ixmp.Scenario):
         self.add_set("lvl_spatial", levels)
         self.add_set("map_spatial_hierarchy", hierarchy)
 
-    def add_horizon(self, data=None, /, year=[], firstmodelyear=None):
+    def add_horizon(self, year=[], firstmodelyear=None, data=None):
         """Set the scenario time horizon via ``year`` and related categories.
 
         :meth:`add_horizon` acts like ``add_set("year", ...)``, except with
@@ -332,11 +332,20 @@ class Scenario(ixmp.Scenario):
         >>> s.add_horizon([2020, 2030, 2040])
         """
         # Check arguments
-        # NB once the deprecated signature is removed, this entire block can be
-        #    deleted, and the signature changed to:
-        #    def add_horizon(self, year=[], firstmodelyear=None):
-        if isinstance(data, dict):
-            warn("add_horizon() with a dict() argument", DeprecationWarning)
+        # NB once the deprecated signature is removed, these two 'if' blocks
+        #    and the data= argument can be deleted.
+        if isinstance(year, dict):
+            # Move a dict argument to `data` to trigger the next block
+            if data:
+                raise ValueError("both year= and data= arguments")
+            data = year
+
+        if data:
+            warn(
+                "dict() argument to add_horizon(); use year= and "
+                "firstmodelyear=",
+                DeprecationWarning
+            )
 
             try:
                 year = data.pop("year")
@@ -350,11 +359,7 @@ class Scenario(ixmp.Scenario):
                     firstmodelyear = data.pop("firstmodelyear", None)
 
             if len(data):
-                raise ValueError(f"Unknown keys: {sorted(data.keys())}")
-        elif isinstance(data, list):
-            # Copy the `data` positional argument to `year`
-            assert len(year) == 0, "both data= and year= supplied"
-            year = data
+                raise ValueError(f"unknown keys: {sorted(data.keys())}")
 
         # Check for existing years
         existing = self.set("year").tolist()

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -147,6 +147,12 @@ def test_add_spatial_hierarchy(test_mp):
         None,
         marks=pytest.mark.xfail(raises=ValueError)
     ),
+    pytest.param(
+        (dict(year=[2010, 2020]),),
+        dict(data=dict(year=[2010, 2020])),
+        None,
+        marks=pytest.mark.xfail(raises=ValueError)
+    ),
 ])
 def test_add_horizon(test_mp, args, kwargs, exp):
     scen = Scenario(test_mp, **SCENARIO['dantzig'], version='new')
@@ -155,7 +161,10 @@ def test_add_horizon(test_mp, args, kwargs, exp):
     if isinstance(args[0], dict):
         with pytest.warns(
             DeprecationWarning,
-            match=r"add_horizon\(\) with a dict\(\) argument",
+            match=(
+                r"dict\(\) argument to add_horizon\(\); use year= and "
+                "firstmodelyear="
+            )
         ):
             scen.add_horizon(*args, **kwargs)
     else:


### PR DESCRIPTION
Addresses two CI issues:

- Codecov is not correctly attaching status checks to message_ix PRs after GitHub Actions workflow runs.
  - This is in contrast to ixmp, which works.
  - The Codecov action used in the workflow seems to have some limitations, see e.g. https://github.com/codecov/codecov-action/issues/51#issuecomment-595077546. This might be related because, unlike ixmp, the message_ix GHA configuration checks the repo out into a subdirectory.
  - Replaced with step that manually downloads and runs the codecov script.
  - See codecov/codecov-action#110—once this is accepted/merged, we can return to using the action.
- The same issue as iiasa/ixmp#359: the checks for Python 3.6 were actually being run with Python 3.8. This allowed #286 to pass and be merged, even though it contained syntax not compatible with Python 3.6.

## How to review

Confirm that Codecov checks are shown on this PR.

## PR checklist

- ~Add or expand tests.~ N/A, CI changes only
- ~Add, expand, or update documentation.~
- ~Update release notes.~