### PR TITLE
Adjust for genno 1.6, pyam 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ tests/data/nightly
 .benchmarks
 .coverage*
 .mypy_cache
+prof/
 .pytest_cache
 coverage.xml
 htmlcov

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,8 +1,11 @@
-.. Next release
-.. ============
+Next release
+============
 
-.. All changes
-.. -----------
+All changes
+-----------
+
+- Adjust the Westeros reporting tutorial to pyam 1.0 deprecations (:pull:`492`).
+
 
 .. _v3.3.0:
 

--- a/message_ix/reporting/computations.py
+++ b/message_ix/reporting/computations.py
@@ -36,7 +36,7 @@ def plot_cumulative(x, y, labels):
     d0_labels = set(x.coords[d0].values) | set(y.coords[d0].values)
     assert (
         len(d0_labels) == 1
-    ), "non-unique values {repr(d0_labels)} for dimension {repr(d0)}"
+    ), f"non-unique values {repr(d0_labels)} for dimension {repr(d0)}"
 
     axes_properties = dict(
         title=f"{d0_labels.pop()} {labels[0].title()}",

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -54,10 +54,10 @@ def test_reporter_from_scenario(message_test_mp):
     assert len(rep.graph["all"]) == 123
 
     # Quantities have short dimension names
-    assert "demand:n-c-l-y-h" in rep.graph
+    assert "demand:n-c-l-y-h" in rep
 
     # Aggregates are available
-    assert "demand:n-l-h" in rep.graph
+    assert "demand:n-l-h" in rep
 
     # Quantities contain expected data
     dims = dict(coords=["chicago new-york topeka".split()], dims=["n"])

--- a/tutorial/westeros/westeros_report.ipynb
+++ b/tutorial/westeros/westeros_report.ipynb
@@ -760,7 +760,7 @@
     "        scenario='baseline',\n",
     "        region='Westeros'\n",
     "    )\n",
-    "    .line_plot()\n",
+    "    .plot()\n",
     ")"
    ]
   },


### PR DESCRIPTION
- As detected in #491:
  - Improve performance of generating the full-scale MESSAGEix reporting graph.

    This was a performance regression introduced in genno 1.5.x (khaeru/genno#42); now fixed by khaeru/genno#47 / version 1.6.0, and it cause some tutorial notebooks to exceed the timeout limit of 10 seconds per cell.
  - Use `in rep` not `in rep.graph` for more flexible `genno.Computer.__contains__()`.
- Adjust to pyam 1.0.

  In particular, IamDataFrame.line_plot() was marked deprecated in 0.10 (IAMconsortium/pyam#473) and then removed as of 1.0, without an intervening major release. This broke the westeros_report.ipynb tutorial.

## How to review

No review: internal/test suite only.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~
- ~Update release notes.~