### PR TITLE
cleanup inconsistency between in gams documentation and equation (OBJ)

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -6,7 +6,7 @@ All changes
 
 - :pull:`286`: Set ``duration_period`` in :meth:`.add_horizon`; add documentation of :doc:`time`.
 - :pull:`377`: Improve the :doc:`rmessageix <rmessageix>` R package, tutorials, and expand documentation and installation instructions.
-
+- :pull:`382`: Update discountfactor from `df-year` to `df-period` in the documentation of the objective function to match the function.
 
 v3.0.0 (2020-06-07)
 ===================

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -298,7 +298,7 @@ Equations
 * relaxations of dynamic constraints
 *
 * .. math::
-*    OBJ = \sum_{n,y \in Y^{M}} df\_year_{y} \cdot COST\_NODAL_{n,y}
+*    OBJ = \sum_{n,y \in Y^{M}} df\_period_{y} \cdot COST\_NODAL_{n,y}
 *
 ***
 OBJECTIVE..


### PR DESCRIPTION
Updating the documentation of the MESSAGE objective function  to match the objective function.

Changing from the discountfactor *df-year* to *df-period* in the documentation of the MESSAGE objective function  to match the objective function.

## How to review
Confirm that using df-period rather than df-year in the objective function is intended.

## PR checklist

- ~Add or expand tests.~ No change in behaviour, simply refactoring.
- ~Add, expand, or update documentation.~
- ~Update release notes.~

