### PR TITLE
Fix/Revise the maths formulations

### DIFF
--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -782,8 +782,8 @@ RENEWABLES_EQUIVALENCE(node,renewable_tec,commodity,year,time)$(
 * This constraint sets the potential potential by grade as the upper bound for the auxiliary variable :math:`REN`.
 *
 *  .. math::
-*     \sum_{\substack{t,h \\ \ t \in T^{R} \subseteq t }} REN_{n,t,c,g,y,h}
-*         \leq \sum_{\substack{l \\ l \in L^{R} \subseteq L }} renewable\_potential_{n,c,g,l,y}
+*     \sum_{\substack{t,h \\ \ t \in T^{REN} \subseteq t }} REN_{n,t,c,g,y,h}
+*         \leq \sum_{\substack{l \\ l \in L^{REN} \subseteq L }} renewable\_potential_{n,c,g,l,y}
 *
 ***
 RENEWABLES_POTENTIAL_CONSTRAINT(node,commodity,grade,year)$( map_ren_grade(node,commodity,grade,year) )..


### PR DESCRIPTION
I find the documentation on the core math formulation is not quite standalone by itself and ends up being quite confusing to external users. It requires filling in or fixing some missing parts to better communicate the formulation doc. I open this PR, but I don't really know answers to all these.

===
Some examples I found:

1. Equation COST_ACCOUNTING_NODAL

- The line explaining n^L is not relevant to the equation. Move it where it first appears, and define 'sub-node'

2. Auxiliary COMMODITY_BALANCE

- Is it missing 'variable' in the title? i.e. "Auxiliary variable COMMODITY_BALANCE"?
- Define h^A below the equation

3. I didn't check all, but multiple equations contain unexplained subscripts, which can only be guessed. (e.g. h^{OD})

4. Sometimes T^R or L^R is used to mean T^{REN} or L^{REN}.

===
Also, I am not sure whether it is a standard notation in the modeling community, but denoting subsets like N(n_hat) is confusing because it usually means functions. Why don't we use N^{n_hat}, just like it does for T^{REN}. 