### PR TITLE
Add .tools.check()

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- Add a tool for :doc:`tools/check` (:pull:`506`).
 - Adjust test suite for pyam v1.1.0 compatibility (:pull:`499`).
 - Add Westeros :doc:`tutorial <tutorials>` on historical parameters (:pull:`478`).
 - Update reference for activity and capacity soft constraints (:pull:`474`).

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -48,8 +48,6 @@ Then, continue with the:
    tutorials
 
 
-
-
 .. _core:
 
 Mathematical specification

--- a/doc/tools/check.rst
+++ b/doc/tools/check.rst
@@ -1,0 +1,27 @@
+Pre-solve checks
+****************
+
+.. currentmodule:: message_ix.tools
+
+.. autofunction:: check
+
+.. currentmodule:: message_ix.tools._check
+
+.. _checks-summary:
+
+.. automodule::  message_ix.tools._check
+   :members: gaps_input, gaps_tl, tl_integer
+
+   .. autoclass:: Result
+
+   Individual checks
+   =================
+
+   Gaps in certain parameters (:func:`gaps_*` check functions) can cause the GAMS implementation to treat that specific technology to be disabled in one period, between other periods where it *is* enabled.
+   This may prevent solution of the model.
+
+   .. autosummary::
+
+      gaps_input
+      gaps_tl
+      tl_integer

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -189,11 +189,14 @@ class Reporter(IXMPReporter):
         solved = scenario.has_solution()
 
         if not solved:
-            log.warning(
-                f'Scenario "{scenario.model}/{scenario.scenario}" has no solution'
-            )
-            log.warning("Some reporting may not function as expected")
-            fail_action = logging.DEBUG
+            if kwargs.pop("solved", True):
+                log.warning(
+                    f'Scenario "{scenario.model}/{scenario.scenario}" has no solution'
+                )
+                log.warning("Some reporting may not function as expected")
+                fail_action = logging.DEBUG
+            else:
+                fail_action = logging.NOTSET
         else:
             fail_action = "raise"
 

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -1,5 +1,6 @@
 import sys
 from shutil import copyfile
+from typing import List, Tuple
 
 import numpy as np
 import pytest
@@ -17,7 +18,7 @@ AT = "Austrian_energy_system"
 # 3. Dictionary with extra keyword arguments to run_notebook().
 
 # FIXME check objective function of the rest of tutorials.
