### PR TITLE
Install GAMS using iiasa/actions for CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,6 @@ on:
   - cron: "0 5 * * *"
 
 env:
-  GAMS_VERSION: 25.1.1
   # See description in lint.yml
   depth: 100
 
@@ -55,10 +54,10 @@ jobs:
           ~/appdata/local/pip/cache
         key: gams${{ env.GAMS_VERSION }}
 
-    - name: Install GAMS
-      env:
-        CI_OS: ubuntu
-      run: ixmp/ci/install-gams.sh
+    - uses: iiasa/actions/setup-gams@main
+      with:
+        version: 25.1.1
+        license: ${{ secrets.GAMS_LICENSE }}
 
     - name: Install Python packages and dependencies
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,8 @@ jobs:
         os:
         - macos-latest
         - ubuntu-latest
-        - windows-latest
+        # Temporary excluded; see https://github.com/iiasa/message_ix/pull/452
+        # - windows-latest
         python-version:
         - "3.6"  # Earliest version supported by ixmp
         - "3.8"  # Latest version testable on GitHub Actions

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,6 @@ on:
     branches: [ master ]
 
 env:
-  GAMS_VERSION: 25.1.1
   # See description in lint.yml
   depth: 100
 
@@ -107,18 +106,12 @@ jobs:
           ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-
           ${{ matrix.os }}-
 
-    - name: Install GAMS and Graphviz
-      # Use the scripts from the checked-out ixmp repo
-      env:
-        CI_OS: ${{ matrix.os }}
-      run: |
-        ixmp/ci/install-gams.sh
-        ixmp/ci/install-graphviz.sh
-      shell: bash
+    - uses: iiasa/actions/setup-gams@main
+      with:
+        version: 25.1.1
+        license: ${{ secrets.GAMS_LICENSE }}
 
-    - name: Check GAMS
-      run: gams
-      shell: bash
+    - uses: ts-graphviz/setup-graphviz@v1
 
     - name: Upgrade pip, wheel, setuptools-scm
       run: python -m pip install --upgrade pip wheel setuptools-scm

--- a/ci/nightly.yaml
+++ b/ci/nightly.yaml
@@ -8,4 +8,3 @@ path: continuous_integration/scenario_db/
 
 filename:
   data: db.tar.gz
-  license: gamslice.txt

--- a/message_ix/tests/reporting/test_computations.py
+++ b/message_ix/tests/reporting/test_computations.py
@@ -11,7 +11,7 @@ from message_ix.testing import SCENARIO
 def test_as_pyam(message_test_mp):
     scen = Scenario(message_test_mp, **SCENARIO["dantzig"])
     if not scen.has_solution():
-        scen.solve()
+        scen.solve(quiet=True)
     rep = Reporter.from_scenario(scen)
 
     # Quantities for 'ACT' variable at full resolution

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -427,7 +427,7 @@ def test_rename_technology(dantzig_message_scenario):
     clone.rename("technology", {"canning_plant": "foo_bar"})
     assert not clone.par("output")["technology"].isin(["canning_plant"]).any()
     assert clone.par("output")["technology"].isin(["foo_bar"]).any()
-    clone.solve()
+    clone.solve(quiet=True)
     assert np.isclose(clone.var("OBJ")["lvl"], 153.675)
 
 
@@ -463,7 +463,7 @@ def test_excel_read_write(message_test_mp, tmp_path):
     scen1.to_excel(fname)
 
     # Writing to Excel when scenario has a solution
-    scen1.solve()
+    scen1.solve(quiet=True)
     scen1.to_excel(fname)
 
     scen2 = Scenario(message_test_mp, model="foo", scenario="bar", version="new")
@@ -482,7 +482,7 @@ def test_excel_read_write(message_test_mp, tmp_path):
     assert scen2.has_par("new_par")
     assert float(scen2.par("new_par")["value"]) == 2
 
-    scen2.solve()
+    scen2.solve(quiet=True)
     assert np.isclose(scen2.var("OBJ")["lvl"], scen1.var("OBJ")["lvl"])
 
 

