### PR TITLE
Update installation documentation using Anaconda

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -55,6 +55,7 @@ jobs:
     - name: Install message-ix
       run: |
         conda config --prepend channels conda-forge
+        conda config --set channel_priority strict
         conda create --name ${{ env.CONDA_ENV }} --quiet message-ix
 
     - name: Check

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -77,22 +77,19 @@ Using Anaconda
    Windows users should use the “Anaconda Prompt” to avoid issues with permissions and environment variables when installing and using |MESSAGEix|.
    This program is available in the Windows Start menu after installing Anaconda.
 
-6. Configure conda to install :mod:`message_ix` from the conda-forge channel [2]_::
+6. Configure conda to install :mod:`message_ix` from the conda-forge channel [2]_ [3]_::
 
     $ conda config --prepend channels conda-forge
-
-7. Set conda channel priority to strict [3]_::
-
     $ conda config --set channel_priority strict
 
-8. Create a new conda environment and activate it.
+7. Create a new conda environment and activate it.
    This step is **required** if using Anaconda, but *optional* if using Miniconda.
    This example uses the name ``message_env``, but you can use any name of your choice::
 
     $ conda create --name message_env
     $ conda activate message_env
 
-9. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``) [4]_::
+8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``) [4]_::
 
     $ conda install message-ix
 
@@ -103,7 +100,8 @@ Go to the section `Check that installation was successful`_.
 .. [1] See the `conda glossary`_ for the differences between Anaconda and Miniconda, and the definitions of the terms ‘channel’ and ‘environment’ here.
 .. [2] The ‘$’ character at the start of these lines indicates that the command text should be entered in the terminal or prompt, depending on the operating system.
        Do not retype the ‘$’ character itself.
-.. [3] See `managing channels`_ of the Anaconda documentation for more information.
+.. [3] "strict" channel priority ensures that conda will select the latest version of message_ix from the "noarch" channel, and ignore much older (v1.0.0) packages in OS-specific channels.
+       See `managing channels`_ of the Anaconda documentation for more information.
 .. [4] Notice that conda uses the hyphen (‘-’) in package names, different from the underscore (‘_’) used in Python when importing the package.
 
 .. note:: When using Anaconda (not Miniconda), steps (5) through (8) can also be performed using the graphical Anaconda Navigator.
@@ -247,4 +245,4 @@ To check which JVM will be used by ixmp, run the following in any prompt or term
 .. _`README`: https://github.com/iiasa/message_ix#install-from-source-advanced-users
 .. _`IRkernel`: https://irkernel.github.io/installation/
 .. _`these instructions`: https://javatutorial.net/set-java-home-windows-10
-.. _`managing channels`: https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#
+.. _`managing channels`: https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -81,14 +81,18 @@ Using Anaconda
 
     $ conda config --prepend channels conda-forge
 
-7. Create a new conda enviroment.
+7. Set conda channel priority to strict [3]_::
+
+    $ conda config --set channel_priority strict
+
+8. Create a new conda environment and activate it.
    This step is **required** if using Anaconda, but *optional* if using Miniconda.
    This example uses the name ``message_env``, but you can use any name of your choice::
 
     $ conda create --name message_env
     $ conda activate message_env
 
-8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``) [3]_::
+9. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``) [4]_::
 
     $ conda install message-ix
 
@@ -99,7 +103,8 @@ Go to the section `Check that installation was successful`_.
 .. [1] See the `conda glossary`_ for the differences between Anaconda and Miniconda, and the definitions of the terms ‘channel’ and ‘environment’ here.
 .. [2] The ‘$’ character at the start of these lines indicates that the command text should be entered in the terminal or prompt, depending on the operating system.
        Do not retype the ‘$’ character itself.
-.. [3] Notice that conda uses the hyphen (‘-’) in package names, different from the underscore (‘_’) used in Python when importing the package.
+.. [3] See `managing channels`_ of the Anaconda documentation for more information.
+.. [4] Notice that conda uses the hyphen (‘-’) in package names, different from the underscore (‘_’) used in Python when importing the package.
 
 .. note:: When using Anaconda (not Miniconda), steps (5) through (8) can also be performed using the graphical Anaconda Navigator.
    See the `Anaconda Navigator documentation`_ for how to perform the various steps.
@@ -242,3 +247,4 @@ To check which JVM will be used by ixmp, run the following in any prompt or term
 .. _`README`: https://github.com/iiasa/message_ix#install-from-source-advanced-users
 .. _`IRkernel`: https://irkernel.github.io/installation/
 .. _`these instructions`: https://javatutorial.net/set-java-home-windows-10
+.. _`managing channels`: https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#


### PR DESCRIPTION
This PR updates the installation documentation using Anaconda with an additional step to set the channel priority to strict with ` $ conda config --set channel_priority strict`. This lead to errors in the past and was issued in #480. Merging this PR will close this issue.

## How to review

- Read the diff and note that the CI checks all pass.
- Build the documentation and look at the installation page.

## PR checklist


- [x] Continuous integration checks all ✅

  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
