### PR TITLE
Ensure `years_active()` uses sorted results

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,18 +4,8 @@ Next release
 All changes
 -----------
 
+- Update :meth:`.years_active` to use sorted results (:pull:`491`).
 - Adjust the Westeros reporting tutorial to pyam 1.0 deprecations (:pull:`492`).
-
-
-.. _v3.4.0:
-
-v3.4.0 (2021-MM-DD)
-===================
-
-All changes
------------
-
-- Update `years_active()` to use sorted results (:pull:`491`).
 
 .. _v3.3.0:
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,6 +7,16 @@ All changes
 - Adjust the Westeros reporting tutorial to pyam 1.0 deprecations (:pull:`492`).
 
 
+.. _v3.4.0:
+
+v3.4.0 (2021-MM-DD)
+===================
+
+All changes
+-----------
+
+- Update `years_active()` to use sorted results (:pull:`491`).
+
 .. _v3.3.0:
 
 v3.3.0 (2021-05-28)

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -494,7 +494,7 @@ class Scenario(ixmp.Scenario):
         lt = self.par("technical_lifetime", filters=filters).at[0, "value"]
 
         # Duration of periods
-        data = self.par("duration_period").sort_values(by='year')
+        data = self.par("duration_period").sort_values(by="year")
         # Cumulative sum for periods including the vintage period
         data["age"] = data.where(data.year >= yv, 0)["value"].cumsum()
 

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -494,7 +494,7 @@ class Scenario(ixmp.Scenario):
         lt = self.par("technical_lifetime", filters=filters).at[0, "value"]
 
         # Duration of periods
-        data = self.par("duration_period")
+        data = self.par("duration_period").sort_values(by='year')
         # Cumulative sum for periods including the vintage period
         data["age"] = data.where(data.year >= yv, 0)["value"].cumsum()
 

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -413,6 +413,39 @@ def test_years_active_extended2(test_mp):
     npt.assert_array_equal(result, years[-2])
 
 
+def test_years_active_extend3(test_mp):
+    test_mp.add_unit("year")
+    scen = Scenario(test_mp, **SCENARIO["dantzig"], version="new")
+    scen.add_set("node", "foo")
+    scen.add_set("technology", "bar")
+
+    # Periods of uneven length
+    years = [1990, 1995, 2000, 2005, 2010, 2020, 2030]
+
+    scen.add_horizon(year=years, firstmodelyear=2010)
+
+    scen.add_set("year", [1992])
+    scen.add_par("duration_period", "1992", 2, "y")
+    scen.add_par("duration_period", "1995", 3, "y")
+
+    scen.add_par(
+        "technical_lifetime",
+        pd.DataFrame(
+            dict(
+                node_loc="foo",
+                technology="bar",
+                unit="year",
+                value=[20],
+                year_vtg=1990,
+            ),
+        ),
+    )
+
+    obs = scen.years_active("foo", "bar", 1990)
+
+    assert obs == [1990, 1992, 1995, 2000, 2005]
+
+
 def test_new_timeseries_long_name64(message_test_mp):
     scen = Scenario(message_test_mp, **SCENARIO["dantzig multi-year"])
     scen = scen.clone(keep_solution=False)


### PR DESCRIPTION
This PR ensures that the function`years_active()` uses sorted results from the parameter `duration_period`.

The observed issue of `years_active()` returning incorrect results as described in #485 is herewith resolved.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Update release notes.