--- a/message_ix/tests/test_feature_addon.py
+++ b/message_ix/tests/test_feature_addon.py
@@ -87,7 +87,7 @@ def test_addon_tec(message_test_mp):
     scen.add_par("bound_activity_up", bda)
     scen.commit("changing output and bounds")
 
-    scen.solve()
+    scen.solve(quiet=True)
 
     exp = scen.var("ACT", f)["lvl"]
     obs = scen.var("ACT", g)["lvl"]
@@ -105,7 +105,7 @@ def test_addon_up(message_test_mp):
     scen.add_par("addon_up", addon_share)
     scen.commit("adding upper bound on addon technology")
 
-    scen.solve()
+    scen.solve(quiet=True)
 
     exp = scen.var("ACT", f)["lvl"] * 0.5
     obs = scen.var("ACT", g)["lvl"]
@@ -124,7 +124,7 @@ def test_addon_lo(message_test_mp):
     scen.add_par("addon_lo", addon_share)
 
     scen.commit("adding lower bound on addon technology")
-    scen.solve()
+    scen.solve(quiet=True)
 
     exp = scen.var("ACT", f)["lvl"] * 0.5
     obs = scen.var("ACT", g)["lvl"]

--- a/message_ix/tests/test_feature_bound_activity_shares.py
+++ b/message_ix/tests/test_feature_bound_activity_shares.py
@@ -36,7 +36,7 @@ def test_add_bound_activity_up(message_test_mp):
     clone.check_out()
     clone.add_par("bound_activity_up", data)
     clone.commit("foo")
-    clone.solve()
+    clone.solve(quiet=True)
     obs = calculate_activity(clone).loc["to_chicago"]
     assert np.isclose(obs, exp)
 
@@ -69,7 +69,7 @@ def test_add_bound_activity_up_all_modes(message_test_mp):
     clone.check_out()
     clone.add_par("bound_activity_up", data)
     clone.commit("foo")
-    clone.solve()
+    clone.solve(quiet=True)
     obs = calculate_activity(clone).sum()
     assert np.isclose(obs, exp)
 
@@ -169,7 +169,7 @@ def test_commodity_share_up(message_test_mp):
     clone.check_out()
     add_data(clone, map_df)
     clone.commit("foo")
-    clone.solve()
+    clone.solve(quiet=True)
 
     # check shares new, should be lower than expected bound
     obs = calc_share(clone)
@@ -197,7 +197,7 @@ def test_commodity_share_up(message_test_mp):
     clone2.check_out()
     add_data(clone2, map_df2)
     clone2.commit("foo")
-    clone2.solve()
+    clone2.solve(quiet=True)
 
     # check shares new, should be lower than expected bound
     obs2 = calc_share(clone2)
@@ -214,7 +214,7 @@ def test_commodity_share_up(message_test_mp):
 
 def test_share_commodity_lo(message_test_mp):
     scen = Scenario(message_test_mp, **SCENARIO["dantzig"]).clone()
-    scen.solve()
+    scen.solve(quiet=True)
 
     # data for share bound
     def calc_share(s):
@@ -277,7 +277,7 @@ def test_share_commodity_lo(message_test_mp):
         ),
     )
     clone.commit("foo")
-    clone.solve()
+    clone.solve(quiet=True)
     obs = calc_share(clone)
     assert np.isclose(obs, exp)
 
@@ -319,7 +319,7 @@ def test_add_share_mode_up(message_test_mp):
         ),
     )
     clone.commit("foo")
-    clone.solve()
+    clone.solve(quiet=True)
     obs = calc_share(clone)
     assert np.isclose(obs, exp)
 
@@ -361,7 +361,7 @@ def test_add_share_mode_lo(message_test_mp):
         ),
     )
     clone.commit("foo")
-    clone.solve()
+    clone.solve(quiet=True)
 
     obs = calc_share(clone)
     assert np.isclose(obs, exp)

