### PR TITLE
Adjust objective values for nightly test scenarios

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -4,8 +4,8 @@ name: Test MESSAGEix-GLOBIOM scenarios
 
 on:
   # Uncomment these two lines for debugging, but leave them commented on 'main'
-  # pull_request:
-  #   branches: [ main ]
+  pull_request:
+    branches: [ main ]
   schedule:
   # 05:00 UTC = 06:00 CET = 07:00 CEST
   - cron: "0 5 * * *"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -4,8 +4,8 @@ name: Test MESSAGEix-GLOBIOM scenarios
 
 on:
   # Uncomment these two lines for debugging, but leave them commented on 'main'
-  pull_request:
-    branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
   schedule:
   # 05:00 UTC = 06:00 CET = 07:00 CEST
   - cron: "0 5 * * *"

--- a/message_ix/tests/data/scenarios.yaml
+++ b/message_ix/tests/data/scenarios.yaml
@@ -19,5 +19,5 @@ CD_Links_SSP2_v2_1000:
     lpmethod: 4
   cases:
   - obs: scen.var('OBJ')['lvl']
-    exp: '3374110.33'
+    exp: '3358441.5'
     test: partial(np.isclose, rtol=3e-6)  # not sure why 1e-6 doesn't work

--- a/message_ix/tests/data/scenarios.yaml
+++ b/message_ix/tests/data/scenarios.yaml
@@ -8,7 +8,7 @@ CD_Links_SSP2_baseline:
     lpmethod: 4
   cases: # Each entry in this list is eval()'d in Python, so must be a string
   - obs: scen.var('OBJ')['lvl']
-    exp: '3857425.75'
+    exp: '3870157.5'
     test: partial(np.isclose, rtol=3e-6)  # not sure why 1e-6 doesn't work
 
 CD_Links_SSP2_v2_1000:


### PR DESCRIPTION
This PR adjusts the expected objectives of both scenarios in the `scenario.yaml` file. This is needed due to the adjustment of the soft constraint of `new capacity` and `activity` by merging the PR #474. 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅

