### PR TITLE
Install 3rd party type stubs for mypy

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -64,7 +64,7 @@ jobs:
       # Point to ixmp code for its type hints, without installing
       env:
         MYPYPATH: "../ixmp/"
-      # Also install packages that provide type hints
+      # Also install type stubs and full packages that provide type hints
       run: |
-        pip install mypy genno sphinx
+        pip install mypy genno sphinx types-pkg_resources types-requests types-PyYAML
         mypy .


### PR DESCRIPTION
As part of #327, the mypy step of the lint workflow began to fail.

This is because mypy 0.900 et seq. were released; in these versions (unlike mypy 0.8xx), type stubs for 3rd-party packages are not bundled and must be installed separately.

This PR adds these to lint.yaml:

- types-requests
- types-PyYAML
- types-pkg_resources

## How to review

No review/FYI only: changes to CI.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, CI only
- ~Update release notes.~