### PR TITLE
Adjust reference new capacity and activity for soft constraints

### DIFF
--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -1489,7 +1489,12 @@ NEW_CAPACITY_CONSTRAINT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 *
 ***
 NEW_CAPACITY_SOFT_CONSTRAINT_UP(node,inv_tec,year)$( soft_new_capacity_up(node,inv_tec,year) )..
-    CAP_NEW_UP(node,inv_tec,year) =L= CAP_NEW(node,inv_tec,year) ;
+    CAP_NEW_UP(node,inv_tec,year) =L=
+        SUM(year2$( seq_period(year2,year) ) 
+            CAP_NEW(node,inv_tec,year2)) $ (NOT first_period(year))
+      + SUM(year_all2$( seq_period(year_all2,year) ) 
+            historical_new_capacity(node,inv_tec,year_all2)) $ first_period(year)
+;
 
 ***
 * Equation NEW_CAPACITY_CONSTRAINT_LO
@@ -1542,7 +1547,12 @@ NEW_CAPACITY_CONSTRAINT_LO(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 *
 ***
 NEW_CAPACITY_SOFT_CONSTRAINT_LO(node,inv_tec,year)$( soft_new_capacity_lo(node,inv_tec,year) )..
-    CAP_NEW_LO(node,inv_tec,year) =L= CAP_NEW(node,inv_tec,year) ;
+    CAP_NEW_LO(node,inv_tec,year) =L=
+        SUM(year2$( seq_period(year2,year) ) 
+            CAP_NEW(node,inv_tec,year2) ) $ (NOT first_period(year))
+      + SUM(year_all2$( seq_period(year_all2,year) ) 
+            historical_new_capacity(node,inv_tec,year_all2) ) $ first_period(year)
+;
 
 ***
 * Equation ACTIVITY_CONSTRAINT_UP
@@ -1600,8 +1610,12 @@ ACTIVITY_CONSTRAINT_UP(node,tec,year,time)$( map_tec_time(node,tec,year,time)
 ***
 ACTIVITY_SOFT_CONSTRAINT_UP(node,tec,year,time)$( soft_activity_up(node,tec,year,time) )..
     ACT_UP(node,tec,year,time) =L=
-        SUM((vintage,mode)$( map_tec_lifetime(node,tec,vintage,year) AND map_tec_act(node,tec,year,mode,time) ),
-            ACT(node,tec,vintage,year,mode,time) ) ;
+        SUM((vintage,mode,year2)$( map_tec_lifetime(node,tec,vintage,year) AND map_tec_act(node,tec,year,mode,time)
+                                   AND seq_period(year2,year) ),
+            ACT(node,tec,vintage,year2,mode,time) ) $ (NOT first_period(year))
+      + SUM((mode,year_all2)$( seq_period(year_all2,year) ),
+            historical_activity(node,tec,year_all2,mode,time) ) $ first_period(year)
+;
 
 ***
 * Equation ACTIVITY_CONSTRAINT_LO
@@ -1659,8 +1673,12 @@ ACTIVITY_CONSTRAINT_LO(node,tec,year,time)$( map_tec_time(node,tec,year,time)
 ***
 ACTIVITY_SOFT_CONSTRAINT_LO(node,tec,year,time)$( soft_activity_lo(node,tec,year,time) )..
     ACT_LO(node,tec,year,time) =L=
-        SUM((vintage,mode)$( map_tec_lifetime(node,tec,vintage,year) AND map_tec_act(node,tec,year,mode,time) ),
-            ACT(node,tec,vintage,year,mode,time) ) ;
+        SUM((vintage,mode,year2)$( map_tec_lifetime(node,tec,vintage,year) AND map_tec_act(node,tec,year,mode,time)
+                                   AND seq_period(year2,year) ),
+            ACT(node,tec,vintage,year2,mode,time) ) $ (NOT first_period(year))
+      + SUM((mode,year_all2)$( seq_period(year_all2,year) ),
+            historical_activity(node,tec,year_all2,mode,time) ) $ first_period(year)
+;
 
 *----------------------------------------------------------------------------------------------------------------------*
 ***


### PR DESCRIPTION
Additional growth in soft constraints of new capacity and activity is now based on previous periods new capacity and activity, respectively, as for the regular growth constraints. Based on a discussion with Daniel, this is probably the least intrusive variant of adjusting the reference year for soft constraints. The soft constraint auxiliary variables (ACT_LO, ACT_UP, CAP_NEW_LO, CAP_NEW_UP) remain to be indexed with time index year, but are constrained by activity (ACT) and new capacity (CAP_NEW) variables of the previous period year-1. This adjustment requires separate treatment of the first model period from following periods in that historical activity and new capacity parameters serve as reference values in the former case.

Note that this is not tested by running MESSAGEix, but thus far only a proposal for discussion. Auto-documentation has not been adjusted yet.