### PR TITLE
Set .gitattributes for RELEASE_NOTES.rst

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Reduce the number of merge conflicts
+RELEASE_NOTES.rst merge=union

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -7,6 +7,7 @@ on:
     branches: [ master ]
 
 env:
+  GAMS_VERSION: 25.1.1
   # See description in lint.yml
   depth: 100
 
@@ -73,6 +74,7 @@ jobs:
       shell: bash
 
     - uses: r-lib/actions/setup-r@master
+      id: setup-r
 
     - name: Use OpenJDK 14 (macOS only)
       # Using the default OpenJDK 1.8 on the macos-latest runner produces
@@ -91,14 +93,15 @@ jobs:
           ~/Library/Caches/pip
           ~/appdata/local/pip/cache
           ${{ env.R_LIBS_USER }}
-        key: ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-py${{ matrix.python-version }}
+        key: ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-py${{ matrix.python-version }}-R${{ steps.setup-r.outputs.installed-r-version }}
         restore-keys: |
+          ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-py${{ matrix.python-version }}-
           ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-
           ${{ matrix.os }}-
 
     - uses: iiasa/actions/setup-gams@main
       with:
-        version: 25.1.1
+        version: ${{ env.GAMS_VERSION }}
         license: ${{ secrets.GAMS_LICENSE }}
 
     - uses: ts-graphviz/setup-graphviz@v1

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -123,9 +123,8 @@ jobs:
         remotes::install_cran(
           c("dplyr", "IRkernel", "reticulate"),
           dependencies = TRUE,
-          force = TRUE,
+          # force = TRUE,
         )
-        print(installed.packages())
         IRkernel::installspec()
       shell: Rscript {0}
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,11 +29,6 @@ jobs:
         # build environment, currently out of scope for the message_ix project.
         # - "3.10.0-alpha.1"  # Development version
 
-        exclude:
-        # See https://github.com/iiasa/ixmp/issues/360
-        - os: windows-latest
-          python-version: "3.6"
-
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/doc/rmessageix.rst
+++ b/doc/rmessageix.rst
@@ -13,7 +13,7 @@ Once installed, use reticulate to import the Python packages:
 
    library(reticulate)
    ixmp <- import("ixmp")
-   ixmp <- import("message_ix")
+   message_ix <- import("message_ix")
 
 This creates two global variables, ``ixmp`` and ``message_ix``, that can be used much like the Python modules:
 

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -45,12 +45,29 @@ tutorials = [
     ((AT, "austria_multiple_policies-answers"), [], {}),
     ((AT, "austria_load_scenario"), [], {}),
     # R tutorials / IR kernel
-    ((AT, "R_austria"), [], dict(kernel="IR")),
-    ((AT, "R_austria_load_scenario"), [], dict(kernel="IR")),
+    pytest.param(
+        (AT, "R_austria"),
+        [],
+        dict(kernel="IR"),
+        marks=pytest.mark.skipif(
+            sys.version_info[1] <= 6 and sys.platform != "linux",
+            reason="R/reticulate link fails on GitHub Actions workers for Python 3.6",
+        ),
+    ),
+    pytest.param(
+        (AT, "R_austria_load_scenario"),
+        [],
+        dict(kernel="IR"),
+        marks=pytest.mark.skipif(
+            sys.version_info[1] <= 6 and sys.platform != "linux",
+            reason="R/reticulate link fails on GitHub Actions workers for Python 3.6",
+        ),
+    ),
 ]
 
-# Short, readable IDs for the tests
-ids = [arg[0][-1] for arg in tutorials]
+# Short, readable IDs for the tests. Use getattr() to unpack the values from
+# pytest.param()
+ids = [getattr(arg, "values", arg)[0][-1] for arg in tutorials]
 
 # List of data files required to run tutorials
 data_files = [


### PR DESCRIPTION
This copies an approach used in xarray: https://github.com/pydata/xarray/blob/master/.gitattributes

- We often need to rebase branches to resolve merge conflicts in the release notes. Sometimes this is the *only* conflict.
- This attribute causes git to use a different merge strategy, for this file only: including lines from both branches.
- This will usually have the intended effect. The order of the lines may be unpredictable, but the order is not super important.

## How to review

No review; CI changes only.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A; CI changes only.
- ~Update release notes.~