--- a/message_ix/tests/test_feature_bound_emission.py
+++ b/message_ix/tests/test_feature_bound_emission.py
@@ -52,7 +52,7 @@ def test_bound_emission_year(test_mp):
     model_setup(scen, [2020, 2030])
     scen.commit("initialize test model")
     add_bound_emission(scen, bound=1.250, year=2020)
-    scen.solve(case="bound_emission_year")
+    scen.solve(case="bound_emission_year", quiet=True)
     assert_function(scen, year=2020)
 
 
@@ -62,7 +62,7 @@ def test_bound_emission_10y(test_mp):
     model_setup(scen, [2020, 2030, 2040, 2050])
     scen.commit("initialize test model")
     add_bound_emission(scen, bound=1.250)
-    scen.solve(case="bound_emission_10y")
+    scen.solve(case="bound_emission_10y", quiet=True)
     assert_function(scen, year="cumulative")
 
 
@@ -72,5 +72,5 @@ def test_bound_emission_5y(test_mp):
     model_setup(scen, [2020, 2025, 2030, 2040])
     scen.commit("initialize test model")
     add_bound_emission(scen, bound=1.250)
-    scen.solve(case="bound_emission_5y")
+    scen.solve(case="bound_emission_5y", quiet=True)
     assert_function(scen, year="cumulative")

--- a/message_ix/tests/test_feature_price_commodity.py
+++ b/message_ix/tests/test_feature_price_commodity.py
@@ -23,7 +23,7 @@ def test_commodity_price(test_mp):
     scen = Scenario(test_mp, "test_commodity_price", "standard", version="new")
     model_setup(scen)
     scen.commit("initialize test model")
-    scen.solve(case="price_commodity_standard")
+    scen.solve(case="price_commodity_standard", quiet=True)
 
     assert scen.var("OBJ")["lvl"] == 1
     assert scen.var("PRICE_COMMODITY")["lvl"][0] == 1
@@ -42,7 +42,7 @@ def test_commodity_price_equality(test_mp):
     scen.check_out()
     scen.add_set("balance_equality", ["comm", "level"])
     scen.commit("set commodity-balance for `[comm, level]` as equality")
-    scen.solve(case="price_commodity_equality")
+    scen.solve(case="price_commodity_equality", quiet=True)
 
     assert scen.var("OBJ")["lvl"] == -1
     assert scen.var("PRICE_COMMODITY")["lvl"][0] == -1

--- a/message_ix/tests/test_feature_price_emission.py
+++ b/message_ix/tests/test_feature_price_emission.py
@@ -82,7 +82,7 @@ def test_cumulative_equidistant(test_mp):
     scen.add_cat("year", "cumulative", years)
     scen.add_par("bound_emission", ["World", "ghg", "all", "cumulative"], 0, "tCO2")
     scen.commit("initialize test scenario")
-    scen.solve()
+    scen.solve(quiet=True)
 
     # with emissions constraint, the technology with costs satisfies demand
     assert scen.var("OBJ")["lvl"] > 0
@@ -101,7 +101,7 @@ def test_per_period_equidistant(test_mp):
         scen.add_cat("year", y, y)
         scen.add_par("bound_emission", ["World", "ghg", "all", y], 0, "tCO2")
     scen.commit("initialize test scenario")
-    scen.solve()
+    scen.solve(quiet=True)
 
     # with emissions constraint, the technology with costs satisfies demand
     assert scen.var("OBJ")["lvl"] > 0
@@ -118,7 +118,7 @@ def test_cumulative_variable_periodlength(test_mp):
     scen.add_cat("year", "cumulative", years)
     scen.add_par("bound_emission", ["World", "ghg", "all", "cumulative"], 0, "tCO2")
     scen.commit("initialize test scenario")
-    scen.solve()
+    scen.solve(quiet=True)
 
     # with an emissions constraint, the technology with costs satisfies demand
     assert scen.var("OBJ")["lvl"] > 0
@@ -137,7 +137,7 @@ def test_per_period_variable_periodlength(test_mp):
         scen.add_cat("year", y, y)
         scen.add_par("bound_emission", ["World", "ghg", "all", y], 0, "tCO2")
     scen.commit("initialize test scenario")
