### PR TITLE
Install ixmp from GitHub master on RTD

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: lint
+name: Lint
 
 on:
   push:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,4 +71,4 @@ jobs:
         MESSAGE_IX_CI_USER: ${{ secrets.ENE_DATA_USER }}
         MESSAGE_IX_CI_PW: ${{ secrets.ENE_DATA_PASS }}
       working-directory: message_ix
-      run: pytest message_ix -m nightly --verbose
+      run: pytest message_ix -m nightly -rA --verbose

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: nightly
+name: Test MESSAGEix-GLOBIOM scenarios
 # This workflow is a stripped-down version of pytest.yaml, with multi-OS
 # features removed.
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,4 @@
-name: pytest
+name: Test
 
 on:
   push:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -149,7 +149,7 @@ jobs:
         # For test_cli.test_dl; see code in message_ix.cli.dl
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       working-directory: message_ix
-      run: pytest message_ix -m "not nightly" --verbose --cov-report=xml --color=yes
+      run: pytest message_ix -m "not nightly" -rA --verbose --cov-report=xml --color=yes
 
     - name: Run R CMD check
       run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,8 +3,7 @@ version: 2
 python:
   install:
   # Install ixmp from latest `master`
-  - method: pip
-    path: git+https://github.com/iiasa/ixmp.git@master#egg=ixmp
+  - requirements: ci/rtd-requirements.txt
   - method: pip
     path: .
     extra_requirements: [docs]

--- a/ci/rtd-requirements.txt
+++ b/ci/rtd-requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/iiasa/ixmp.git@master#egg=ixmp

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 # Use the fixtures test_mp, test_mp_props, and tmp_env from ixmp.testing
 pytest_plugins = ["ixmp.testing"]
@@ -13,3 +14,9 @@ def pytest_sessionstart(session):
     if "GITHUB_ACTIONS" in os.environ:
         message_ix.models.DEFAULT_CPLEX_OPTIONS["threads"] = 2
 
+
+def pytest_report_header(config, startdir):
+    """Add the message_ix import path to the pytest report header."""
+    import message_ix
+
+    return f"message_ix location: {Path(message_ix.__file__).parent}"

--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,15 @@
+import os
+
 # Use the fixtures test_mp, test_mp_props, and tmp_env from ixmp.testing
 pytest_plugins = ["ixmp.testing"]
+
+# Hooks
+
+
+def pytest_sessionstart(session):
+    """Use only 2 threads for CPLEX on GitHub Actions runners with 2 CPU cores."""
+    import message_ix.models
+
+    if "GITHUB_ACTIONS" in os.environ:
+        message_ix.models.DEFAULT_CPLEX_OPTIONS["threads"] = 2
+

--- a/message_ix/__init__.py
+++ b/message_ix/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-from ixmp import config
+from ixmp import ModelError, config
 from ixmp.model import MODELS
 from pkg_resources import DistributionNotFound, get_distribution
 
@@ -15,8 +15,9 @@ __all__ = [
     "MESSAGE",
     "MESSAGE_MACRO",
     "MODELS",
-    "Scenario",
+    "ModelError",
     "Reporter",
+    "Scenario",
     "config",
     "make_df",
 ]

--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -88,7 +88,7 @@ cfl                  0.0  0.1   10   900
 )
 
 
-def make_austria(mp, solve=False):
+def make_austria(mp, solve=False, quiet=True):
     """Return an :class:`message_ix.Scenario` for the Austrian energy system.
 
     This is the same model used in the ``austria.ipynb`` tutorial.
@@ -262,7 +262,7 @@ def make_austria(mp, solve=False):
     scen.set_as_default()
 
     if solve:
-        scen.solve()
+        scen.solve(quiet=quiet)
 
     return scen
 
@@ -413,6 +413,7 @@ def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
     scen.set_as_default()
 
     if solve:
+        solve_opts.setdefault("quiet", True)
         scen.solve(**solve_opts)
 
     scen.check_out(timeseries_only=True)
@@ -423,7 +424,7 @@ def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
     return scen
 
 
-def make_westeros(mp, emissions=False, solve=False):
+def make_westeros(mp, emissions=False, solve=False, quiet=True):
     """Return an :class:`message_ix.Scenario` for the Westeros model.
 
     This is the same model used in the ``westeros_baseline.ipynb`` tutorial.
@@ -585,6 +586,6 @@ def make_westeros(mp, emissions=False, solve=False):
         scen.commit("Added emissions sets/params to Westeros model.")
 
     if solve:
-        scen.solve()
+        scen.solve(quiet=quiet)
 
     return scen

--- a/message_ix/tests/conftest.py
+++ b/message_ix/tests/conftest.py
@@ -66,7 +66,7 @@ def dantzig_reporter(message_test_mp, ureg):
     scen = message_ix.Scenario(message_test_mp, **SCENARIO["dantzig"])
 
     if not scen.has_solution():
