### PR TITLE
MACRO GDP reporting correction and documentation updated 

### DIFF
--- a/message_ix/model/MACRO/macro_core.gms
+++ b/message_ix/model/MACRO/macro_core.gms
@@ -161,8 +161,17 @@ SUM(node_active,
 * Equation CAPITAL_CONSTRAINT
 * ---------------------------------
 * The following equation specifies the allocation of total production among current consumption :math:`{C}_{n, y}`, investment into building up capital stock excluding
-* the sectors represented in MESSAGE :math:`{I}_{n, y}` and the MESSAGE system costs :math:`{EC}_{n, y}` which are derived from a previous MESSAGE model run. As described in :cite:`manne_buying_1992`, the first-order
-* optimality conditions lead to the Ramsey rule for the optimal allocation of savings, investment and consumption over time.
+* the sectors represented in MESSAGE :math:`{I}_{n, y}` and the MESSAGE system costs :math:`{EC}_{n, y}` which are derived from a previous MESSAGE model run. MESSAGE system
+* costs are all the energy system costs for a certain region including the trade balance from fuel and emissions certificate trade. Therefore, the constraint assures that the net
+* expenditures and savings cannot exceed the total income in a region. As described in :cite:`manne_buying_1992`, the first-order optimality conditions lead to the Ramsey rule for
+* the optimal allocation of savings, investment and consumption over time.
+
+* Since MACRO does not include the trade of normal goods, there is not an explicit component in the equation which takes the trade revenues into account. The trade of energy goods and
+* emission certificates is accounted within :math:`{EC}_{n, y}` and not added as a seperate component as well. The reason for that is, the NEW PRODUCTION equation in MACRO
+* only accounts for non-energy producing part of the economy and the energy system is modeled seperately in MESSAGE. However, the revenues from energy goods and emission allowances
+* would increase the domestic income and therefore should be accounted in the GDP definition. This is achieved via deducting the trade costs of MESSAGE from :math:`{Y}_{n, y}`in GDP
+* reporting. Positive contribution of EC to GDP would be counter balanced by the decrease of consumption :math:`{C}_{n, y}` and investment :math:`{I}_{n, y}` in the certain year as well
+* as by the reduction in capacity to invest and grow the economy for later years. 
 *
 * .. math:: Y_{n, y} = C_{n, y} + I_{r, y} + {EC}_{n, y} \qquad \forall{n, y}
 *

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -114,6 +114,7 @@ Parameters
     price_diff_rel(*,node,sector,year_all)
 
     report_iteration(iteration,*)
+    trade_cost_detail(node, commodity, year_all)              'net of commodity import costs and commodity export revenues by commodity, node and year'
 ;
 
 * variables to report back to user if needed
@@ -158,6 +159,11 @@ ctr = ctr + 1 ;
 
 * to keep the model in memory between runs, this will speed up computation
 MESSAGE_LP.solvelink = 1 ;
+
+*----------------------------------------------------------------------------------------------------------------------*
+* update total energy system costs by node and time with information from latest MESSAGE run
+total_cost(node_macro, year) = COST_NODAL.L(node_macro, year) / 1000 ;
+trade_cost_detail(node, commodity, year) = import_cost(node, commodity, year) - export_cost(node, commodity, year) ;
 
 $INCLUDE MESSAGE/model_solve.gms
 

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -120,6 +120,7 @@ Parameters
 Variables
     N_ITER
     MAX_ITER
+    GDP_corr(node, year_all)                   corrected gross domestic product (GDP) in market exchange rates for MACRO reporting
 ;
 
 
@@ -235,6 +236,8 @@ COST_NODAL_NET.L(node_macro,year) =
 ;
 
 GDP.L(node_macro,year) = (I.L(node_macro,year) + C.L(node_macro,year) + EC.L(node_macro,year)) * 1000 ;
+GDP_corr.L(node_macro,year) = (I.L(node_macro,year) + C.L(node_macro,year) + EC.L(node_macro,year) - ( trade_cost(node_macro, year) * 1E-6 ))*1000;
+
 
 * calculate convergence level (maximum absolute scaling factor minus 1 across all regions, sectors, and years)
 max_adjustment_pos = smax((node_macro,sector,year)$( NOT macro_base_period(year) AND demand_scale(node_macro,sector,year) > 1),

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -162,7 +162,7 @@ MESSAGE_LP.solvelink = 1 ;
 
 *----------------------------------------------------------------------------------------------------------------------*
 * update total energy system costs by node and time with information from latest MESSAGE run
-total_cost(node_macro, year) = COST_NODAL.L(node_macro, year) / 1000 ;
+total_cost(node_macro, year) = COST_NODAL_NET.L(node_macro, year) / 1000 ;
 trade_cost_detail(node, commodity, year) = import_cost(node, commodity, year) - export_cost(node, commodity, year) ;
 
 $INCLUDE MESSAGE/model_solve.gms


### PR DESCRIPTION
This PR:

- Corrects the reporting of GDP by introducing the` GDP_corr `parameter which includes the deduction of `trade_costs` coming from MESSAGE. 

- Updates MESSAGEix based total_cost parameter in iteration with MACRO. 

- Extends the documentation of the capital constraint section in MACRO to explain the reasoning behind the changes. 