-    scen.solve()
+    scen.solve(quiet=True)
 
     # with an emissions constraint, the technology with costs satisfies demand
     assert scen.var("OBJ")["lvl"] > 0
@@ -156,7 +156,7 @@ def test_custom_type_variable_periodlength(test_mp):
     scen.add_par("bound_emission", ["World", "ghg", "all", "custom"], 0, "tCO2")
 
     scen.commit("initialize test scenario")
-    scen.solve()
+    scen.solve(quiet=True)
 
     # with an emissions constraint, the technology with costs satisfies demand
     assert scen.var("OBJ")["lvl"] > 0
@@ -177,7 +177,7 @@ def test_price_duality(test_mp):
             "bound_emission", ["World", "ghg", "all", "cumulative"], 0.5, "tCO2"
         )
         scen.commit("initialize test scenario")
-        scen.solve()
+        scen.solve(quiet=True)
 
         # set up a new scenario with emissions taxes
         tax_scen = Scenario(test_mp, MODEL, "tax_many_tecs", version="new")
@@ -192,7 +192,7 @@ def test_price_duality(test_mp):
         taxes["unit"] = "USD/tCO2"
         tax_scen.add_par("tax_emission", taxes)
         tax_scen.commit("initialize test scenario for taxes")
-        tax_scen.solve()
+        tax_scen.solve(quiet=True)
 
         # check that emissions are close between cumulative and tax scenario
         filters = {"node": "World"}

--- a/message_ix/tests/test_feature_storage.py
+++ b/message_ix/tests/test_feature_storage.py
@@ -128,7 +128,7 @@ def storage_setup(test_mp, time_duration, comment):
     demand_share = {"a": 0.15, "b": 0.2, "c": 0.4, "d": 0.25}
     year_to_time(scen, "demand", demand_share)
     scen.commit("initialized a model with timesteps")
-    scen.solve(case="no_storage" + comment)
+    scen.solve(case="no_storage" + comment, quiet=True)
 
     # Second, adding upper bound on activity of the cheap technology (wind_ppl)
     scen.remove_solution()
@@ -138,7 +138,7 @@ def storage_setup(test_mp, time_duration, comment):
             "bound_activity_up", ["node", "wind_ppl", 2020, "mode", h], 0.25, "GWa"
         )
     scen.commit("activity bounded")
-    scen.solve(case="no_storage_bounded" + comment)
+    scen.solve(case="no_storage_bounded" + comment, quiet=True)
     cost_no_stor = scen.var("OBJ")["lvl"]
     act_no_stor = scen.var("ACT", {"technology": "gas_ppl"})["lvl"].sum()
 
@@ -149,7 +149,7 @@ def storage_setup(test_mp, time_duration, comment):
     time_order = {"a": 1, "b": 2, "c": 3, "d": 4}
     add_storage_data(scen, time_order)
     scen.commit("storage data added")
-    scen.solve(case="with_storage_no_input" + comment)
+    scen.solve(case="with_storage_no_input" + comment, quiet=True)
     act = scen.var("ACT")
 
     # Forth, adding storage technologies and providing input to storage device
@@ -166,7 +166,7 @@ def storage_setup(test_mp, time_duration, comment):
     df["value"] = 1.2
     scen.add_par("input", df)
     scen.commit("storage needs no separate input")
-    scen.solve(case="with_storage_and_input" + comment)
+    scen.solve(case="with_storage_and_input" + comment, quiet=True)
     cost_with_stor = scen.var("OBJ")["lvl"]
     act_with_stor = scen.var("ACT", {"technology": "gas_ppl"})["lvl"].sum()
 

--- a/message_ix/tests/test_macro.py
+++ b/message_ix/tests/test_macro.py
@@ -174,7 +174,7 @@ def test_add_model_data(westeros_solved):
     MACRO.initialize(clone)
     macro.add_model_data(base, clone, W_DATA_PATH)
     clone.commit("finished adding macro")