-        scen.solve()
+        scen.solve(quiet=True)
 
     rep = message_ix.Reporter.from_scenario(scen)
 

--- a/message_ix/tests/conftest.py
+++ b/message_ix/tests/conftest.py
@@ -7,14 +7,6 @@ from click.testing import CliRunner
 import message_ix
 from message_ix.testing import SCENARIO, make_dantzig
 
-# Hooks
-
-
-def pytest_report_header(config, startdir):
-    """Add the message_ix import path to the pytest report header."""
-    return "message_ix location: {}".format(Path(message_ix.__file__).parent)
-
-
 # Fixtures
 
 

--- a/message_ix/tests/test_feature_bound_activity_shares.py
+++ b/message_ix/tests/test_feature_bound_activity_shares.py
@@ -14,7 +14,7 @@ def calculate_activity(scen, tec="transport_from_seattle"):
 
 def test_add_bound_activity_up(message_test_mp):
     scen = Scenario(message_test_mp, **SCENARIO["dantzig"]).clone()
-    scen.solve()
+    scen.solve(quiet=True)
 
     # data for act bound
     exp = 0.5 * calculate_activity(scen).sum()
@@ -47,7 +47,7 @@ def test_add_bound_activity_up(message_test_mp):
 
 def test_add_bound_activity_up_all_modes(message_test_mp):
     scen = Scenario(message_test_mp, **SCENARIO["dantzig"]).clone()
-    scen.solve()
+    scen.solve(quiet=True)
 
     # data for act bound
     exp = 0.95 * calculate_activity(scen).sum()
@@ -146,7 +146,7 @@ def test_commodity_share_up(message_test_mp):
 
     # initial data
     scen = Scenario(message_test_mp, **SCENARIO["dantzig"]).clone()
-    scen.solve()
+    scen.solve(quiet=True)
     exp = 0.5
 
     # check shares orig, should be bigger than expected bound
@@ -288,7 +288,7 @@ def test_share_commodity_lo(message_test_mp):
 
 def test_add_share_mode_up(message_test_mp):
     scen = Scenario(message_test_mp, **SCENARIO["dantzig"]).clone()
-    scen.solve()
+    scen.solve(quiet=True)
 
     # data for share bound
     def calc_share(s):
@@ -330,7 +330,7 @@ def test_add_share_mode_up(message_test_mp):
 
 def test_add_share_mode_lo(message_test_mp):
     scen = Scenario(message_test_mp, **SCENARIO["dantzig"]).clone()
-    scen.solve()
+    scen.solve(quiet=True)
 
     # data for share bound
     def calc_share(s):

--- a/message_ix/tests/test_feature_price_commodity.py
+++ b/message_ix/tests/test_feature_price_commodity.py
@@ -1,8 +1,6 @@
-from subprocess import CalledProcessError
-
 import pytest
 
-from message_ix import Scenario
+from message_ix import ModelError, Scenario
 
 
 def model_setup(scen, var_cost=1):
@@ -37,7 +35,8 @@ def test_commodity_price_equality(test_mp):
     scen.commit("initialize test model with negative variable costs")
 
     # negative variable costs and supply >= demand causes an unbounded ray
-    pytest.raises(CalledProcessError, scen.solve)
+    with pytest.raises(ModelError, match="GAMS errored with return code 3"):
+        scen.solve(quiet=True)
 
     # use the commodity-balance equality feature
     scen.check_out()

--- a/message_ix/tests/test_feature_price_emission.py
+++ b/message_ix/tests/test_feature_price_emission.py
@@ -66,7 +66,7 @@ def test_no_constraint(test_mp):
     scen = Scenario(test_mp, MODEL, "no_constraint", version="new")
     model_setup(scen, [2020, 2030])
     scen.commit("initialize test scenario")
-    scen.solve()
+    scen.solve(quiet=True)
 
     # without emissions constraint, the zero-cost technology satisfies demand
     assert scen.var("OBJ")["lvl"] == 0

--- a/message_ix/tests/test_integration.py
+++ b/message_ix/tests/test_integration.py
@@ -38,7 +38,7 @@ def test_run_clone(tmpdir):
 
 def test_run_remove_solution(test_mp):
     # create a new instance of the transport problem and solve it
-    scen = make_dantzig(test_mp, solve=True)
+    scen = make_dantzig(test_mp, solve=True, quiet=True)
     assert np.isclose(scen.var("OBJ")["lvl"], 153.675)
 
     # check that re-solving the model will raise an error if a solution exists
@@ -56,7 +56,7 @@ def test_run_remove_solution(test_mp):
 
 
 def test_shift_first_model_year(test_mp):
