### PR TITLE
Prepare v3.2.0 release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,10 @@ jobs:
 
     - name: Check typing with mypy
       working-directory: message_ix
-      # Also install sphinx for checking message_ix.util.sphinx_gams
+      # Point to ixmp code for its type hints, without installing
+      env:
+        MYPYPATH: "../ixmp/"
+      # Also install packages that provide type hints
       run: |
         pip install mypy sphinx
         mypy .

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,8 +63,8 @@ jobs:
     - name: Install Python packages and dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools-scm
-        (cd ixmp; pip install .)
-        (cd message_ix; pip install .[docs,reporting,tests,tutorial])
+        (cd ixmp; pip install .[tests])
+        (cd message_ix; pip install .[tests])
 
     - name: Run test suite using pytest
       env:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -120,7 +120,7 @@ jobs:
 
     - name: Install Python package and dependencies
       working-directory: message_ix
-      run: pip install .[docs,reporting,tests,tutorial]
+      run: pip install .[tests]
 
     - name: Install R package, dependencies, and tutorial requirements
       run: |

--- a/NOTICE.rst
+++ b/NOTICE.rst
@@ -53,7 +53,7 @@ the form "MESSAGEix [xxx]" or "MESSAGEix-[xxx]", where [xxx] is replaced by:
 For example, the national model for South Africa developed by Orthofer et al. [1] is named "MESSAGEix South Africa".
 
 Ensure there is no naming conflict with existing versions of the |MESSAGEix| model family.
-When in doubt, contact the IIASA Energy Program at <message_ix@iiasa.ac.at> for a list of existing model instances.
+When in doubt, contact the IIASA ECE Program at <message_ix@iiasa.ac.at> for a list of existing model instances.
 
 
 4. Give notice of publication

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ including the complete mathematical formulation and associated files, is
 automatically created from mark-up comments in the GAMS, Python, and R code.
 
 - Documentation for the ‘latest’ or ‘stable’ release is shown by default.
