### PR TITLE
add annotation to westeros baseline tutorial initial creation of scenario 

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -6,7 +6,7 @@ All changes
 
 - :pull:`286`: Set ``duration_period`` in :meth:`.add_horizon`; add documentation of :doc:`time`.
 - :pull:`377`: Improve the :doc:`rmessageix <rmessageix>` R package, tutorials, and expand documentation and installation instructions.
-
+- :pull:`384`: Fix westeros baseline tutorial by adding annotation to scenario creation call.
 
 v3.0.0 (2020-06-07)
 ===================

--- a/tutorial/westeros/westeros_baseline.ipynb
+++ b/tutorial/westeros/westeros_baseline.ipynb
@@ -201,7 +201,7 @@
    "outputs": [],
    "source": [
     "scenario = message_ix.Scenario(mp, model='Westeros Electrified', \n",
-    "                               scenario='baseline', version='new')"
+    "                               scenario='baseline', version='new', annotation='Create new scenario')"
    ]
   },
   {


### PR DESCRIPTION
add annotation to the creation of the new scenario in the westeros tutorial to make it run 


## How to review
- Confirm that making the annotation a required argument is the desired behavior of the `message_ix.Scenario()` function. 


## PR checklist

<!-- The following items are all **required* if the PR results in changes to
the user behaviour, e.g. new features or fixes to existing behaviour. They are
**optional** if the changes are solely to documentation, CI configuration, etc.

In ambiguous cases, strike them out and add a short explanation, e.g.

- ~Add or expand tests.~ No change in behaviour, simply refactoring.
-->

- [ ] Add or expand tests.
- [ ] Add, expand, or update documentation.
- [x] Update release notes.
  <!-- Add a single line at the top of the “Next release” section of
       RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

    - :pull:`999`: Title or single-sentence description from above.
  -->