-    scen = make_dantzig(test_mp, solve=True, multi_year=True)
+    scen = make_dantzig(test_mp, solve=True, multi_year=True, quiet=True)
 
     # assert that `historical_activity` is empty in the source scenario
     assert scen.par("historical_activity").empty
@@ -87,7 +87,7 @@ def assert_multi_db(mp1, mp2):
 def test_multi_db_run(tmpdir):
     # create a new instance of the transport problem and solve it
     mp1 = Platform(driver="hsqldb", path=tmpdir / "mp1")
-    scen1 = make_dantzig(mp1, solve=True)
+    scen1 = make_dantzig(mp1, solve=True, quiet=True)
 
     mp2 = Platform(driver="hsqldb", path=tmpdir / "mp2")
     # add other unit to make sure that the mapping is correct during clone

--- a/message_ix/tests/test_macro.py
+++ b/message_ix/tests/test_macro.py
@@ -44,7 +44,7 @@ class MockScenario:
 
 @pytest.fixture(scope="class")
 def westeros_solved(test_mp):
-    yield make_westeros(test_mp, solve=True)
+    yield make_westeros(test_mp, solve=True, quiet=True)
 
 
 @pytest.fixture(scope="class")
@@ -158,7 +158,7 @@ def test_init(message_test_mp):
     scen.check_out()
     MACRO.initialize(scen)
     scen.commit("foo")
-    scen.solve()
+    scen.solve(quiet=True)
 
     assert np.isclose(scen.var("OBJ")["lvl"], 153.675)
     assert "mapping_macro_sector" in scen.set_list()

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -42,7 +42,7 @@ def test_reporter_from_scenario(message_test_mp):
     # Varies between local & CI contexts
     # DEBUG may be due to reuse of test_mp in a non-deterministic order
     if not scen.has_solution():
-        scen.solve()
+        scen.solve(quiet=True)
 
     # IXMPReporter can be initialized on a MESSAGE Scenario
     rep_ix = ixmp_Reporter.from_scenario(scen)
@@ -90,7 +90,7 @@ def test_reporter_from_scenario(message_test_mp):
 
 
 def test_reporter_from_dantzig(test_mp):
-    scen = make_dantzig(test_mp, solve=True)
+    scen = make_dantzig(test_mp, solve=True, quiet=True)
 
     # Reporter.from_scenario can handle Dantzig example model
     rep = Reporter.from_scenario(scen)
@@ -100,7 +100,7 @@ def test_reporter_from_dantzig(test_mp):
 
 
 def test_reporter_from_westeros(test_mp):
-    scen = make_westeros(test_mp, emissions=True, solve=True)
+    scen = make_westeros(test_mp, emissions=True, solve=True, quiet=True)
 
     # Reporter.from_scenario can handle Westeros example model
     rep = Reporter.from_scenario(scen)

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -145,7 +145,9 @@ def test_reporter_from_westeros(test_mp):
     assert_allclose(obs, exp)
 
 
-def test_reporter_convert_pyam(dantzig_reporter, caplog, tmp_path):
+def test_reporter_convert_pyam(caplog, tmp_path, dantzig_reporter):
+    caplog.set_level(logging.INFO)
+
     rep = dantzig_reporter
     as_pyam = rep.get_comp("as_pyam")
 

--- a/message_ix/tests/test_testing.py
+++ b/message_ix/tests/test_testing.py
@@ -2,7 +2,7 @@ from message_ix.testing import make_austria
 
 
 def test_make_austria(test_mp):
-    make_austria(test_mp, solve=False)
+    make_austria(test_mp, solve=False, quiet=True)
 
     # commented: this is tested via austria_load_scenario.ipynb
     # scenario = make_austria(test_mp, solve=True)

--- a/message_ix/tests/test_util.py
+++ b/message_ix/tests/test_util.py
@@ -57,5 +57,5 @@ def test_testing_make_scenario(test_mp):
     assert isinstance(scen, Scenario)
 
     # Westeros model can be created
-    scen = make_westeros(test_mp, True)
+    scen = make_westeros(test_mp, solve=True)
     assert isinstance(scen, Scenario)


### PR DESCRIPTION
Other changes:
- Use more readable, upper-case display names for GitHub Actions workflows.
- Give the pytest `-rA` option to show verbose output for even passing tests.
- Move pytest hooks to the top-level conftest.py from the one in the tests/ directory; they are not picked up/run in the latter location.
- `ixmp.ModelError` (iiasa/ixmp#398) is now importable from the top level of `message_ix`; check for this in tests instead of `CalledProcessError`
- Use the `solve(quiet=True)` option added by iiasa/ixmp#399 throughout the test suite.

## How to review

Ensure that RTD builds complete successfully.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, CI only
- ~Update release notes.~ N/A, CI only