### PR TITLE
Test & improve perfomance in .tools.add_year

### DIFF
--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -10,8 +10,8 @@
 #  VI. Two utility functions, interpolate_1d() and interpolate_2d(), for
 #      calculating missing values
 
-# %% I) Importing required packages
 import logging
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -531,15 +531,15 @@ def add_year_par(
 
 # %% VI) Required functions
 def interpolate_1d(
-    df,
-    yrs_new,
-    horizon,
-    year_col,
-    value_col="value",
-    extrapolate=False,
-    extrapol_neg=None,
-    bound_extend=True,
-):
+    df: pd.DataFrame,
+    yrs_new: List[int],
+    horizon: List[int],
+    year_col: str,
+    value_col: str = "value",
+    extrapolate: bool = False,
+    extrapol_neg: bool = None,
+    bound_extend: bool = True,
+) -> pd.DataFrame:
     """Interpolate data with one year dimension.
 
     This function receives a parameter data as a dataframe, and adds new data

--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -11,7 +11,7 @@
 #      calculating missing values
 
 import logging
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -537,13 +537,13 @@ def interpolate_1d(
     year_col: str,
     value_col: str = "value",
     extrapolate: bool = False,
-    extrapol_neg: bool = None,
+    extrapol_neg: Optional[float] = None,
     bound_extend: bool = True,
 ) -> pd.DataFrame:
     """Interpolate data with one year dimension.
 
-    This function receives a parameter data as a dataframe, and adds new data
-    for the additonal years by interpolation and extrapolation.
+    This function receives parameter data as a data frame, and adds new data for
+    `yrs_new` by interpolation and extrapolation.
 
     Parameters
     ----------