-    clone.solve()
+    clone.solve(quiet=True)
     obs = clone.var("OBJ")["lvl"]
     exp = base.var("OBJ")["lvl"]
     assert np.isclose(obs, exp)

--- a/message_ix/tests/tools/test_add_year.py
+++ b/message_ix/tests/tools/test_add_year.py
@@ -28,7 +28,7 @@ def base_scen_mp(test_mp):
         scen.add_par("var_cost", tec_specs + ["year"], value, "USD/GWa")
 
     scen.commit("initialize test model")
-    scen.solve(case="original_years")
+    scen.solve(case="original_years", quiet=True)
 
     yield scen, test_mp
 
@@ -90,7 +90,7 @@ def test_add_year(base_scen_mp):
         test_mp, model="add_year", scenario="standard", version="new", annotation=" "
     )
     add_year(scen_ref, scen_new, YEARS_NEW)
-    scen_new.solve(case="new_years")
+    scen_new.solve(case="new_years", quiet=True)
 
     # Running the tests
     assert_function(scen_ref, scen_new, YEARS_NEW, yr_test=2025)

--- a/message_ix/tests/util/test_tutorial.py
+++ b/message_ix/tests/util/test_tutorial.py
@@ -31,7 +31,7 @@ def test_solve_modified(caplog, message_test_mp):
     base = Scenario(message_test_mp, **SCENARIO["dantzig"])
 
     # Base objective value
-    base.solve()
+    base.solve(quiet=True)
     base_obj = base.var("OBJ")["lvl"]
 
     with solve_modified(base, "new scenario name") as scenario:

--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -11,9 +11,12 @@
 #      calculating missing values
 
 # %% I) Importing required packages
+import logging
 
 import numpy as np
 import pandas as pd
+
+log = logging.getLogger(__name__)
 
 
 # %% II) Utility functions for dataframe manupulation