-tutorials = [
+tutorials: List[Tuple] = [
     # IPython kernel
     (
         ("westeros", "westeros_baseline"),

--- a/message_ix/tests/tools/test_check.py
+++ b/message_ix/tests/tools/test_check.py
@@ -45,6 +45,38 @@ def test_check_westeros(test_mp):
     assert not results[0]
 
 
+def test_check_tl_integer(test_mp):
+    scen = make_westeros(test_mp)
+
+    # Minimal config to make Westeros reportable
+    config = {"units": {"replace": {"-": ""}}}
+
+    # Change one value
+    tl = "technical_lifetime"
+    with scen.transact():
+        scen.add_par(
+            tl,
+            make_df(
+                tl,
+                node_loc="Westeros",
+                technology="bulb",
+                year_vtg=700,
+                value=1.1,
+                unit="y",
+            ),
+        )
+
+    # Checks fail
+    results = check(scen, config=config)
+    assert not results[0]
+
+    assert """FAIL Non-integer values for technical_lifetime:
+See https://github.com/iiasa/message_ix/issues/503.
+- 1.1 at indices: nl=Westeros t=bulb yv=700""" in map(
+        str, results
+    )
+
+
 @pytest.mark.parametrize(
     "url, config",
     [

--- a/message_ix/tests/tools/test_check.py
+++ b/message_ix/tests/tools/test_check.py
@@ -1,0 +1,45 @@
+import pytest
+
+from message_ix import Scenario, make_df
+from message_ix.testing import make_dantzig, make_westeros
+from message_ix.tools import check
+
+
+def test_check_dantzig(test_mp):
+    scen = make_dantzig(test_mp)
+
+    # Checks all True
+    results = check(scen)
+    assert results[0]
+
+
+def test_check_westeros(test_mp):
+    scen = make_westeros(test_mp)
+
+    # Minimal config to make Westeros reportable
+    config = {"units": {"replace": {"-": ""}}}
+
+    # Checks all pass
+    results = check(scen, config=config)
+    assert results[0]
+
+    # Delete one value
+    to_delete = make_df(
+        "input",
+        node_loc="Westeros",
+        technology="bulb",
+        year_vtg=690,
+        year_act=710,
+        mode="standard",
+        node_origin="Westeros",
+        commodity="electricity",
+        level="final",
+        time="year",
+        time_origin="year",
+    ).dropna(axis=1)
+    with scen.transact():
+        scen.remove_par("input", to_delete)
+
+    # Checks fail
+    results = check(scen, config=config)
+    assert not results[0]

--- a/message_ix/tests/tools/test_check.py
+++ b/message_ix/tests/tools/test_check.py
@@ -43,3 +43,27 @@ def test_check_westeros(test_mp):
     # Checks fail
     results = check(scen, config=config)
     assert not results[0]
+
+
+@pytest.mark.parametrize(
+    "url, config",
+    [
+        # ("ixmp://platform/model/scenario#version", dict()),
+    ],
+)
+def test_check_existing(url, config):
+    """Check existing scenarios.
+
+    For local use only: extend the list of parameters, above, but do not commit
+    additions to ``main``.
+    """
+    # import pint
+    # from iam_units import registry
+    #
+    # pint.set_application_registry(registry)
+
+    scen, mp = Scenario.from_url(url)
+    results = check(scen, config=config)
+
+    # Checks all pass
+    assert results[0], "\n".join(map(str, results))

--- a/message_ix/tests/tools/test_check.py
+++ b/message_ix/tests/tools/test_check.py
@@ -13,16 +13,16 @@ def test_check_dantzig(test_mp):
     assert results[0]
 
 
-def test_check_westeros(test_mp):
-    scen = make_westeros(test_mp)
+@pytest.fixture
+def westeros(test_mp):
+    yield make_westeros(test_mp)
 
-    # Minimal config to make Westeros reportable
-    config = {"units": {"replace": {"-": ""}}}
 
-    # Checks all pass
-    results = check(scen, config=config)
-    assert results[0]
+# Minimal config to make Westeros reportable
+WESTEROS_CONFIG = {"units": {"replace": {"-": ""}}}
 
+
+def test_gaps_input(westeros):
     # Delete one value
     to_delete = make_df(
         "input",
@@ -37,24 +37,19 @@ def test_check_westeros(test_mp):
         time="year",
         time_origin="year",
     ).dropna(axis=1)
-    with scen.transact():
-        scen.remove_par("input", to_delete)
+    with westeros.transact():
+        westeros.remove_par("input", to_delete)
 
     # Checks fail
-    results = check(scen, config=config)
+    results = check(westeros, config=WESTEROS_CONFIG)
     assert not results[0]
 
 
-def test_check_tl_integer(test_mp):
-    scen = make_westeros(test_mp)
-
-    # Minimal config to make Westeros reportable
-    config = {"units": {"replace": {"-": ""}}}
-
+def test_check_tl_integer(westeros):
     # Change one value
     tl = "technical_lifetime"
-    with scen.transact():
-        scen.add_par(
+    with westeros.transact():
+        westeros.add_par(
             tl,
             make_df(
                 tl,
@@ -67,10 +62,10 @@ def test_check_tl_integer(test_mp):
         )
 
     # Checks fail
-    results = check(scen, config=config)
+    results = check(westeros, config=WESTEROS_CONFIG)
     assert not results[0]
 
-    assert """FAIL Non-integer values for technical_lifetime:
+    assert """FAIL Non-integer values for ``technical_lifetime``:
 See https://github.com/iiasa/message_ix/issues/503.
 - 1.1 at indices: nl=Westeros t=bulb yv=700""" in map(
         str, results

--- a/message_ix/tools/__init__.py
+++ b/message_ix/tools/__init__.py
@@ -1,0 +1,5 @@
+from ._check import check
+
+__all__ = [
+    "check",
+]

--- a/message_ix/tools/_check.py
+++ b/message_ix/tools/_check.py
@@ -1,0 +1,158 @@
+from functools import partial
+from logging import ERROR as FAIL
+from logging import NOTSET as PASS
+from logging import WARNING
+from typing import Any, Dict, Iterable, Tuple, Union
+
+from message_ix.reporting import Reporter
+
+CHECKS = []
+
+
+def append(func):
+    CHECKS.append(func)
+
+
+class Result:
+    """Container class for a check result and associated messages."""
+
+    desc: str
+    result: int
+    message: str = ""
+
+    def __init__(
+        self, desc: str, result: int, message_or_lines: Union[str, Iterable[str]] = ""
+    ):
+        self.description = desc
+        self.result = (
+            {True: PASS, False: FAIL}.get(result, result)
+            if isinstance(result, bool)
+            else result
+        )
+        self.message = (
+            message_or_lines
+            if isinstance(message_or_lines, str)
+            else "\n".join(message_or_lines)
+        )
+
+    def __bool__(self):
+        return self.result is PASS
+
+    def __str__(self):
+        if self.result is PASS:
+            return f"PASS {self.description}"
+        else:
+            result_str = {WARNING: "WARNING", FAIL: "FAIL"}.get(self.result)
+            return f"{result_str} {self.description}:\n{self.message}"
+
+    def __repr__(self):
+        return str(self)
+
+
+def check(scenario, config=None) -> Dict[str, Tuple[bool, Any]]:
+    """Check that data in `scenario` is consistent with the MESSAGE(-MACRO) formulation.
+
+    :func:`check` applies multiple checks, including:
+
+    1. ``technical_lifetime`` (maybe also ``var_cost`` missing for corresponding with
+       ``input``/``output`` values.
+    2. Period “gaps” in data.
+
+    Other checks that could be added include:
+    """
+    # Create a Reporter
+    config = config or dict()
+    rep = Reporter.from_scenario(scenario, solved=False, **config)
+
+    # Apply each function to the reporter; collect names and keys for check results
+    keys = [func(rep) for func in CHECKS]
+
+    # Add a key that collects all check results
+    rep.add("check all", keys)
+
+    # Trigger all checks
+    results = rep.get("check all")
+
+    # Prepare an overall Result object that gives overall success or failure
+    results.insert(0, Result("Overall", all(map(bool, results))))
+
+    return results
+
+
+@append
+def var_cost(rep):
+    def _(vc, input, output):
+        # TODO implement the check
+        return Result("var_cost missing for corresponding input/output", PASS)
+
+    key = {k: rep.full_key(k) for k in "var_cost input output".split()}
+    return rep.add(
+        "check var_cost",
+        _,
+        key["var_cost"],
+        key["input"],
+        key["output"],
+    )
+
+
+def check_gaps(qty, years, dim):
+    """Check `qty` for gaps in data along `dim`."""
+    result = PASS
+    messages = []
+
+    # List of dimensions other than `dim`
+    dims = list(qty.dims)
+    dims.pop(dims.index(dim))
+
+    # Find the nulls in `qty`, then iterate over groups of `dims`
+    for key, group in qty.isnull().groupby(dims):
+        # print(key, group)
+
+        # Set of years for which `qty` is not null, i.e. data exists
+        seen = set()
+        for idx, null in group.drop(dims).to_series().items():
+            if not null:
+                seen.add(idx)
+
+        # Elements from `years` that don't appear in `seen`
+        gaps = list(
+            filter(lambda y: min(seen) < y < max(seen) and y not in seen, years)
+        )
+
+        if len(gaps):
+            # At least 1 gap; format a message
+            result = WARNING
+            key_str = " ".join(f"{d}={k}" for d, k in zip(dims, key))
+            messages.extend(
+                [
+                    f"- at indices: {key_str}",
+                    f"  for {dim}: {min(seen)} < {repr(gaps)} < {max(seen)}",
+                ]
+            )
+
+    return Result(f"Data gaps in '{qty.name}'", result, messages)
+
+
+@append
+def gaps_input(rep):
+    return rep.add(
+        "check gaps in input", partial(check_gaps, dim="ya"), rep.full_key("input"), "y"
+    )
+
+
+@append
+def gaps_tl(rep):
+    return rep.add(
+        "check gaps in technical_lifetime",
+        partial(check_gaps, dim="yv"),
+        rep.full_key("technical_lifetime"),
+        "y",
+    )
+
+
+# @append
+def map_tec(rep):
+    def _(scen):
+        return Result("map_tec is present", FAIL, repr(scen.set("map_tec")))
+
+    return rep.add("map_tec", _, "scenario")


### PR DESCRIPTION
This PR adds a new function `message_ix.tools.check()`.

This function does **pre-solve checks** on MESSAGE-scheme scenarios: it examines the contents of a Scenario object and returns failure or warning if the contents of the Scenario are not compatible with the MESSAGE GAMS implementation and will certainly or likely cause an error if `Scenario.solve()` is called.

Details:
- This parallels some existing "sanity checks" already implemented in the GAMS code itself, e.g. https://github.com/iiasa/message_ix/blob/900a9f863b21f865e5e51bb83350e9d9507db049/message_ix/model/MESSAGE/data_load.gms#L175-L177
  Since GAMS is not a general-purpose programming language, checks in Python with more sophisticated checks and informative error messages can be easier to write and maintain.
- The `check()` method returns a list of Result objects. This is a simple class that includes a description of the check, the outcome (pass, fail, warning) and optional informative messages that can explain the offending contents of the scenario.
- The first Result is an "overall" result, only passing if all the other checks pass.
- The list of checks is extensible.
- The implementation uses `message_ix.reporting` (ultimately `genno`) internally.

## How to review

- Read the diff and note that the CI checks all pass.
- View the added documentation and ensure the checks are fully described.

## PR checklist

- [x] Extend checks
  - [x] #503
- [ ] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.