### PR TITLE
Fix bug in years_active() function

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :pull:`456`: Fix bug in :func:`.years_active` to use the lifetime corresponding to the year_vintage for which the active years are being retrieved.
 - :pull:`408`: Add a PowerPoint document usable to generate the RES diagrams for the Westeros tutorials.
 - :pull:`460`: Expand documentation :doc:`install` for installing GAMS under macOS.
 - :pull:`365`: Add new Westeros :doc:`tutorial <tutorials>` on add-on technologies.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,7 +4,7 @@ Next release
 All changes
 -----------
 
-- :pull:`456`: Fix bug in :func:`.years_active` to use the lifetime corresponding to the year_vintage for which the active years are being retrieved.
+- :pull:`456`: Fix bug in :meth:`.years_active` to use the lifetime corresponding to the vintage year for which the active years are being retrieved.
 - :pull:`408`: Add a PowerPoint document usable to generate the RES diagrams for the Westeros tutorials.
 - :pull:`460`: Expand documentation :doc:`install` for installing GAMS under macOS.
 - :pull:`365`: Add new Westeros :doc:`tutorial <tutorials>` on add-on technologies.

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -487,8 +487,8 @@ class Scenario(ixmp.Scenario):
         list of int
         """
         # Handle arguments
-        filters = dict(node_loc=[node], technology=[tec])
         yv = int(yr_vtg)
+        filters = dict(node_loc=[node], technology=[tec], year_vtg=[yv])
 
         # Lifetime of the technology at the node
         lt = self.par("technical_lifetime", filters=filters).at[0, "value"]

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -336,8 +336,8 @@ def test_years_active(test_mp):
     result = scen.years_active("foo", "bar", years[1])
 
     # Correct return type
-    assert isinstance(years, list)
-    assert isinstance(years[0], int)
+    assert isinstance(result, list)
+    assert isinstance(result[0], int)
 
     # Years 1995 through 2020
     npt.assert_array_equal(result, years[1:-1])
@@ -404,11 +404,10 @@ def test_years_active_extended2(test_mp):
     )
 
     result = scen.years_active("foo", "bar", years[-2])
-    print("Results for", years[-2], "years:", result)
 
     # Correct return type
-    assert isinstance(years, list)
-    assert isinstance(years[0], int)
+    assert isinstance(result, list)
+    assert isinstance(result[0], int)
 
     # Years 2020
     npt.assert_array_equal(result, years[-2])

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -403,8 +403,8 @@ def test_years_active_extended2(test_mp):
         ),
     )
 
-    result = scen.years_active("foo", "bar",  years[-2])
-    print('Results for', years[-2], 'years:', result)
+    result = scen.years_active("foo", "bar", years[-2])
+    print("Results for", years[-2], "years:", result)
 
     # Correct return type
     assert isinstance(years, list)


### PR DESCRIPTION
This PR ensures that the years_active() function retrieves the lifetime that corresponds to the vintage for which the active years are being retrieved, and not the first in the list.

## How to review

- Ensure the new tests work.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
<!--
The following items are all *required* if the PR results in changes to user-
facing behaviour, e.g. new features or fixes to existing behaviour. They are
*optional* if the changes are solely to documentation, CI configuration, etc.

In ambiguous cases, strike them out and add a short explanation, e.g.

- ~Add or expand tests.~ No change in behaviour, simply refactoring.
-->
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
