### PR TITLE
Adjust test suite for pyam v1.1.0 compatibility

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- Adjust test suite for pyam v1.1.0 compatibility (:pull:`499`).
 - Update reference for activity and capacity soft constraints (:pull:`474`).
 - Update :meth:`.years_active` to use sorted results (:pull:`491`).
 - Adjust the Westeros reporting tutorial to pyam 1.0 deprecations (:pull:`492`).

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -129,7 +129,7 @@ def test_reporter_from_westeros(test_mp):
     )
     assert all(obs["year"] == [700, 710, 720] * 3)
 
-    obs = obs["value"].values
+    obs = obs.data["value"].values
     exp = [
         4832.177734,
         8786.515625,


### PR DESCRIPTION
This PR adjusts the test suite of `message_ix/tests/test_reporting.py::test_reporter_from_westeros` for compatibility with pyam v1.1.0. 

Merging this PR should close the issue #498. 

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist


- [x] Continuous integration checks all ✅
- [x] Update release notes.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