@@ -552,20 +552,20 @@ def interpolate_1d(
     yrs_new : list of int
         New years to be added.
     horizon: list of int
-        The horizon of the reference scenario.
+        Years in the reference scenario.
     year_col : str
-        The header of the column to which the new years should be added, e.g.
-        `'year_act'`.
+        Dimension to which the new years should be added, e.g. ``year_act``.
     value_col : str
-        The header of the column containing values.
+        Label of the column containing values; default ``value``.
     extrapolate : bool
-        Allow extrapolation when a new year is outside the parameter years.
-    extrapol_neg : bool
-        Allow negative values obtained by extrapolation.
-
-        - Appears to have no effect when extrapolating *before* `horizon`.
+        Extrapolate data for new years before and after the existing years in
+        ``df[year_col]``.
+    extrapol_neg : float or None
+        If :obj:`None` (the default), allow extrapolation to produce negative values.
+        Otherwise, override such negative values with `extrapol_neg` times the value
+        in the preceding period.
     bound_extend : bool
-        Allow extrapolation of bounds for new years
+        Allow extrapolation of bounds for new years.
     """
     horizon_new = sorted(horizon + yrs_new)
     idx = [x for x in df.columns if x not in [year_col, value_col]]
@@ -740,8 +740,8 @@ def interpolate_2d(
         return df1.loc[df1.index.isin(df2.index)]
 
     if df.empty:
-        return df
         log.warning("The submitted dataframe is empty, so returned empty results")
+        return df
 
     df_tec = df.loc[df["technology"].isin(tec_list)]
     idx = [x for x in df.columns if x not in [year_col, value_col]]

--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -562,119 +562,121 @@ def interpolate_1d(
         Allow extrapolation when a new year is outside the parameter years.
     extrapol_neg : bool
         Allow negative values obtained by extrapolation.
+
+        - Appears to have no effect when extrapolating *before* `horizon`.
     bound_extend : bool
         Allow extrapolation of bounds for new years
     """
     horizon_new = sorted(horizon + yrs_new)
     idx = [x for x in df.columns if x not in [year_col, value_col]]
-    if not df.empty:
-        df2 = df.pivot_table(index=idx, columns=year_col, values=value_col)
 
-        # To sort the new years smaller than the first year for
-        # extrapolation (e.g. 2025 values are calculated first; then
-        # values of 2015 based on 2020 and 2025)
-        year_before = sorted([x for x in yrs_new if x < min(df2.columns)], reverse=True)
-        if year_before and extrapolate:
-            for y in year_before:
-                yrs_new.insert(len(yrs_new), yrs_new.pop(yrs_new.index(y)))
+    if df.empty:
+        log.warning("The submitted dataframe is empty, so returned empty results")
+        return df
 
-        for yr in yrs_new:
-            if yr > max(horizon):
-                extrapol = True
-            else:
-                extrapol = extrapolate
+    df2 = df.pivot_table(index=idx, columns=year_col, values=value_col)
 
-            # a) If this new year greater than modeled years, do extrapolation
-            if yr > max(df2.columns) and extrapol:
-                if yr == horizon_new[horizon_new.index(max(df2.columns)) + 1]:
-                    year_pre = max([x for x in df2.columns if x < yr])
+    # To sort the new years smaller than the first year for extrapolation (e.g. 2025
+    # values are calculated first; then values of 2015 based on 2020 and 2025)
+    year_before = sorted([x for x in yrs_new if x < min(df2.columns)], reverse=True)
+    if year_before and extrapolate:
+        for y in year_before:
+            yrs_new.insert(len(yrs_new), yrs_new.pop(yrs_new.index(y)))
 
-                    if len([x for x in df2.columns if x < yr]) >= 2:
-                        year_pp = max([x for x in df2.columns if x < year_pre])
-                        df2[yr] = intpol(
-                            df2[year_pre], df2[year_pp], year_pre, year_pp, yr
-                        )
+    for yr in yrs_new:
+        if yr > max(horizon):
+            extrapol = True
+        else:
+            extrapol = extrapolate
 
-                        if bound_extend:
-                            df2[yr] = df2[yr].fillna(df2[year_pre])
-
-                        df2[yr][np.isinf(df2[year_pre])] = df2[year_pre]
-                        if (
-                            not df2[yr].loc[(df2[yr] < 0) & (df2[year_pre] >= 0)].empty
-                            and extrapol_neg
-                        ):
-                            df2.loc[(df2[yr] < 0) & (df2[year_pre] >= 0), yr] = (
-                                df2.loc[(df2[yr] < 0) & (df2[year_pre] >= 0), year_pre]
-                                * extrapol_neg
-                            )
-                    else:
-                        df2[yr] = df2[year_pre]
-
-            # b) If the new year is smaller than modeled years, extrapolate
-            elif yr < min(df2.columns) and extrapol:
-                year_next = min([x for x in df2.columns if x > yr])
-
-                # To make sure the new year is not two steps smaller
-                cond = year_next == horizon_new[horizon_new.index(yr) + 1]
-
-                if len([x for x in df2.columns if x > yr]) >= 2 and cond:
-                    year_nn = min([x for x in df2.columns if x > year_next])
-                    df2[yr] = intpol(
-                        df2[year_next], df2[year_nn], year_next, year_nn, yr
-                    )
-                    df2[yr][np.isinf(df2[year_next])] = df2[year_next]
-                    if (
-                        not df2[yr].loc[(df2[yr] < 0) & (df2[year_next] >= 0)].empty
-                        and extrapol_neg
-                    ):
-                        df2.loc[(df2[yr] < 0) & (df2[year_next] >= 0), yr] = (
-                            df2.loc[(df2[yr] < 0) & (df2[year_next] >= 0), year_next]
-                            * extrapol_neg
-                        )
-
-                elif bound_extend and cond:
-                    df2[yr] = df2[year_next]
-
-            # c) Otherise, do intrapolation
-            elif yr > min(df2.columns) and yr < max(df2.columns):
+        # a) If this new year greater than modeled years, do extrapolation
+        if yr > max(df2.columns) and extrapol:
+            if yr == horizon_new[horizon_new.index(max(df2.columns)) + 1]:
                 year_pre = max([x for x in df2.columns if x < yr])
-                year_next = min([x for x in df2.columns if x > yr])
-                df2[yr] = intpol(df2[year_pre], df2[year_next], year_pre, year_next, yr)
 
-                # Extrapolate for new years if the value exists for the
-                # previous year but not for the next years
-                # TODO: here is the place that should be changed if the
-                # new year should go to the time step before the existing one
-                if [x for x in df2.columns if x > year_next]:
-                    year_nn = min([x for x in df2.columns if x > year_next])
-                    df2[yr] = df2[yr].fillna(
-                        intpol(df2[year_next], df2[year_nn], year_next, year_nn, yr)
-                    )
+                if len([x for x in df2.columns if x < yr]) >= 2:
+                    year_pp = max([x for x in df2.columns if x < year_pre])
+                    df2[yr] = intpol(df2[year_pre], df2[year_pp], year_pre, year_pp, yr)
+
+                    if bound_extend:
+                        df2[yr] = df2[yr].fillna(df2[year_pre])
+
+                    df2[yr][np.isinf(df2[year_pre])] = df2[year_pre]
                     if (
-                        not df2[yr].loc[(df2[yr] < 0) & (df2[year_next] >= 0)].empty
+                        not df2[yr].loc[(df2[yr] < 0) & (df2[year_pre] >= 0)].empty
                         and extrapol_neg
                     ):
-                        df2.loc[(df2[yr] < 0) & (df2[year_next] >= 0), yr] = (
-                            df2.loc[(df2[yr] < 0) & (df2[year_next] >= 0), year_next]
+                        df2.loc[(df2[yr] < 0) & (df2[year_pre] >= 0), yr] = (
+                            df2.loc[(df2[yr] < 0) & (df2[year_pre] >= 0), year_pre]
                             * extrapol_neg
                         )
+                else:
+                    df2[yr] = df2[year_pre]
 
-                if bound_extend:
-                    df2[yr] = df2[yr].fillna(df2[year_pre])
-                df2[yr][np.isinf(df2[year_pre])] = df2[year_pre]
+        # b) If the new year is smaller than modeled years, extrapolate
+        elif yr < min(df2.columns) and extrapol:
+            year_next = min([x for x in df2.columns if x > yr])
 
-        df2 = (
-            pd.melt(
-                df2.reset_index(),
-                id_vars=idx,
-                value_vars=[x for x in df2.columns if x not in idx],
-                var_name=year_col,
-                value_name=value_col,
-            )
-            .dropna(subset=[value_col])
-            .reset_index(drop=True)
+            # To make sure the new year is not two steps smaller
+            cond = year_next == horizon_new[horizon_new.index(yr) + 1]
+
+            if len([x for x in df2.columns if x > yr]) >= 2 and cond:
+                year_nn = min([x for x in df2.columns if x > year_next])
+                df2[yr] = intpol(df2[year_next], df2[year_nn], year_next, year_nn, yr)
+                df2[yr][np.isinf(df2[year_next])] = df2[year_next]
+                if (
+                    not df2[yr].loc[(df2[yr] < 0) & (df2[year_next] >= 0)].empty
+                    and extrapol_neg
+                ):
+                    df2.loc[(df2[yr] < 0) & (df2[year_next] >= 0), yr] = (
+                        df2.loc[(df2[yr] < 0) & (df2[year_next] >= 0), year_next]
+                        * extrapol_neg
+                    )
+
+            elif bound_extend and cond:
+                df2[yr] = df2[year_next]
+
+        # c) Otherise, do intrapolation
+        elif yr > min(df2.columns) and yr < max(df2.columns):
+            year_pre = max([x for x in df2.columns if x < yr])
+            year_next = min([x for x in df2.columns if x > yr])
+            df2[yr] = intpol(df2[year_pre], df2[year_next], year_pre, year_next, yr)
+
+            # Extrapolate for new years if the value exists for the previous year but
+            # not for the next years
+            # TODO: here is the place that should be changed if the new year should go
+            # to the time step before the existing one
+            if [x for x in df2.columns if x > year_next]:
+                year_nn = min([x for x in df2.columns if x > year_next])
+                df2[yr] = df2[yr].fillna(
+                    intpol(df2[year_next], df2[year_nn], year_next, year_nn, yr)
+                )
+                if (
+                    not df2[yr].loc[(df2[yr] < 0) & (df2[year_next] >= 0)].empty
+                    and extrapol_neg
+                ):
+                    df2.loc[(df2[yr] < 0) & (df2[year_next] >= 0), yr] = (
+                        df2.loc[(df2[yr] < 0) & (df2[year_next] >= 0), year_next]
+                        * extrapol_neg
+                    )
+
+            if bound_extend:
+                df2[yr] = df2[yr].fillna(df2[year_pre])
+            df2[yr][np.isinf(df2[year_pre])] = df2[year_pre]
+
+    return (
+        pd.melt(
+            df2.reset_index(),
+            id_vars=idx,
+            value_vars=[x for x in df2.columns if x not in idx],
+            var_name=year_col,
+            value_name=value_col,
         )
-        df2 = df2.sort_values(idx).reset_index(drop=True)
+        .dropna(subset=[value_col])
+        .reset_index(drop=True)
+        .sort_values(idx)
+        .reset_index(drop=True)
+    )
     else:
         log.warning("The submitted dataframe is empty, so returned empty results")
         df2 = df

--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -15,6 +15,7 @@ from typing import List, Optional
 
 import numpy as np
 import pandas as pd
+from genno import Quantity, computations
 
 log = logging.getLogger(__name__)
 
@@ -677,10 +678,83 @@ def interpolate_1d(
         .sort_values(idx)
         .reset_index(drop=True)
     )
-    else:
-        log.warning("The submitted dataframe is empty, so returned empty results")
-        df2 = df
-    return df2
+
+
+def i1d_genno(
+    df: pd.DataFrame,
+    yrs_new: List[int],
+    horizon: List[int],
+    year_col: str,
+    value_col: str = "value",
+    extrapolate: bool = False,
+    extrapol_neg: Optional[float] = None,
+    bound_extend: bool = True,
+) -> pd.DataFrame:
+    """:func:`interpolate_1d` vectorized using :mod:`genno`."""
+    if df.empty:
+        return df
+
+    # Existing range of years
+    y_df = df[year_col].unique()
+
+    # Split new periods into 5 lists:
+    # - Less than `horizon`.
+    # - Between `horizon` and `y_df`.
+    # - Within `y_df`.
+    # - Between `horizon` and `y_df`.
+    # - Greater than `horizon`.
+    y_lo1, y_lo0, y_mid, y_hi0, y_hi1 = np.split(
+        sorted(yrs_new),
+        np.searchsorted(yrs_new, [min(horizon), min(y_df), max(y_df), max(horizon)]),
+    )
+
+    # TODO check this logic is what is intended
+    if not extrapolate:
+        # Exclude periods that fall outside `horizon`
+        log.info(f"Omit periods {y_lo1 + y_lo0 + y_hi1} (extrapolate=False)")
+        yrs_new = np.concatenate([y_mid, y_hi0, y_hi1])
+    elif not bound_extend:
+        log.info(f"Omit periods {y_lo1 + y_hi1} (bound_extend=False)")
+        yrs_new = np.concatenate([y_lo0, y_mid, y_lo1])
+
+    y_all = sorted(set(horizon) | set(yrs_new))
+    # Index of the final period of the original data
+    i = y_all.index(sorted(horizon)[-1])
+
+    # Dimensions and units
+    dims = list(set(df.columns) - {value_col, "unit"})
+    unit = df["unit"].unique()
+    assert 1 == len(unit)
+
+    # - Convert to genno.Quantity
+    # - Apply genno's interpolation function
+    result = computations.interpolate(
+        Quantity(df.drop(columns="unit").set_index(dims)[value_col], units=unit[0]),
+        coords={year_col: y_all},
+        kwargs=dict(fill_value="extrapolate"),
+    )
+
+    # Handle extrapol_neg: check for negative values that should be overridden
+    # Select the final period of the original data, plus any extrapolated periods
+    check = (
+        Quantity([1]) if extrapol_neg is None else result.sel({year_col: y_all[i:]})
+    ) < 0
+
+    if check.any():
+        log.info(f"Override negative extrapolated values for:\n{check}")
+        # Keep `result` where values are > 0.
+        # Elsewhere:
+        # - Take the cumulative product of `extrapol_neg` for periods where the
+        #   extrapolated value is < 0.
+        # - Multiply by the value in the final year of the original data.
+        result = result.where(
+            result > 0,
+            check.map({True: extrapol_neg, False: np.NaN}).cumprod(dim=year_col)
+            * result.sel({year_col: y_all[i]}),
+        )
+
+    # Convert back to pd.DataFrame
+    return result.to_dataframe().reset_index().assign(unit=result.units)
 
 
 # %% VI.B) Interpolating parameters with two dimensions related to time


### PR DESCRIPTION
Most (137 of 187) untested lines in `message_ix` are in `.tools.add_year`: https://codecov.io/gh/iiasa/message_ix/tree/master/message_ix/tools/add_year

This PR adds tests for this code, but also reimplements some internal methods for better performance.

## How to review

**To be added.**

## PR checklist

- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.