### PR TITLE
Fix passthrough of reporting.pyam.concat() args

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,7 +4,8 @@ Next release
 All changes
 -----------
 
-- :pull:`286`, :pull:`381`: Set ``duration_period`` in :meth:`.add_horizon`; add documentation of :doc:`time`.
+- :pull:`389`: Fix a bug in :func:`.pyam.concat` using *non*-pyam objects.
+- :pull:`286`, :pull:`381`, :pull:`389`: Set ``duration_period`` in :meth:`.add_horizon`; add documentation of :doc:`time`.
 - :pull:`377`: Improve the :doc:`rmessageix <rmessageix>` R package, tutorials, and expand documentation and installation instructions.
 - :pull:`382`: Update discount factor from ``df_year`` to ``df_period`` in documentation of the objective function to match the GAMS formulation.
 

--- a/message_ix/reporting/pyam.py
+++ b/message_ix/reporting/pyam.py
@@ -90,12 +90,15 @@ def as_pyam(scenario, quantity, replace_vars=None, year_time_dim=None,
 
 # Computations that operate on pyam.IamDataFrame inputs
 
-def concat(*args):
+def concat(*args, **kwargs):
     """Concatenate *args*, which must all be :class:`pyam.IamDataFrame`."""
     if isinstance(args[0], IamDataFrame):
-        return pyam_concat(args)
+        # pyam.concat() takes an iterable of args
+        return pyam_concat(args, **kwargs)
     else:
-        return ixmp_concat(args)
+        # ixmp.reporting.computations.concat() takes a variable number of
+        # positional arguments
+        return ixmp_concat(*args, **kwargs)
 
 
 def write_report(quantity, path):

--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -83,7 +83,7 @@ def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
     for name, values in sets.items():
         scen.add_set(name, values)
 
-    scen.add_horizon({'year': [1962, 1963], 'firstmodelyear': 1963})
+    scen.add_horizon(year=[1962, 1963], firstmodelyear=1963)
 
     # Parameters
     par = {}

--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -190,8 +190,10 @@ def make_westeros(mp, emissions=False, solve=False):
 
     history = [690]
     model_horizon = [700, 710, 720]
-    scen.add_horizon({'year': history + model_horizon,
-                      'firstmodelyear': model_horizon[0]})
+    scen.add_horizon(
+        year=history + model_horizon,
+        firstmodelyear=model_horizon[0]
+    )
 
     country = 'Westeros'
     scen.add_spatial_sets({'country': country})

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -448,7 +448,6 @@ def test_excel_read_write(message_test_mp, tmp_path):
     assert scen2.has_par('new_par')
     assert float(scen2.par('new_par')['value']) == 2
 
-    scen2.commit('foo')  # must be checked in
     scen2.solve()
     assert np.isclose(scen2.var('OBJ')['lvl'], scen1.var('OBJ')['lvl'])
 

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -195,7 +195,7 @@ def test_vintage_and_active_years(test_mp):
     scen = Scenario(test_mp, **SCENARIO['dantzig'], version='new')
 
     years = [2000, 2010, 2020]
-    scen.add_horizon({'year': years, 'firstmodelyear': 2010})
+    scen.add_horizon(year=years, firstmodelyear=2010)
     obs = scen.vintage_and_active_years()
     exp = pd.DataFrame({'year_vtg': (2000, 2000, 2010, 2010, 2020),
                         'year_act': (2010, 2020, 2010, 2020, 2020)})
@@ -304,7 +304,7 @@ def test_years_active(test_mp):
 
     # First period length is immaterial
     duration = [1900, 5, 5, 5, 5, 10, 10]
-    scen.add_horizon({'year': years, 'firstmodelyear': years[-1]})
+    scen.add_horizon(year=years, firstmodelyear=years[-1])
     scen.add_par('duration_period',
                  pd.DataFrame(zip(years, duration), columns=['year', 'value']))
 
@@ -462,7 +462,7 @@ def test_clone(tmpdir):
     scen1 = Scenario(mp1, model='model', scenario='scenario', version='new')
     scen1.add_spatial_sets({'country': 'Austria'})
     scen1.add_set('technology', 'bar')
-    scen1.add_horizon({'year': [2010, 2020]})
+    scen1.add_horizon(year=[2010, 2020])
     scen1.commit('add minimal sets for testing')
 
     assert len(mp1.scenario_list(default=False)) == 1

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -244,3 +244,17 @@ def test_reporter_convert_pyam(dantzig_reporter, caplog, tmp_path):
     # Results have the expected units
     assert all(df5['unit'] == 'centiUSD / case')
     assert_series_equal(df4['value'], df5['value'] / 100.)
+
+
+def test_concat(dantzig_reporter):
+    """pyam.concat() correctly passes through to ixmp…concat()."""
+    rep = dantzig_reporter
+
+    key = rep.add(
+        "test",
+        computations.concat,
+        "fom:nl-t-ya",
+        "vom:nl-t-ya",
+        "tom:nl-t-ya",
+    )
+    rep.get(key)

--- a/message_ix/tools/add_year/README.rst
+++ b/message_ix/tools/add_year/README.rst
@@ -8,8 +8,10 @@ This tool adds new modeling years to an existing :class:`message_ix.Scenario` (h
 
     history = [690]
     model_horizon = [700, 710, 720]
-    sc_ref.add_horizon({'year': history + model_horizon,
-                          'firstmodelyear': model_horizon[0]})
+    sc_ref.add_horizon(
+        year=history + model_horizon,
+        firstmodelyear=model_horizon[0]
+    )
 
 …additional years can be added after importing the add_year function::
 

--- a/message_ix/utils.py
+++ b/message_ix/utils.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Mapping
 import copy
 
 import pandas as pd
@@ -33,10 +33,10 @@ def make_df(base, **kwargs):
     2	bar	44
 
     """
-    if not isinstance(base, (collections.Mapping, pd.Series, pd.DataFrame)):
+    if not isinstance(base, (Mapping, pd.Series, pd.DataFrame)):
         raise ValueError('base argument must be a dictionary or Pandas object')
     base = copy.deepcopy(base)
-    if not isinstance(base, collections.Mapping):
+    if not isinstance(base, Mapping):
         base = base.to_dict()
     base.update(**kwargs)
     return pd.DataFrame(base)

--- a/tutorial/Austrian_energy_system/austria.ipynb
+++ b/tutorial/Austrian_energy_system/austria.ipynb
@@ -136,7 +136,7 @@
    "outputs": [],
    "source": [
     "horizon = range(2010, 2041, 10)\n",
-    "scenario.add_horizon({'year': horizon})"
+    "scenario.add_horizon(year=horizon)"
    ]
   },
   {

--- a/tutorial/westeros/westeros_baseline.ipynb
+++ b/tutorial/westeros/westeros_baseline.ipynb
@@ -245,8 +245,10 @@
    "source": [
     "history = [690]\n",
     "model_horizon = [700, 710, 720]\n",
-    "scenario.add_horizon({'year': history + model_horizon,  \n",
-    "                      'firstmodelyear': model_horizon[0]})"
+    "scenario.add_horizon(\n",
+    "    year=history + model_horizon,\n",
+    "    firstmodelyear=model_horizon[0]\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
During work on iiasa/message_ix#120, @francescolovat and I discovered that `reporting.pyam.concat()` did not chain correctly to `ixmp.reporting.computations.concat()` in cases where the objects concatenated were **not** pyam.IamDataFrames.

This PR fixes this issue and adds a test.

## How to review

Note that the CI checks all pass.

## PR checklist

- [x] Add or expand tests.
- ~Add, expand, or update documentation.~ Fix to intended behaviour.
- [x] Update release notes.