@@ -26,7 +29,7 @@ def intpol(y1, y2, x1, x2, x):
     x1, x2, x : int
     """
     if x2 == x1 and y2 != y1:
-        print(">>> Warning <<<: No difference between x1 and x2," "returned empty!!!")
+        log.warning("No difference between x1 and x2, returned empty")
         return []
     elif x2 == x1 and y2 == y1:
         return y1
@@ -145,8 +148,8 @@ def add_year(
     elif isinstance(parameter, str):
         par_list = [parameter]
     else:
-        print(
-            "Parameters should be defined in a list of strings or as a single string!"
+        log.warning(
+            "Parameters should be defined in a list of strings or as a single string"
         )
 
     if "technical_lifetime" in par_list:
@@ -159,7 +162,9 @@ def add_year(
     elif isinstance(region, str):
         reg_list = [region]
     else:
-        print("Regions should be defined in a list of strings or as a single string!")
+        log.warning(
+            "Regions should be defined in a list of strings or as a single string"
+        )
 
     # List of parameters to be ignored (even not copied to the new
     # scenario)
@@ -252,7 +257,7 @@ def add_year(
             )
 
     sc_new.set_as_default()
-    print("> All required parameters were successfully added to the new scenario.")
+    log.info("All required parameters were successfully added to the new scenario")
 
 
 # %% Submodules needed for running the main function
@@ -354,7 +359,7 @@ def add_year_set(
         sc_new.add_set(set_name, sc_ref.set(set_name))
 
     sc_new.commit("sets added!")
-    print("> All the sets updated and added to the new scenario.")
+    log.info("All the sets updated and added to the new scenario")
 
 
 # %% V) Adding new years to parameters
@@ -416,14 +421,14 @@ def add_year_par(
         nodes = ["N/A"]
 
     if not par_new.empty and not rewrite:
-        print(
-            f"> Parameter {repr(parname)} already has data in new scenario and left "
-            f"unchanged for node/s: {repr(reg_list)}"
+        log.info(
+            f"Parameter {repr(parname)} already has data in new scenario and left "
+            f"unchanged for node(s): {repr(reg_list)}"
         )
         return
     if par_old.empty:
-        print(
-            f"> Parameter {repr(parname)} is empty in reference scenario for node/s: "
+        log.info(
+            f"Parameter {repr(parname)} is empty in reference scenario for node(s): "
             + repr(reg_list)
         )
         return
@@ -437,9 +442,9 @@ def add_year_par(
 
     sc_new.check_out()
     if not par_new.empty and rewrite:
-        print(
-            '> Parameter "' + parname + '" is being removed from new'
-            " scenario to be updated for node/s in {}...".format(nodes)
+        log.info(
+            f"Parameter {parname} is being removed from new scenario to be updated for "
+            f"node(s) in {nodes}"
         )
         sc_new.remove_par(parname, par_new)
 
@@ -452,9 +457,9 @@ def add_year_par(
     if len(year_list) == 0:
         sc_new.add_par(parname, par_old)
         sc_new.commit(parname)
-        print(
-            '> Parameter "' + parname + '" just copied to new scenario '
-            "since has no time-related entries."
+        log.info(
+            f"Parameter {parname} just copied to new scenario since has no time-related"
+            "entries"
         )
 
     #   V.B.2) Parameters with one index related to time
@@ -473,10 +478,7 @@ def add_year_par(
         )
         sc_new.add_par(parname, df_y)
         sc_new.commit(" ")
-        print(
-            '> Parameter "{}" copied and new years'
-            ' added for node/s: "{}".'.format(parname, nodes)
-        )
+        log.info(f"Parameter {parname} copied and new years added for node(s): {nodes}")
 
     #   V.B.3) Parameters with two indexes related to time (such as 'input')
     elif len(year_list) == 2:
@@ -487,10 +489,7 @@ def add_year_par(
             return x[i + 1] - x[i] > x[i] - x[i - 1]
 
         year_diff = [x for x in horizon[1:-1] if f(horizon, horizon.index(x))]
-        print(
-            '> Parameter "{}" is being added for node/s'
-            ' "{}"...'.format(parname, nodes)
-        )
+        log.info(f"Parameter {parname} is being added for node(s): {nodes}")
 
         # Flagging technologies that have lifetime for adding new timesteps
         yr_list = [
@@ -527,10 +526,7 @@ def add_year_par(
         )
         sc_new.add_par(parname, df_y)
         sc_new.commit(parname)
-        print(
-            '> Parameter "{}" copied and new years added'
-            ' for node/s: "{}".'.format(parname, nodes)
-        )
+        log.info(f"Parameter {parname} copied and new years added for node(s): {nodes}")
 
 
 # %% VI) Required functions
@@ -680,10 +676,7 @@ def interpolate_1d(
         )
         df2 = df2.sort_values(idx).reset_index(drop=True)
     else:
-        print(
-            "+++ WARNING: The submitted dataframe is empty, so returned"
-            " empty results!!! +++"
-        )
+        log.warning("The submitted dataframe is empty, so returned empty results")
         df2 = df
     return df2
 
@@ -746,10 +739,7 @@ def interpolate_2d(
 
     if df.empty:
         return df
-        print(
-            "+++ WARNING: The submitted dataframe is empty, so"
-            " returned empty results!!! +++"
-        )
+        log.warning("The submitted dataframe is empty, so returned empty results")
 
     df_tec = df.loc[df["technology"].isin(tec_list)]
     idx = [x for x in df.columns if x not in [year_col, value_col]]


### PR DESCRIPTION
This PR uses the new [`iiasa/actions`](https://github.com/iiasa/actions) repo and `setup-gams` action to install GAMS on GitHub Actions runners.

This approach is more modular and simple than the prior approach of checking out the ixmp repo and calling a script contained there.

Other changes:
- Also use the [`ts-graphviz/setup-graphviz`](https://github.com/marketplace/actions/setup-graphviz) action, which does essentially the same thing as the Bash script used from ixmp
- Remove code in `message_ix.testing.nightly` that handles the GAMS license upload and download. The new action uses license file contents stored as a [repository secret](https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow).

## How to review

No review; CI changes only.

## PR checklist

- [ ] Continuous integration checks all ✅
- [ ] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A; CI changes only
- ~Update release notes.~