-- Use the chooser to reach the [docs for the ``master`` branch](https://docs.messageix.org/en/master) of the GitHub repository, including the latest development code.
+- Use the chooser to access the [docs for the ‘master’ branch](https://docs.messageix.org/en/master) of the GitHub repository, including the latest development code; or, to access docs for a specific version of message_ix, e.g. `v3.2.0`.
 - For offline use, the documentation can be built from the source code.
   See the file `doc/README.rst`.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Test coverage](https://codecov.io/gh/iiasa/message_ix/branch/master/graph/badge.svg)](https://codecov.io/gh/iiasa/message_ix)
 
 
-MESSAGEix is a versatile, dynamic systems-optimization modeling framework developed by the IIASA Energy Program since the 1980s.
+MESSAGEix is a versatile, dynamic systems-optimization modeling framework developed by the IIASA Energy, Climate, and Environment (ECE) Program since the 1980s.
 
 MESSAGE is a specific mathematical formulation of a model for strategic energy planning and integrated assessment of energy-engineering-economy-environment (E4) systems.
 The linear-programming optimization model can be be linked to the general-equilibrium MACRO model to incorporate feedback between prices and demand levels for energy and commodities.
@@ -19,7 +19,7 @@ The framework is built on IIASA's [*ix* modeling platform (ixmp)](https://github
 
 ## License
 
-Copyright © 2018–2020 IIASA Energy Program
+Copyright © 2018–2021 IIASA Energy, Climate, and Environment (ECE) Program
 
 The MESSAGEix framework is licensed under the Apache License, Version 2.0 (the
 "License"); you may not use the files in this repository except in compliance

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,14 +1,16 @@
-Next release
-============
+v3.2.0 (2021-01-24)
+===================
 
 Migration notes
 ---------------
 
 - Code that uses :func:`.make_df` can be adjusted in one of two ways.
   See the function documentation for details.
-  The function should be imported from the top level::
+  The function should be imported from the top level:
 
-    from message_ix import make_df
+  .. code-block:: python
+
+     from message_ix import make_df
 
 
 All changes

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,7 +17,7 @@ from pkg_resources import get_distribution
 # -- Project information -----------------------------------------------------
 
 project = "MESSAGEix"
-copyright = "2020, IIASA Energy Program"
+copyright = "2021, IIASA Energy, Climate, and Environment (ECE) Program"
 author = "MESSAGEix Developers"
 
 # The major project version, used as the replacement for |version|.

--- a/doc/contrib/cla.rst
+++ b/doc/contrib/cla.rst
@@ -1,0 +1,3 @@
+Included from :file:`CONTRIBUTOR_LICENSE.rst`:
+
+.. include:: ../../CONTRIBUTOR_LICENSE.rst

--- a/doc/contrib/release.rst
+++ b/doc/contrib/release.rst
@@ -1,0 +1,146 @@
+Release procedure
+*****************
+
+.. contents::
+   :local:
+   :backlinks: none
+
+Preliminaries
+=============
+
+- The procedure applies to both ixmp and message_ix.
+- The ixmp release must be processed *before* message_ix.
+- The person (or persons) processing the release needs the following authorizations:
+
+  - Maintainer or Owner on both Github repositories.
+  - Maintainer on the
+    `conda-forge/ixmp-feedstock <https://github.com/conda-forge/ixmp-feedstock>`__
+    and
+    `conda-forge/message-ix-feedstock <https://github.com/conda-forge/message-ix-feedstock>`__
+    repositories.
+    This means your Github account is listed in the :file:`recipe/meta.yaml`, under the key ``recipe-maintainers:``.
+  - Accounts on both https://test.pypi.org and https://pypi.org.
+  - "Maintainer" or "Owner" permissions for both projects on both sites; i.e. your account should appear in https://test.pypi.org/manage/project/ixmp/collaboration/.
+
+- In the below:
+
+  - ``<version>`` stands for the full version number, e.g. ``1.2.0``.
+    Always include all three parts: major, minor, and patch, i.e. ``1.2.0`` and never ``1.2``.
+    Look very carefully to see when ``v<version>`` versus ``<version>`` should be used.
+  - ``<upstream>`` stands for your local name for the Git remote that is the IIASA Github repository.
+
+Before releasing
+================
+
+**Update these instructions.** Keep them current with actual practice.
+
+**Handle deprecations.** You can find these by searching the code base for "deprecat".
+
+A deprecation always involves *two* versions: (1) the version in which the item "is [marked as] deprecated", and (2) the version in which the item is removed.
+These must always be separated by at least one major version.
+For instance, an item marked as deprecated in v2.1 can be removed as of v3.0; an item marked as deprecated in v3.0 can be removed in v4.0, or later, e.g. in v5.0.
+
+1. Mark new deprecations.
+   Explicitly state the version when the removal is targeted, so that users can adjust their code.
+2. Remove items targeted for this release.
+
+   .. note:: This can be done at any point, and should be done before the release prep begins.
+      For instance, a feature marked as deprecated in v2.0 *should* be removed before 3.0 is released.
+      But *may* also be removed from the ``master`` branch *immediately after* 2.0.0 is released.
+      This is preferred, because it forces tutorials, user code, etc. to stay ahead of deprecations.
+
+Releasing
+=========
+
+1. Create a "release candidate" (RC) branch named e.g. 'prepare-<version>' or 'release-<version>'.
+2. Update the following files:
+
+   1. :file:`setup.cfg` (message_ix only):
+      Update the ``install_requires`` line for ixmp.
+      Each version of message_ix depends on the corresponding version of ixmp.
+      For instance, message_ix 3.1 depends on ixmp 3.1; not ixmp 3.0.
+
+   2. :file:`RELEASE_NOTES.rst`:
+
+      - Rename the section "Next Release" to "``v<version>`` (YYYY-MM-DD)".
+      - Add a short text description summarizing the release.
+      - Optionally, add a subsection "Migration notes" explaining to users how to adjust to changes in the release.
+
+   2. :file:`README.rst`: Adjust the documentation badge to link to the 'stable' instead of 'master' version of the docs.
+   3. :file:`tutorial/README.rst`: Adjust the links to the tutorials, replacing all instances of ``/blob/master/`` with ``blob/v<version>/``.
+   4. :file:`rmessageix/DESCRIPTION` (message_ix only): Set the "Version:"" line to ``<version>``.
+
+3. Create a pull request to merge the RC branch into 'master'.
+
+   1. Ensure all continuous integration checks pass.
+   2. On `Read The Docs <https://readthedocs.com>`_, enable the build of the RC branch and ensure the docs build correctly.
+
+4. Test publishing using TestPyPI.
+
+   1. On your local machine, create a *temporary* tag for the release number::
+
+        git tag v<version>
+
+      - This is **NOT** the commit we will distribute. The tag is only for testing.
+      - **DO NOT** push this tag anywhere, e.g. to GitHub!
+
+   2. Build and check::
+
+        rm -rf build dist
+        python3 setup.py bdist_wheel sdist
+        twine check dist/*
+
+      This should complete without any errors.
+      If it does not: fix any issues, create new commit(s), retag (``git tag --delete v<version>`` then ``git tag <version>``), and try again.
+
+   3. Publish and check::
+
+        twine upload -r testpypi dist/*
+
+      View and download the package from TestPyPI to ensure the README and contents are complete and free of errors.
+   4. Delete the test tag::
+
+        git tag --delete v<version>
+
+5. On Github, merge the RC PR using the ‘rebase’ approach.
+6. On your local machine, pull the now-updated 'master', tag and push:
+
+    git checkout master
+    git pull <upstream> master
+    git tag v<version>
+    git push <upstream> --tags
+
+7. On `Read The Docs`_, set the privacy level for the docs built from the new ``v<version>`` tag to “Public.”
+8. Publish on PyPI::
+
+    rm -rf build dist
+    python3 setup.py bdist_wheel sdist
+    twine check dist/*
+    twine upload dist/*
+
+9. Create a new release on GitHub.
+
+   - Choose the existing tag ``v<version>`` created/pushed earlier; *do not* create a new one.
+   - Add a link to the section in the “What's New” page of the documentation corresponding to the new release.
+
+10. Update on conda-forge.
+    A PR should automatically be opened by a bot after the GitHub release (sometimes this takes up to 30 minutes).
+
+    1. Confirm that any new dependencies are added. The minimum versions in :file:`meta.yaml` should match the versions in :file:`setup.cfg`.
+    2. Ensure that tests pass and complete any other checklist items.
+    3. Merge the PR.
+    4. Check that the new package version appears on conda-forge. This may take up to several hours.
+
+11. Announce the release(s) on our mailing list/Google group and/or on Twitter.
+    Copy the text from the What's New page of the built documentation.
+
+After the release
+=================
+
+**Update the following files.** Make a single commit directly to 'master' with a message like “Reset to development state”.
+The following changes essentially reverse the changes under step (2) in the release procedure, above.
+
+- :file:`RELEASE_NOTES.rst`: Add new section "Next Release" and subsection "All changes" above the section for the release.
+- :file:`README`: Adjust the docs badge to link to 'master' instead of 'stable'.
+- :file:`tutorial/README.rst`: Replace all instances of ``/blob/v<version>/`` with ``blob/master/``.
+- :file:`rmessageix/DESCRIPTION`: (message_ix only) Append ".9000" to the "Version: " line, e.g. "2.0.0.9000" to indicate a development version following v2.0.0.

--- a/doc/contrib/release.rst
+++ b/doc/contrib/release.rst
@@ -78,9 +78,9 @@ Releasing
 
 4. Test publishing using TestPyPI.
 
-   1. On your local machine, create a *temporary* tag for the release number::
+   1. On your local machine, create a *temporary* tag for the release number, adding a 'rc' suffix::
 
-        git tag v<version>
+        git tag v<version>rc1
 
       - This is **NOT** the commit we will distribute. The tag is only for testing.
       - **DO NOT** push this tag anywhere, e.g. to GitHub!
@@ -92,16 +92,20 @@ Releasing
         twine check dist/*
 
       This should complete without any errors.
-      If it does not: fix any issues, create new commit(s), retag (``git tag --delete v<version>`` then ``git tag <version>``), and try again.
+      If it does not: fix any issues, create new commit(s), retag (``git tag --delete v<version>rc1`` then ``git tag v<version>rc1``), and try again.
 
    3. Publish and check::
 
         twine upload -r testpypi dist/*
 
       View and download the package from TestPyPI to ensure the README and contents are complete and free of errors.
-   4. Delete the test tag::
+      If they are not, fix any issues, create new commit(s), and try again fro step (4)(1), using an incremented ``rc`` part, e.g. ``v<version>rc2``.
 
-        git tag --delete v<version>
+   4. Delete all test tags created::
+
+        git tag --delete v<version>rc1
+        git tag --delete v<version>rc2
+        # etc.
 
 5. On Github, merge the RC PR using the ‘rebase’ approach.
 6. On your local machine, pull the now-updated 'master', tag and push:
@@ -118,6 +122,9 @@ Releasing
     python3 setup.py bdist_wheel sdist
     twine check dist/*
     twine upload dist/*
+
+    # Also upload to testpypi, so the latest version is not the RC above
+    twine upload -r testpypi dist/*
 
 9. Create a new release on GitHub.
 

--- a/doc/contrib/release.rst
+++ b/doc/contrib/release.rst
@@ -66,9 +66,10 @@ Releasing
       - Add a short text description summarizing the release.
       - Optionally, add a subsection "Migration notes" explaining to users how to adjust to changes in the release.
 
-   2. :file:`README.rst`: Adjust the documentation badge to link to the 'stable' instead of 'master' version of the docs.
    3. :file:`tutorial/README.rst`: Adjust the links to the tutorials, replacing all instances of ``/blob/master/`` with ``blob/v<version>/``.
    4. :file:`rmessageix/DESCRIPTION` (message_ix only): Set the "Version:"" line to ``<version>``.
+
+   Commit with a message like “Prepare ``v<version>``”.
 
 3. Create a pull request to merge the RC branch into 'master'.
 
@@ -141,6 +142,5 @@ After the release
 The following changes essentially reverse the changes under step (2) in the release procedure, above.
 
 - :file:`RELEASE_NOTES.rst`: Add new section "Next Release" and subsection "All changes" above the section for the release.
-- :file:`README`: Adjust the docs badge to link to 'master' instead of 'stable'.
 - :file:`tutorial/README.rst`: Replace all instances of ``/blob/v<version>/`` with ``blob/master/``.
 - :file:`rmessageix/DESCRIPTION`: (message_ix only) Append ".9000" to the "Version: " line, e.g. "2.0.0.9000" to indicate a development version following v2.0.0.

--- a/doc/contrib/release.rst
+++ b/doc/contrib/release.rst
@@ -129,7 +129,13 @@ Releasing
 9. Create a new release on GitHub.
 
    - Choose the existing tag ``v<version>`` created/pushed earlier; *do not* create a new one.
-   - Add a link to the section in the “What's New” page of the documentation corresponding to the new release.
+   - For the description, provide a link to the section in the “What's New” page of the documentation that corresponds to the new release.
+     For example:
+
+     .. code-block:: markdown
+
+        See the [“What's New” page](https://docs.messageix.org/projects/ixmp/en/stable/whatsnew.html#v3-1-0-2020-08-28) in the ixmp documentation for a list of all changes.
+
 
 10. Update on conda-forge.
     A PR should automatically be opened by a bot after the GitHub release (sometimes this takes up to 30 minutes).

--- a/doc/contrib/tutorial.rst
+++ b/doc/contrib/tutorial.rst
@@ -1,0 +1,88 @@
+Developing tutorials
+********************
+
+Developers *and users* of the |MESSAGEix| framework are welcome to contribute **tutorials**, according to the following guidelines.
+Per the license and CLA, tutorials will become part of the message_ix test suite and will be publicly available.
+
+Developers **must** ensure new features (including :mod:`message_ix.tools` submodules) are fully documented.
+This can be done via the API documentation (this site) and, optionally, a tutorial.
+These have complementary purposes:
+
+- The API documentation (built using Sphinx and ReadTheDocs) must completely, but succinctly, *describe the arguments and behaviour* of every class and method in the code.
+- Tutorials serve as *structured learning exercises* for the classroom or self-study.
+  The intended learning outcome for each tutorial is that students understand how the model framework API may be used for scientific research, and can begin to implement their own models or model changes.
+
+
+Code and writing style
+======================
+
+- Python and R code in notebooks: follow all points of the :ref:`code-style` for message_ix.
+- Only commit 'bare' Jupyter notebooks: clear all cell output before committing.
+  Notebooks will be run and rendered when the documentation is generated.
+- Add a line to :file:`message_ix/tests/test_tutorials.py`, so that the parametrized test function runs the tutorial (as noted at :pull:`196`).
+- Optionally, use Jupyter notebook slide-show features so that the tutorial can be viewed as a presentation.
+- When relevant, provide links to publications or sources that provide greater detail for the methodology, data, or other packages used.
+- Providing the mathematical formulation in the tutorial itself is optional.
+- Framework specific variables and parameters or functions must be in italic.
+- Relevant figures, tables, or diagrams should be added to the tutorial if these can help users to understand concepts.
+
+  - Place rendered versions of graphics in a directory with the tutorial (see `Location`_ below).
+    Use SVG, PNG, JPG, or other web-ready formats.
+
+
+Structure
+=========
+
+Generally, a tutorial should have the following elements or sections.
+
+- Tutorial introduction:
+
+  - The general overview of tutorial.
+  - The intended learning outcome.
+  - An explanation of which features are covered.
+  - Reference and provide links to any tutorials that are interlinked or part of a series.
+
+- Description of individual steps:
+
+  - A brief explanation of the step.
+  - A link to any relevant mathematical documentation.
+
+- Modeling results and visualizations:
+
+  - Model outputs and post-processing calculations in tutorials should demonstrate usage of the :doc:`message_ix.reporting module <reporting>`.
+  - Plots to depict results should use `pyam <https://github.com/IAMconsortium/pyam/>`_.
+  - Include a brief discussion of insights from the results, in line with the learning objectives.
+
+- Exercises: include self-test questions, small activities, and exercises at the end of a tutorial so that users (and instructors, if any) can check their learning.
+
+
+Location
+========
+
+Place notebooks in an appropriate location:
+
+:file:`tutorial/name.ipynb``
+   Stand-alone tutorial.
+
+:file:`tutorial/example/example_baseline.ipynb`
+   Group of tutorials named “example.”
+   Each notebook's file name begins with the group name, followed by a name
+   beginning with underscores.
+   The group name can refer to a specific RES shared across multiple tutorials.
+   Some example names include::
+
+       <group>_baseline.ipynb
+
+       <group>_basic.ipynb  # Basic modeling features, e.g.:
+       <group>_emmission_bounds.ipynb
+       <group>_emission_taxes.ipynb
+       <group>_fossil_resources.ipynb
+
+       <group>_adv.ipynb  # Advanced modeling features, e.g.:
+       <group>_addon_technologies.ipynb
+       <group>_share_constraints.ipynb
+
+       <group>_renewables.ipynb  # Features related to renewable energy, e.g.:
+       <group>_firm_capacity.ipynb
+       <group>_flexible_generation.ipynb
+       <group>_renewable_resources.ipynb

--- a/doc/contrib/version.rst
+++ b/doc/contrib/version.rst
@@ -1,0 +1,29 @@
+.. _releases:
+
+Versions and releases
+*********************
+
+- We use `semantic versioning <https://semver.org>`_.
+
+  To paraphrase: a **major** version increment (e.g. from 3.5 to 4.0) means there are *backwards-incompatible* changes to the API or functionality (e.g. code written for version 3.5 may no longer work with 4.0).
+  Major releases always include migration notes in :doc:`whatsnew` to alert users to such changes and suggest how to adjust their code.
+  A **minor** version increment may fix bugs or add new features, but does not change existing functionality.
+  Code written for e.g. version 3.5 will continue to work with 3.6.
+
+- Releases of :mod:`ixmp` and :mod:`message_ix` are generally made at the same time, and the version numbers kept synchronized.
+
+- Each version of :mod:`message_ix` has a minimum required version of :mod:`ixmp`.
+
+- We keep at least two active milestones on each of the message_ix and ixmp repositories:
+
+  - The next minor version. e.g. if the latest release was 3.5, the next minor release/milestone is 3.6.
+  - The next major version. e.g. 4.0.
+
+- The milestones are closed at the time a new version is released.
+  If a major release (e.g. 4.0) is made without the preceding minor release (e.g. 3.6), both are closed together.
+
+- Every issue and PR should be assigned to a milestone to record the decision/intent to release it at a certain time.
+
+- New releases are made by ECE Program staff using the :doc:`release`, and appear on Github, PyPI, and conda-forge.
+
+- There is no fixed **release schedule**, but new releases are generally made twice each year, sometimes more often.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -5,8 +5,19 @@ We welcome contributions to the code base and development of new features for th
 This page contains guidelines for making such contributions.
 Each section requires some of the listed :doc:`prerequisite knowledge and skills <prereqs>`; use the links there to external resources about git, Github, Python, etc. to ensure you are able to understand and complete the steps.
 
+On this page:
+
 .. contents::
   :local:
+
+On separate pages:
+
+.. toctree::
+   :maxdepth: 1
+
+   contrib/version
+   contrib/tutorial
+   contrib/cla
 
 
 File issues for bugs and enhancements
@@ -89,7 +100,7 @@ __ https://help.github.com/en/github/collaborating-with-issues-and-pull-requests
 
 |MESSAGEix| has several kinds of automatic, or *continuous integration*, checks:
 
-- The `CLA Assistant <https://github.com/cla-assistant/>`_ ensures you have signed the `Contributor License Agreement`_ (text below).
+- The `CLA Assistant <https://github.com/cla-assistant/>`_ ensures you have signed the :doc:`contrib/cla` (follow link for text).
   All contributors are required to sign the CLA before any pull request can be reviewed.
   This ensures that all future users can benefit from your contribution, and that your contributions do not infringe on anyone else's rights.
 - GitHub Actions is used to run several *workflows*.
@@ -159,6 +170,8 @@ Current practice for the ``ixmp``, ``message_ix``, and ``message_data`` reposito
   Rebasing avoids this problem by ensuring each PR's commits are displayed together & in sequence.
 
 
+.. _code-style:
+
 Code style
 ==========
 
@@ -180,7 +193,7 @@ Code style
 
 - Write docstrings in the `numpydoc <https://numpydoc.readthedocs.io/en/latest/format.html>`_ style.
 - For new or modified **R** code, follow the style of the existing code base.
-- For Jupyter notebooks (:file:`.ipynb`): see below, under `Contribute tutorials`_.
+- Jupyter notebooks (:file:`.ipynb`): see :doc:`contrib/tutorial`.
 - For **documentation** in ReStructuredText formats, in :file:`doc/*.rst` and inline in :file:`message_ix/model/*.gms` files:
 
   - Start each sentence on a new line.
@@ -192,127 +205,6 @@ Code style
   - Wrap lines at 121 characters, except for inline documentation (see above).
 
 - Other (file names, CLI, etc.): follow the style of the existing code base.
-
-
-.. _releases:
-
-Versions and releases
-=====================
-
-- We use `semantic versioning <https://semver.org>`_.
-
-  To paraphrase: a **major** version increment (e.g. from 3.5 to 4.0) means there are *backwards-incompatible* changes to the API or functionality (e.g. code written for version 3.5 may no longer work with 4.0).
-  Major releases always include migration notes in :doc:`whatsnew` to alert users to such changes and suggest how to adjust their code.
-  A **minor** version increment may fix bugs or add new features, but does not change existing functionality.
-  Code written for e.g. version 3.5 will continue to work with 3.6.
-
-- Releases of :mod:`ixmp` and :mod:`message_ix` are generally made at the same time, and the version numbers kept synchronized.
-
-- Each version of :mod:`message_ix` has a minimum required version of :mod:`ixmp`.
-
-- We keep at least two active milestones on each of the message_ix and ixmp repositories:
-
-  - The next minor version. e.g. if the latest release was 3.5, the next minor release/milestone is 3.6.
-  - The next major version. e.g. 4.0.
-
-- The milestones are closed at the time a new version is released.
-  If a major release (e.g. 4.0) is made without the preceding minor release (e.g. 3.6), both are closed together.
-
-- Every issue and PR should be assigned to a milestone to record the decision/intent to release it at a certain time.
-
-- New releases are made by ECE Program staff using the `Release procedure <https://github.com/iiasa/message_ix/wiki/Release-procedure>`_, and appear on Github, PyPI, and conda-forge.
-
-- There is no fixed **release schedule**, but new releases are generally made twice each year, sometimes more often.
-
-
-Contribute tutorials
-====================
-
-Developers *and users* of the |MESSAGEix| framework are welcome to contribute **tutorials**, according to the following guidelines.
-Per the license and CLA, tutorials will become part of the message_ix test suite and will be publicly available.
-
-Developers **must** ensure new features (including :mod:`message_ix.tools` submodules) are fully documented.
-This can be done via the API documentation (this site) and, optionally, a tutorial.
-These have complementary purposes:
-
-- The API documentation (built using Sphinx and ReadTheDocs) must completely, but succinctly, *describe the arguments and behaviour* of every class and method in the code.
-- Tutorials serve as *structured learning exercises* for the classroom or self-study.
-  The intended learning outcome for each tutorial is that students understand how the model framework API may be used for scientific research, and can begin to implement their own models or model changes.
-
-
-Code and writing style
-----------------------
-
-- Format tutorials as Jupyter notebooks in Python or R.
-- Only commit 'bare' notebooks to git, i.e. without cell output.
-  Notebooks will be run and rendered when the documentation is generated.
-- Add a line to ``tests/test_tutorials.py``, so that the parametrized test function runs the tutorial (as noted at :pull:`196`).
-- Optionally, use Jupyter notebook slide-show features so that the tutorial can be viewed as a presentation.
-- When relevant, provide links to publications or sources that provide greater detail for the methodology, data, or other packages used.
-- Providing the mathematical formulation in the tutorial itself is optional.
-- Framework specific variables and parameters or functions must be in italic.
-- Relevant figures, tables, or diagrams should be added to the tutorial if these can help users to understand concepts.
-
-  - Place rendered versions of graphics in a directory with the tutorial (see `Location`_ below).
-    Use SVG, PNG, JPG, or other web-ready formats.
-
-
-Structure
----------
-
-Generally, a tutorial should have the following elements or sections.
-
-- Tutorial introduction:
-
-  - The general overview of tutorial.
-  - The intended learning outcome.
-  - An explanation of which features are covered.
-  - Reference and provide links to any tutorials that are interlinked or part of a series.
-
-- Description of individual steps:
-
-  - A brief explanation of the step.
-  - A link to any relevant mathematical documentation.
-
-- Modeling results and visualizations:
-
-  - Model outputs and post-processing calculations in tutorials should demonstrate usage of the :doc:`message_ix.reporting module <reporting>`.
-  - Plots to depict results should use `pyam <https://github.com/IAMconsortium/pyam/>`_.
-  - Include a brief discussion of insights from the results, in line with the learning objectives.
-
-- Exercises: include self-test questions, small activities, and exercises at the end of a tutorial so that users (and instructors, if any) can check their learning.
-
-
-Location
---------
-
-Place notebooks in an appropriate location:
-
-``tutorial/name.ipynb``:
-   Stand-alone tutorial.
-
-``tutorial/example/example_baseline.ipynb``:
-   Group of tutorials named “example.”
-   Each notebook's file name begins with the group name, followed by a name
-   beginning with underscores.
-   The group name can refer to a specific RES shared across multiple tutorials.
-   Some example names include::
-
-       <group>_baseline.ipynb
-
-       <group>_basic.ipynb  # Basic modeling features, e.g.:
-       <group>_emmission_bounds.ipynb
-       <group>_emission_taxes.ipynb
-       <group>_fossil_resources.ipynb
-
-       <group>_adv.ipynb  # Advanced modeling features, e.g.:
-       <group>_addon_technologies.ipynb
-       <group>_share_constraints.ipynb
-
-       <group>_renewables.ipynb  # Features related to renewable energy, e.g.:
-       <group>_firm_capacity.ipynb
-       <group>_flexible_generation.ipynb
-       <group>_renewable_resources.ipynb
 
 
 Manage issues and pull requests
@@ -333,9 +225,3 @@ Manage issues and pull requests
 
   - Ask (in a new comment, on Slack, in person) the assignee or last commenter what the status is.
   - Close or re-assign, with a comment that describes your reasoning.
-
-----
-
-Included from :file:`CONTRIBUTOR_LICENSE.rst`:
-
-.. include:: ../CONTRIBUTOR_LICENSE.rst

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -16,6 +16,7 @@ On separate pages:
    :maxdepth: 1
 
    contrib/version
+   contrib/release
    contrib/tutorial
    contrib/cla
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -126,7 +126,7 @@ See ``doc/README.rst``.
 ---------
 
 Using the GitHub sidebar on your PR, request a review from another |MESSAGEix| contributor.
-GitHub suggests reviewers; optionally, contact the IIASA Energy Program to ask who should review your code.
+GitHub suggests reviewers; optionally, contact the IIASA ECE Program to ask who should review your code.
 
 - If you want them to follow along with progress, tag them in the PR description, like “FYI @Alice @Bob”.
 - Only formally request review once the code is ready to review.
@@ -220,7 +220,7 @@ Versions and releases
 
 - Every issue and PR should be assigned to a milestone to record the decision/intent to release it at a certain time.
 
-- New releases are made by Energy Program staff using the `Release procedure <https://github.com/iiasa/message_ix/wiki/Release-procedure>`_, and appear on Github, PyPI, and conda-forge.
+- New releases are made by ECE Program staff using the `Release procedure <https://github.com/iiasa/message_ix/wiki/Release-procedure>`_, and appear on Github, PyPI, and conda-forge.
 
 - There is no fixed **release schedule**, but new releases are generally made twice each year, sometimes more often.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,13 +7,13 @@ The |MESSAGEix| framework
 
    The |ixmp| (:cite:`huppmann_messageix_2018`)
 
-|MESSAGEix| is a versatile, dynamic systems-optimization modelling framework developed by the |IIASA| Energy Program since the 1980s.
+|MESSAGEix| is a versatile, dynamic systems-optimization modelling framework developed by the |IIASA| Energy, Climate, and Environment (ECE) Program [#rename]_ since the 1980s.
 
 This is the documentation for :mod:`message_ix`, a Python package that ties together all components of the framework.
 :mod:`message_ix` and :mod:`ixmp` are free and open source, licensed under the `APACHE 2.0 open-source license`_.
 
 - For the scientific reference of the framework, see Huppmann et al. (2019) :cite:`huppmann_messageix_2018`.
-- For an overview and recent publications related to the specific |MESSAGEix|-GLOBIOM global model instance used at the IIASA Energy Program, see the `MESSAGEix-GLOBIOM documentation`_.
+- For an overview and recent publications related to the specific |MESSAGEix|-GLOBIOM global model instance used at the IIASA ECE Program, see the `MESSAGEix-GLOBIOM documentation`_.
 
 
 .. _getting-started:
@@ -143,3 +143,5 @@ Have a question?
 
 .. _`MESSAGEix-GLOBIOM documentation`: http://data.ene.iiasa.ac.at/message-globiom/
 .. _`APACHE 2.0 open-source license`: https://github.com/iiasa/message_ix/blob/master/LICENSE
+
+.. [#rename] Known as the “Energy Program” until 2020-12-31.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -134,12 +134,15 @@ Everyone is encouraged to use the framework to develop energy system and integra
 
 .. _help:
 
-Have a question?
+Have a question? Check…
 
-- Check the :doc:`faq`.
-- Search current and older `issues on GitHub <https://github.com/iiasa/message_ix/issues?q=is:issue>`_, or open a new one with your question.
-- Consult the community Google group on the web at https://groups.google.com/d/forum/message_ix, or via e-mail at <message_ix@googlegroups.com>.
+- …on GitHub:
 
+  - Join an existing `discussion <https://github.com/iiasa/message_ix/discussions>`_ or start a new one with your question.
+  - Search `current issues <https://github.com/iiasa/message_ix/issues?q=is:issue>`_, or open a new one to report a bug in the code.
+
+- …the :doc:`faq`.
+- …the message_ix Google Group, either `online <https://groups.google.com/d/forum/message_ix>`_ or via e-mail at <message_ix@googlegroups.com>.
 
 .. _`MESSAGEix-GLOBIOM documentation`: http://data.ene.iiasa.ac.at/message-globiom/
 .. _`APACHE 2.0 open-source license`: https://github.com/iiasa/message_ix/blob/master/LICENSE

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -2,7 +2,7 @@ $TITLE The MESSAGEix-MACRO Integrated Assessment Model
 $ONDOLLAR
 $ONTEXT
 
-   Copyright 2018 IIASA Energy Program
+   Copyright 2017–2021 IIASA Energy, Climate, and Environment (ECE) Program
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/message_ix/model/MESSAGE_run.gms
+++ b/message_ix/model/MESSAGE_run.gms
@@ -2,7 +2,7 @@ $TITLE The MESSAGEix Integrated Assessment Model
 $ONDOLLAR
 $ONTEXT
 
-   Copyright 2018 IIASA Energy Program
+   Copyright 2017–2021 IIASA Energy, Climate, and Environment (ECE) Program
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/rmessageix/DESCRIPTION
+++ b/rmessageix/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rmessageix
 Type: Package
 Title: MESSAGEix Modeling Framework
-Version: 3.1.0.9000
+Version: 3.2.0
 Authors@R: c(
     person("Alessio", "Mastrucci", email = "mastrucc@iiasa.ac.at",
            role = c("aut", "cre")),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = message_ix
-author = IIASA Energy Program
+author = IIASA Energy, Climate, and Environment (ECE) Program
 author_email = message_ix@iiasa.ac.at
 license = Apache
 description = the MESSAGEix integrated assessment model
@@ -40,7 +40,7 @@ tutorial =
     jupyter
     matplotlib
     plotnine
-   
+
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,8 +80,6 @@ max-line-length = 88
 
 [mypy-asyncssh.*]
 ignore_missing_imports = True
-[mypy-ixmp.*]
-ignore_missing_imports = True
 [mypy-matplotlib.*]
 ignore_missing_imports = True
 [mypy-numpy.*]
@@ -97,4 +95,18 @@ ignore_missing_imports = True
 [mypy-setuptools.*]
 ignore_missing_imports = True
 [mypy-xarray.*]
+ignore_missing_imports = True
+
+# Indirectly via ixmp; this should be a subset of the list in ixmp's setup.cfg
+[mypy-dask.*]
+ignore_missing_imports = True
+[mypy-jpype.*]
+ignore_missing_imports = True
+[mypy-nbclient.*]
+ignore_missing_imports = True
+[mypy-nbformat.*]
+ignore_missing_imports = True
+[mypy-memory_profiler.*]
+ignore_missing_imports = True
+[mypy-sparse.*]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ zip_safe = True
 include_package_data = True
 install_requires =
     click
-    ixmp >= 3.1.0
+    ixmp >= 3.2.0
     numpy
     pandas
     PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,28 +18,33 @@ install_requires =
     numpy
     pandas
     PyYAML
+    setuptools >= 41
 setup_requires =
     setuptools >= 41
     setuptools_scm
 
 [options.extras_require]
+reporting =
+    pint
+    pyam-iamc >= 0.6
 docs =
+    %(reporting)s
     numpydoc
     sphinx >= 3.0
     sphinx_rtd_theme
     sphinxcontrib-bibtex
-reporting =
-    pint
-    pyam-iamc >= 0.6
+tutorial =
+    %(reporting)s
+    jupyter
+    matplotlib
+    plotnine
 tests =
+    %(docs)s
+    %(tutorial)s
     asyncssh
     pytest >= 5
     pytest-cov
     requests
-tutorial =
-    jupyter
-    matplotlib
-    plotnine
 
 
 [options.entry_points]

--- a/tutorial/README.rst
+++ b/tutorial/README.rst
@@ -108,15 +108,15 @@ uses it to illustrate a range of framework features.
       module to ‘report’ results, e.g. do post-processing, plotting, and other
       calculations (`westeros_report.ipynb`_).
 
-.. _westeros_baseline.ipynb:            https://github.com/iiasa/message_ix/blob/master/tutorial/westeros/westeros_baseline.ipynb
-.. _westeros_emissions_bounds.ipynb:    https://github.com/iiasa/message_ix/blob/master/tutorial/westeros/westeros_emissions_bounds.ipynb
-.. _westeros_emissions_taxes.ipynb:     https://github.com/iiasa/message_ix/blob/master/tutorial/westeros/westeros_emissions_taxes.ipynb
-.. _westeros_firm_capacity.ipynb:       https://github.com/iiasa/message_ix/blob/master/tutorial/westeros/westeros_firm_capacity.ipynb
-.. _westeros_flexible_generation.ipynb: https://github.com/iiasa/message_ix/blob/master/tutorial/westeros/westeros_flexible_generation.ipynb
-.. _westeros_seasonality.ipynb:         https://github.com/iiasa/message_ix/blob/master/tutorial/westeros/westeros_seasonality.ipynb
-.. _westeros_share_constraint.ipynb:    https://github.com/iiasa/message_ix/blob/master/tutorial/westeros/westeros_share_constraint.ipynb
-.. _westeros_fossil_resource.ipynb:     https://github.com/iiasa/message_ix/blob/master/tutorial/westeros/westeros_fossil_resource.ipynb
-.. _westeros_report.ipynb:              https://github.com/iiasa/message_ix/blob/master/tutorial/westeros/westeros_report.ipynb
+.. _westeros_baseline.ipynb:            https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/westeros/westeros_baseline.ipynb
+.. _westeros_emissions_bounds.ipynb:    https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/westeros/westeros_emissions_bounds.ipynb
+.. _westeros_emissions_taxes.ipynb:     https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/westeros/westeros_emissions_taxes.ipynb
+.. _westeros_firm_capacity.ipynb:       https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/westeros/westeros_firm_capacity.ipynb
+.. _westeros_flexible_generation.ipynb: https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/westeros/westeros_flexible_generation.ipynb
+.. _westeros_seasonality.ipynb:         https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/westeros/westeros_seasonality.ipynb
+.. _westeros_share_constraint.ipynb:    https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/westeros/westeros_share_constraint.ipynb
+.. _westeros_fossil_resource.ipynb:     https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/westeros/westeros_fossil_resource.ipynb
+.. _westeros_report.ipynb:              https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/westeros/westeros_report.ipynb
 
 
 
@@ -138,13 +138,13 @@ sector model, with several fossil and renewable power plant types.
    completed code for the exercises
    (`austria_multiple_policies-answers.ipynb`_).
 
-.. _austria.ipynb:                           https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria.ipynb
-.. _R_austria.ipynb:                         https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/R_austria.ipynb
-.. _austria_load_scenario.ipynb:             https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_load_scenario.ipynb
-.. _R_austria_load_scenario.ipynb:           https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/R_austria_load_scenario_R.ipynb
-.. _austria_single_policy.ipynb:             https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_single_policy.ipynb
-.. _austria_multiple_policies.ipynb:         https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_multiple_policies.ipynb
-.. _austria_multiple_policies-answers.ipynb: https://github.com/iiasa/message_ix/blob/master/tutorial/Austrian_energy_system/austria_multiple_policies-answers.ipynb
+.. _austria.ipynb:                           https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/Austrian_energy_system/austria.ipynb
+.. _R_austria.ipynb:                         https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/Austrian_energy_system/R_austria.ipynb
+.. _austria_load_scenario.ipynb:             https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/Austrian_energy_system/austria_load_scenario.ipynb
+.. _R_austria_load_scenario.ipynb:           https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/Austrian_energy_system/R_austria_load_scenario_R.ipynb
+.. _austria_single_policy.ipynb:             https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/Austrian_energy_system/austria_single_policy.ipynb
+.. _austria_multiple_policies.ipynb:         https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/Austrian_energy_system/austria_multiple_policies.ipynb
+.. _austria_multiple_policies-answers.ipynb: https://github.com/iiasa/message_ix/blob/v3.2.0/tutorial/Austrian_energy_system/austria_multiple_policies-answers.ipynb
 
 
 Code reference

--- a/tutorial/westeros/westeros_report.ipynb
+++ b/tutorial/westeros/westeros_report.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "## Reporting features in MESSAGEix\n",
     "\n",
-    "The reporting features in ``ixmp`` and ``message_ix`` are developed to support the complicated reporting and multiple workflows required by the IIASA Energy program for research projects involving large, detailed models such as the [MESSAGEix-GLOBIOM global model](https://docs.messageix.org/global/).\n",
+    "The reporting features in ``ixmp`` and ``message_ix`` are developed to support the complicated reporting and multiple workflows required by the IIASA ECE program for research projects involving large, detailed models such as the [MESSAGEix-GLOBIOM global model](https://docs.messageix.org/global/).\n",
     "While powerful enough for this purpose, they are also intended to be user-friendly, flexible, and customizable.\n",
     "\n",
     "The core class used for reporting is ``message_ix.Reporter``, which extends the class ``ixmp.Reporter``.\n",


### PR DESCRIPTION
- Update copyright year and program name
- Adjust for mypy
- [x] Move the [Release procedure](https://github.com/iiasa/message_ix/wiki/Release-procedure) from the wiki into the code/docs.
- [x] Increase minimum version of ixmp to 3.2.0 (once that is released).
