### PR TITLE
Enhance mathematical formulation to treat sub-annual time slices consistently

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,7 +12,6 @@ All changes
 - Adjust the Westeros reporting tutorial to pyam 1.0 deprecations (:pull:`492`).
 - Change precision of GAMS check for parameter "duration_time" (:pull:`513`).
 - Update light and historic demand in Westeros baseline tutorial (:pull:`523`).
-
 - Enhance mathematical formulation to represent sub-annual time slices consistently (:pull:`509`).
 
 .. _v3.3.0:

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -13,6 +13,7 @@ All changes
 - Change precision of GAMS check for parameter "duration_time" (:pull:`513`).
 - Update light and historic demand in Westeros baseline tutorial (:pull:`523`).
 
+- Enhance mathematical formulation to represent sub-annual time slices consistently (:pull:`509`).
 
 .. _v3.3.0:
 

--- a/doc/time.rst
+++ b/doc/time.rst
@@ -71,7 +71,7 @@ By default, the unit of ``ACT`` is treated per year in the GAMS formulation for 
 in time slice "year" and "month" both have the same unit (e.g., GWa). However, the user can report the values across parameters
 and variables with different units relative to the length of the full year. For example, the user can report ``ACT`` in units of
 "GWa" and "GWh" for time slices of "year" and "hour", respectively, in the same model. To activate this feature, the parent time slice
-for which the relative units are desired should be specified by set ``relative_time``. This will ensure that parameter ``duration_time_rel`` 
+for which the relative units are desired should be specified by set ``time_relative``. This will ensure that parameter ``duration_time_rel`` 
 is effective. Otherwise, this parameter is filled by value of 1, meaning that the units will be treated uniformly across
 different sub-annual time slices.
 

--- a/doc/time.rst
+++ b/doc/time.rst
@@ -55,17 +55,15 @@ Example 4
 
 Duration of sub-annual time slices
 ----------------------------------
-The duration of each sub-annual time slice should be defined relative to the whole year, with a value
-between 0 and 1, using parameter ``duration_time``. For example, in a model with four seasons with the same length, ``duration_time`` of each season will be 0.25.
-This information is needed to calculate capacity of a technology that is active in different time slices.
-
+The duration of each sub-annual time slice should be defined relative to the whole year, with a value between 0 and 1, using parameter ``duration_time``.
+For example, in a model with four seasons with the same length, ``duration_time`` of each season will be 0.25.
+Please note that the duration of time slices does not need to be equal to each other.
+This information is needed to calculate capacity of a technology that is active in different time slices. 
 Time slices can be represented at different temporal levels, using sets ``lvl_temporal`` and ``map_temporal_hierarchy``.
-This helps introducing a flexible temporal resolution, e.g., by representing some technologies at finer time resolution
-while others at ``year``.
-
-When there are more than one temporal levels, e.g., "year", "season", "month", "day", etc., ``duration_time`` is defined for each **temporal level** separately.
-The sum of ``duration_time`` at each temporal level must be equal to 1. For example, in a model with 4 time slices as "season" and 10 time slices as "day" under each "season",
-``duration_time`` of each "season" and "day" should be specified as 0.25 and 0.025, respectively.
+This helps introducing a flexible temporal resolution, e.g., by representing some technologies at finer time resolution while others at ``year``.
+When there are more than one temporal levels, e.g., "year", "season", "month", "day", etc., ``duration_time`` is defined for time slices at each **temporal level** separately.
+The sum of ``duration_time`` of time slices at each temporal level must be equal to 1.
+For example, in a model with 4 time slices as "season" and 10 time slices as "day" under each "season", ``duration_time`` of each "season" and "day" can be specified as 0.25 and 0.025, respectively.
 
 By default, the unit of ``ACT`` is treated per year in the GAMS formulation for different time slices. This means values reported
 in time slice "year" and "month" both have the same unit (e.g., GWa). However, the user can report the values across parameters

--- a/doc/time.rst
+++ b/doc/time.rst
@@ -58,18 +58,22 @@ Duration of sub-annual time slices
 The duration of each sub-annual time slice should be defined relative to the whole year, with a value
 between 0 and 1, using parameter ``duration_time``. For example, in a model with four seasons with the same length, ``duration_time`` of each season will be 0.25.
 This information is needed to calculate capacity of a technology that is active in different time slices.
-When there are more than one temporal levels, e.g., "season", "month", "day", etc., ``duration_time`` is defined for each **temporal level** separately.
-The sum of ``duration_time`` at each temporal level must be equal to 1. For example, in a model with 4 time slices as "season" and 10 time slices as "day" under each "season",
-``duration_time`` of each "season" and "day" should be specified as 0.25 and 0.025, respectively.
-season
- 
-Time slices are defined with their ``duration_time`` as a portion of the full year a value between 0 and 1. 
-For example, the user can define four time slices like 'summer', ''winter', 'jan', 'peak-hour', etc.
-with different ``duration_time``. The sume of ``duration_time`` must be equal to 1, otherwise an error is triggered in GAMS.
 
-Time slices can be represented at different temporal levels, using the sets ``lvl_temporal`` and ``map_temporal_hierarchy``.
+Time slices can be represented at different temporal levels, using sets ``lvl_temporal`` and ``map_temporal_hierarchy``.
 This helps introducing a flexible temporal resolution, e.g., by representing some technologies at finer time resolution
 while others at ``year``.
+
+When there are more than one temporal levels, e.g., "year", "season", "month", "day", etc., ``duration_time`` is defined for each **temporal level** separately.
+The sum of ``duration_time`` at each temporal level must be equal to 1. For example, in a model with 4 time slices as "season" and 10 time slices as "day" under each "season",
+``duration_time`` of each "season" and "day" should be specified as 0.25 and 0.025, respectively.
+
+By default, the unit of ``ACT`` is treated per year in the GAMS formulation for different time slices. This means values reported
+in time slice "year" and "month" both have the same unit (e.g., GWa). However, the user can report the values across parameters
+and variables with different units relative to the length of the full year. For example, the user can report ``ACT`` in units of
+"GWa" and "GWh" for time slices of "year" and "hour", respectively, in the same model. To activate this feature, the parent time slice
+for which the relative units are desired should be specified by set ``relative_time``. This will ensure that parameter ``duration_time_rel`` 
+is effective. Otherwise, this parameter is filled by value of 1, meaning that the units will be treated uniformly across
+different sub-annual time slices.
 
 Discounting
 ===========

--- a/doc/time.rst
+++ b/doc/time.rst
@@ -63,6 +63,14 @@ The sum of ``duration_time`` at each temporal level must be equal to 1. For exam
 ``duration_time`` of each "season" and "day" should be specified as 0.25 and 0.025, respectively.
 season
  
+Time slices are defined with their ``duration_time`` as a portion of the full year a value between 0 and 1. 
+For example, the user can define four time slices like 'summer', ''winter', 'jan', 'peak-hour', etc.
+with different ``duration_time``. The sume of ``duration_time`` must be equal to 1, otherwise an error is triggered in GAMS.
+
+Time slices can be represented at different temporal levels, using the sets ``lvl_temporal`` and ``map_temporal_hierarchy``.
+This helps introducing a flexible temporal resolution, e.g., by representing some technologies at finer time resolution
+while others at ``year``.
+
 Discounting
 ===========
 

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -15,7 +15,7 @@ $LOAD map_node, map_time, map_commodity, map_resource, map_stocks, map_tec, map_
 $LOAD map_land, map_relation
 $LOAD type_tec, cat_tec, type_year, cat_year, type_emission, cat_emission, type_tec_land
 $LOAD inv_tec, renewable_tec
-$LOAD balance_equality, relative_time
+$LOAD balance_equality, time_relative
 $LOAD shares
 $LOAD addon, type_addon, cat_addon, map_tec_addon
 $LOAD storage_tec, level_storage, map_tec_storage
@@ -105,8 +105,8 @@ $INCLUDE includes/period_parameter_assignment.gms
 
 * compute auxiliary parameters for relative duration of subannual time periods
 duration_time_rel(time,time2)$( map_time(time,time2) ) = duration_time(time2) / duration_time(time) ;
-* making duration_time_rel equal to 1, i.e., unifroming the units of ACT in sub-annual time slices, for parent 'time' not specified in set 'relative_time'
-duration_time_rel(time,time2)$( Not relative_time(time) ) = 1 ;
+* making duration_time_rel equal to 1, i.e., unifroming the units of ACT in sub-annual time slices, for parent 'time' not specified in set 'time_relative'
+duration_time_rel(time,time2)$( Not time_relative(time) ) = 1 ;
 
 * assign an additional mapping set for technologies to nodes, modes and subannual time slices (for shorter reference)
 map_tec_act(node,tec,year_all,mode,time)$( map_tec_time(node,tec,year_all,time) AND

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -15,7 +15,7 @@ $LOAD map_node, map_time, map_commodity, map_resource, map_stocks, map_tec, map_
 $LOAD map_land, map_relation
 $LOAD type_tec, cat_tec, type_year, cat_year, type_emission, cat_emission, type_tec_land
 $LOAD inv_tec, renewable_tec
-$LOAD balance_equality
+$LOAD balance_equality, relative_time
 $LOAD shares
 $LOAD addon, type_addon, cat_addon, map_tec_addon
 $LOAD storage_tec, level_storage, map_tec_storage
@@ -105,6 +105,8 @@ $INCLUDE includes/period_parameter_assignment.gms
 
 * compute auxiliary parameters for relative duration of subannual time periods
 duration_time_rel(time,time2)$( map_time(time,time2) ) = duration_time(time2) / duration_time(time) ;
+* making duration_time_rel equal to 1, i.e., unifroming the units of ACT in sub-annual time slices, for parent 'time' not specified in set 'relative_time'
+duration_time_rel(time,time2)$( Not relative_time(time) ) = 1 ;
 
 * assign an additional mapping set for technologies to nodes, modes and subannual time slices (for shorter reference)
 map_tec_act(node,tec,year_all,mode,time)$( map_tec_time(node,tec,year_all,time) AND

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -105,7 +105,7 @@ $INCLUDE includes/period_parameter_assignment.gms
 
 * compute auxiliary parameters for relative duration of subannual time periods
 duration_time_rel(time,time2)$( map_time(time,time2) ) = duration_time(time2) / duration_time(time) ;
-* making duration_time_rel equal to 1, i.e., unifroming the units of ACT in sub-annual time slices, for parent 'time' not specified in set 'time_relative'
+* making duration_time_rel equal to 1, i.e., a consistent unit for ACT in sub-annual time slices, for parent 'time' not specified in set 'time_relative'
 duration_time_rel(time,time2)$( Not time_relative(time) ) = 1 ;
 
 * assign an additional mapping set for technologies to nodes, modes and subannual time slices (for shorter reference)

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -567,10 +567,10 @@ $macro COMMODITY_BALANCE(node,commodity,level,year,time) (                      
             AND map_tec_lifetime(location,tec,vintage,year) ),                                                         \
 * import into node and output by all technologies located at 'location' sending to 'node' and 'time2' sending to 'time'
         output(location,tec,vintage,year,mode,node,commodity,level,time2,time)                                         \
-        * ACT(location,tec,vintage,year,mode,time2)                                    \
+        * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time2)                                    \
 * export from node and input into technologies located at 'location' taking from 'node' and 'time2' taking from 'time'
         - input(location,tec,vintage,year,mode,node,commodity,level,time2,time)                                        \
-        * ACT(location,tec,vintage,year,mode,time2) )                                  \
+        * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time2) )                                  \
 * quantity taken out from ( >0 ) or put into ( <0 ) inter-period stock (storage)
     + STOCK_CHG(node,commodity,level,year,time)$( map_stocks(node,commodity,level,year) )                              \
 * yield from land-use model emulator
@@ -980,6 +980,7 @@ COMMODITY_USE_LEVEL(node,commodity,level,year,time)$(
     SUM( (location,tec,vintage,mode,time2)$( map_tec_act(location,tec,year,mode,time2)
                                              AND map_tec_lifetime(location,tec,vintage,year) ),
         input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
+        * duration_time_rel(time,time2)
         * ACT(location,tec,vintage,year,mode,time2) ) ;
 
 ***
@@ -1036,6 +1037,7 @@ ACTIVITY_RATING_TOTAL(node,tec,vintage,year,commodity,level,time)$(
               AND map_tec_lifetime(location,tec,vintage,year) ),
             ( output(location,tec,vintage,year,mode,node,commodity,level,time2,time)
               + input(location,tec,vintage,year,mode,node,commodity,level,time2,time) )
+                * duration_time_rel(time,time2)
                 * ACT(location,tec,vintage,year,mode,time2) ) ;
 
 ***
@@ -1139,6 +1141,7 @@ SYSTEM_FLEXIBILITY_CONSTRAINT(node,commodity,level,year,time)$(
               AND map_tec_lifetime(location,tec,vintage,year) ),
             ( output(location,tec,vintage,year,mode,node,commodity,level,time2,time)
               + input(location,tec,vintage,year,mode,node,commodity,level,time2,time) )
+                * duration_time_rel(time,time2)
                 * ACT(location,tec,vintage,year,mode,time2) ) )
     + SUM((tec, vintage, mode, rating_unrated)$(
             flexibility_factor(node,tec,vintage,year,mode,commodity,level,time,rating_unrated)
@@ -1432,6 +1435,7 @@ SHARE_CONSTRAINT_COMMODITY_UP(shares,node_share,year,time)$( share_commodity_up(
             output(location,tec,vintage,year,mode,node,commodity,level,time2,time) +
             input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
         ) *
+        duration_time_rel(time,time2) *
         ACT(location,tec,vintage,year,mode,time2)
     )
     =L=
@@ -1448,6 +1452,7 @@ SHARE_CONSTRAINT_COMMODITY_UP(shares,node_share,year,time)$( share_commodity_up(
             output(location,tec,vintage,year,mode,node,commodity,level,time2,time) +
             input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
         ) *
+        duration_time_rel(time,time2) *
         ACT(location,tec,vintage,year,mode,time2)
     ) ) ;
 
@@ -1481,6 +1486,7 @@ SHARE_CONSTRAINT_COMMODITY_LO(shares,node_share,year,time)$( share_commodity_lo(
             output(location,tec,vintage,year,mode,node,commodity,level,time2,time) +
             input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
         ) *
+        duration_time_rel(time,time2) *
         ACT(location,tec,vintage,year,mode,time2)
     )
     =G=
@@ -1497,6 +1503,7 @@ SHARE_CONSTRAINT_COMMODITY_LO(shares,node_share,year,time)$( share_commodity_lo(
             output(location,tec,vintage,year,mode,node,commodity,level,time2,time) +
             input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
         ) *
+        duration_time_rel(time,time2) *
         ACT(location,tec,vintage,year,mode,time2)
     ) ) ;
 
@@ -2158,7 +2165,7 @@ RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,yea
 *          - \sum_{\substack{n^L,m,c,h-1 \\ y^V \leq y, (n,t^D,t,l,y) \sim S^{storage}}} input_{n^L,t^D,y^V,y,m,n,c,l,h-1,h}
 *              \cdot ACT_{n^L,t^D,y^V,y,m,h-1} \quad \forall \ t \in T^{STOR}, & \forall \ l \in L^{STOR}
 ***
-STORAGE_CHANGE(node,storage_tec,level_storage,commodity,year,time)..
+STORAGE_CHANGE(node,storage_tec,level_storage,commodity,year,time) ..
 * change in the content of storage in the examined timestep
     STORAGE_CHARGE(node,storage_tec,level_storage,commodity,year,time) =E=
 * increase in the content of storage due to the activity of charging technologies
@@ -2166,13 +2173,13 @@ STORAGE_CHANGE(node,storage_tec,level_storage,commodity,year,time)..
         map_tec_lifetime(node,tec,vintage,year)
         AND map_tec_storage(node,tec,storage_tec,level_storage,commodity) ),
             output(location,tec,vintage,year,mode,node,commodity,level_storage,time2,time)
-            * ACT(location,tec,vintage,year,mode,time) )
+            * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time) )
 * decrease in the content of storage due to the activity of discharging technologies
         - SUM( (location,vintage,mode,tec,time2)$(
         map_tec_lifetime(node,tec,vintage,year)
         AND map_tec_storage(node,tec,storage_tec,level_storage,commodity) ),
             input(location,tec,vintage,year,mode,node,commodity,level_storage,time2,time)
-            * ACT(location,tec,vintage,year,mode,time) );
+            * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time) );
 
 ***
 * .. _equation_storage_balance:
@@ -2251,7 +2258,7 @@ STORAGE_EQUIVALENCE(node,storage_tec,level,commodity,level_storage,commodity2,mo
          STORAGE(node,storage_tec,level_storage,commodity2,year,time) =E=
         SUM( (location,vintage,time2)$(map_tec_lifetime(node,storage_tec,vintage,year)$(
               input(location,storage_tec,vintage,year,mode,node,commodity,level,time2,time) ) ),
-              ACT(location,storage_tec,vintage,year,mode,time) );
+              duration_time_rel(time,time2) * ACT(location,storage_tec,vintage,year,mode,time) );
 
 *----------------------------------------------------------------------------------------------------------------------*
 * model statements                                                                                                     *

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -567,10 +567,10 @@ $macro COMMODITY_BALANCE(node,commodity,level,year,time) (                      
             AND map_tec_lifetime(location,tec,vintage,year) ),                                                         \
 * import into node and output by all technologies located at 'location' sending to 'node' and 'time2' sending to 'time'
         output(location,tec,vintage,year,mode,node,commodity,level,time2,time)                                         \
-        * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time2)                                    \
+        * ACT(location,tec,vintage,year,mode,time2)                                    \
 * export from node and input into technologies located at 'location' taking from 'node' and 'time2' taking from 'time'
         - input(location,tec,vintage,year,mode,node,commodity,level,time2,time)                                        \
-        * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time2) )                                  \
+        * ACT(location,tec,vintage,year,mode,time2) )                                  \
 * quantity taken out from ( >0 ) or put into ( <0 ) inter-period stock (storage)
     + STOCK_CHG(node,commodity,level,year,time)$( map_stocks(node,commodity,level,year) )                              \
 * yield from land-use model emulator
@@ -980,7 +980,6 @@ COMMODITY_USE_LEVEL(node,commodity,level,year,time)$(
     SUM( (location,tec,vintage,mode,time2)$( map_tec_act(location,tec,year,mode,time2)
                                              AND map_tec_lifetime(location,tec,vintage,year) ),
         input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
-        * duration_time_rel(time,time2)
         * ACT(location,tec,vintage,year,mode,time2) ) ;
 
 ***
@@ -1037,7 +1036,6 @@ ACTIVITY_RATING_TOTAL(node,tec,vintage,year,commodity,level,time)$(
               AND map_tec_lifetime(location,tec,vintage,year) ),
             ( output(location,tec,vintage,year,mode,node,commodity,level,time2,time)
               + input(location,tec,vintage,year,mode,node,commodity,level,time2,time) )
-                * duration_time_rel(time,time2)
                 * ACT(location,tec,vintage,year,mode,time2) ) ;
 
 ***
@@ -1141,7 +1139,6 @@ SYSTEM_FLEXIBILITY_CONSTRAINT(node,commodity,level,year,time)$(
               AND map_tec_lifetime(location,tec,vintage,year) ),
             ( output(location,tec,vintage,year,mode,node,commodity,level,time2,time)
               + input(location,tec,vintage,year,mode,node,commodity,level,time2,time) )
-                * duration_time_rel(time,time2)
                 * ACT(location,tec,vintage,year,mode,time2) ) )
     + SUM((tec, vintage, mode, rating_unrated)$(
             flexibility_factor(node,tec,vintage,year,mode,commodity,level,time,rating_unrated)
@@ -1435,7 +1432,6 @@ SHARE_CONSTRAINT_COMMODITY_UP(shares,node_share,year,time)$( share_commodity_up(
             output(location,tec,vintage,year,mode,node,commodity,level,time2,time) +
             input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
         ) *
-        duration_time_rel(time,time2) *
         ACT(location,tec,vintage,year,mode,time2)
     )
     =L=
@@ -1452,7 +1448,6 @@ SHARE_CONSTRAINT_COMMODITY_UP(shares,node_share,year,time)$( share_commodity_up(
             output(location,tec,vintage,year,mode,node,commodity,level,time2,time) +
             input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
         ) *
-        duration_time_rel(time,time2) *
         ACT(location,tec,vintage,year,mode,time2)
     ) ) ;
 
@@ -1486,7 +1481,6 @@ SHARE_CONSTRAINT_COMMODITY_LO(shares,node_share,year,time)$( share_commodity_lo(
             output(location,tec,vintage,year,mode,node,commodity,level,time2,time) +
             input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
         ) *
-        duration_time_rel(time,time2) *
         ACT(location,tec,vintage,year,mode,time2)
     )
     =G=
@@ -1503,7 +1497,6 @@ SHARE_CONSTRAINT_COMMODITY_LO(shares,node_share,year,time)$( share_commodity_lo(
             output(location,tec,vintage,year,mode,node,commodity,level,time2,time) +
             input(location,tec,vintage,year,mode,node,commodity,level,time2,time)
         ) *
-        duration_time_rel(time,time2) *
         ACT(location,tec,vintage,year,mode,time2)
     ) ) ;
 
@@ -2165,7 +2158,7 @@ RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,yea
 *          - \sum_{\substack{n^L,m,c,h-1 \\ y^V \leq y, (n,t^D,t,l,y) \sim S^{storage}}} input_{n^L,t^D,y^V,y,m,n,c,l,h-1,h}
 *              \cdot ACT_{n^L,t^D,y^V,y,m,h-1} \quad \forall \ t \in T^{STOR}, & \forall \ l \in L^{STOR}
 ***
-STORAGE_CHANGE(node,storage_tec,level_storage,commodity,year,time) ..
+STORAGE_CHANGE(node,storage_tec,level_storage,commodity,year,time)$sum(tec, map_tec_storage(node,tec,storage_tec,level_storage,commodity) ) ..
 * change in the content of storage in the examined timestep
     STORAGE_CHARGE(node,storage_tec,level_storage,commodity,year,time) =E=
 * increase in the content of storage due to the activity of charging technologies
@@ -2173,13 +2166,13 @@ STORAGE_CHANGE(node,storage_tec,level_storage,commodity,year,time) ..
         map_tec_lifetime(node,tec,vintage,year)
         AND map_tec_storage(node,tec,storage_tec,level_storage,commodity) ),
             output(location,tec,vintage,year,mode,node,commodity,level_storage,time2,time)
-            * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time) )
+            * ACT(location,tec,vintage,year,mode,time) )
 * decrease in the content of storage due to the activity of discharging technologies
         - SUM( (location,vintage,mode,tec,time2)$(
         map_tec_lifetime(node,tec,vintage,year)
         AND map_tec_storage(node,tec,storage_tec,level_storage,commodity) ),
             input(location,tec,vintage,year,mode,node,commodity,level_storage,time2,time)
-            * duration_time_rel(time,time2) * ACT(location,tec,vintage,year,mode,time) );
+            * ACT(location,tec,vintage,year,mode,time) );
 
 ***
 * .. _equation_storage_balance:
@@ -2258,7 +2251,7 @@ STORAGE_EQUIVALENCE(node,storage_tec,level,commodity,level_storage,commodity2,mo
          STORAGE(node,storage_tec,level_storage,commodity2,year,time) =E=
         SUM( (location,vintage,time2)$(map_tec_lifetime(node,storage_tec,vintage,year)$(
               input(location,storage_tec,vintage,year,mode,node,commodity,level,time2,time) ) ),
-              duration_time_rel(time,time2) * ACT(location,storage_tec,vintage,year,mode,time) );
+              ACT(location,storage_tec,vintage,year,mode,time) )
 
 *----------------------------------------------------------------------------------------------------------------------*
 * model statements                                                                                                     *

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -2158,7 +2158,7 @@ RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,yea
 *          - \sum_{\substack{n^L,m,c,h-1 \\ y^V \leq y, (n,t^D,t,l,y) \sim S^{storage}}} input_{n^L,t^D,y^V,y,m,n,c,l,h-1,h}
 *              \cdot ACT_{n^L,t^D,y^V,y,m,h-1} \quad \forall \ t \in T^{STOR}, & \forall \ l \in L^{STOR}
 ***
-STORAGE_CHANGE(node,storage_tec,level_storage,commodity,year,time)$sum(tec, map_tec_storage(node,tec,storage_tec,level_storage,commodity) ) ..
+STORAGE_CHANGE(node,storage_tec,level_storage,commodity,year,time)..
 * change in the content of storage in the examined timestep
     STORAGE_CHARGE(node,storage_tec,level_storage,commodity,year,time) =E=
 * increase in the content of storage due to the activity of charging technologies

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -2251,7 +2251,7 @@ STORAGE_EQUIVALENCE(node,storage_tec,level,commodity,level_storage,commodity2,mo
          STORAGE(node,storage_tec,level_storage,commodity2,year,time) =E=
         SUM( (location,vintage,time2)$(map_tec_lifetime(node,storage_tec,vintage,year)$(
               input(location,storage_tec,vintage,year,mode,node,commodity,level,time2,time) ) ),
-              ACT(location,storage_tec,vintage,year,mode,time) )
+              ACT(location,storage_tec,vintage,year,mode,time) );
 
 *----------------------------------------------------------------------------------------------------------------------*
 * model statements                                                                                                     *

--- a/message_ix/model/MESSAGE/sets_maps_def.gms
+++ b/message_ix/model/MESSAGE/sets_maps_def.gms
@@ -304,6 +304,7 @@ Sets
     cat_emission(type_emission,emission)    mapping of emissions to respective categories
     type_tec_land(type_tec)                 dynamic set whether emissions from land use are included in type_tec
     balance_equality(commodity,level)       mapping of commodities-level where the supply-demand balance must be maintained with equality
+    relative_time(time)                     flag for treating unit of ACT in sub-annual time slices relative to parent 'time' (=activating parameter 'duration_time_rel')  
 ;
 
 Alias(type_tec,type_tec_share);

--- a/message_ix/model/MESSAGE/sets_maps_def.gms
+++ b/message_ix/model/MESSAGE/sets_maps_def.gms
@@ -260,6 +260,9 @@ Alias(commodity,commodity2);
 *    * - balance_equality (commodity,level)
 *      - :math:`c \in C, l \in L`
 *      - Commodities and level related to :ref:`commodity_balance_lt`
+*    * - relative_time (time)
+*      - :math:`h \in H`
+*      - Parent sub-annual time slices for considering relative time in parameter :ref:`duration_time_rel`
 *
 * .. [#level_res] The constraint :ref:`extraction_equivalence` is active only for the levels included in this set,
 *    and the constraint :ref:`commodity_balance` is deactivated for these levels.
@@ -304,7 +307,7 @@ Sets
     cat_emission(type_emission,emission)    mapping of emissions to respective categories
     type_tec_land(type_tec)                 dynamic set whether emissions from land use are included in type_tec
     balance_equality(commodity,level)       mapping of commodities-level where the supply-demand balance must be maintained with equality
-    relative_time(time)                     flag for treating unit of ACT in sub-annual time slices relative to parent 'time' (=activating parameter 'duration_time_rel')  
+    relative_time(time)                     flag for treating unit of ACT in sub-annual time slices relative to parent 'time' (=activating parameter 'duration_time_rel')
 ;
 
 Alias(type_tec,type_tec_share);

--- a/message_ix/model/MESSAGE/sets_maps_def.gms
+++ b/message_ix/model/MESSAGE/sets_maps_def.gms
@@ -260,7 +260,7 @@ Alias(commodity,commodity2);
 *    * - balance_equality (commodity,level)
 *      - :math:`c \in C, l \in L`
 *      - Commodities and level related to :ref:`commodity_balance_lt`
-*    * - relative_time (time)
+*    * - time_relative (time)
 *      - :math:`h \in H`
 *      - Parent sub-annual time slices for considering relative time in parameter :ref:`duration_time_rel`
 *
@@ -307,7 +307,7 @@ Sets
     cat_emission(type_emission,emission)    mapping of emissions to respective categories
     type_tec_land(type_tec)                 dynamic set whether emissions from land use are included in type_tec
     balance_equality(commodity,level)       mapping of commodities-level where the supply-demand balance must be maintained with equality
-    relative_time(time)                     flag for treating unit of ACT in sub-annual time slices relative to parent 'time' (=activating parameter 'duration_time_rel')
+    time_relative(time)                     flag for treating unit of ACT in sub-annual time slices relative to parent 'time' (=activating parameter 'duration_time_rel')
 ;
 
 Alias(type_tec,type_tec_share);

--- a/message_ix/model/includes/period_parameter_assignment.gms
+++ b/message_ix/model/includes/period_parameter_assignment.gms
@@ -18,7 +18,7 @@ Sets
 
 Parameter
     duration_period_sum(year_all,year_all2) number of years between two periods ('year_all' must precede 'year_all2')
-    duration_time_rel(time,time2)         relative duration of subannual time slice 'time2' relative to parent 'time' (only for 'time' specified in set 'relative_time')
+    duration_time_rel(time,time2)         relative duration of subannual time slice 'time2' relative to parent 'time' (only for 'time' specified in set 'time_relative')')
     elapsed_years(year_all)    elapsed years since the start of the model horizon (not including 'year_all' period)
     remaining_years(year_all)  remaining years until the end of the model horizon (including last period)
     year_order(year_all)       order for members of set 'year_all'

--- a/message_ix/model/includes/period_parameter_assignment.gms
+++ b/message_ix/model/includes/period_parameter_assignment.gms
@@ -18,7 +18,7 @@ Sets
 
 Parameter
     duration_period_sum(year_all,year_all2) number of years between two periods ('year_all' must precede 'year_all2')
-    duration_time_rel(time,time2)         relative duration of subannual time period ('time2' relative to parent 'time')
+    duration_time_rel(time,time2)         relative duration of subannual time slice 'time2' relative to parent 'time' (only for 'time' specified in set 'relative_time')
     elapsed_years(year_all)    elapsed years since the start of the model horizon (not including 'year_all' period)
     remaining_years(year_all)  remaining years until the end of the model horizon (including last period)
     year_order(year_all)       order for members of set 'year_all'
@@ -91,7 +91,7 @@ df_period(year_all) =
     df_year(year_all) * (
 * multiply the per-year discount factor by the geometric series of over the duration of the period
         ( ( POWER( 1 + interestrate(year_all) , duration_period(year_all) ) - 1 )
-	/ interestrate(year_all) )$( interestrate(year_all) )
+        / interestrate(year_all) )$( interestrate(year_all) )
 * if interest rate = 0, multiply by the number of years in that period
         + ( duration_period(year_all) )$( interestrate(year_all) eq 0 ) )
 ;

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -138,6 +138,7 @@ MESSAGE_ITEMS = {
     "map_time": dict(
         ix_type="set", idx_sets=["time", "time"], idx_names=["time_parent", "time"]
     ),
+    "relative_time": dict(ix_type="set", idx_sets=["time"]),
     "type_tec_land": dict(ix_type="set", idx_sets=["type_tec"]),
     #
     # Parameters

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -91,6 +91,7 @@ MESSAGE_ITEMS = {
     "storage_tec": dict(ix_type="set"),  # Storage reservoir technology
     "technology": dict(ix_type="set"),
     "time": dict(ix_type="set"),
+    "time_relative": dict(ix_type="set"),
     "type_addon": dict(ix_type="set"),
     "type_emission": dict(ix_type="set"),
     "type_node": dict(ix_type="set"),
@@ -138,7 +139,6 @@ MESSAGE_ITEMS = {
     "map_time": dict(
         ix_type="set", idx_sets=["time", "time"], idx_names=["time_parent", "time"]
     ),
-    "relative_time": dict(ix_type="set", idx_sets=["time"]),
     "type_tec_land": dict(ix_type="set", idx_sets=["type_tec"]),
     #
     # Parameters

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -5,8 +5,9 @@ months, etc., and with different duration times.
 
 """
 
-import pytest
 from itertools import product
+
+import pytest
 
 from message_ix import ModelError, Scenario
 

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -8,8 +8,7 @@ months, etc., and with different duration times.
 
 from itertools import product
 
-from ixmp.model.base import ModelError
-from message_ix import Scenario
+from message_ix import ModelError, Scenario
 
 
 # A function for adding required parameters for representing "capacity"

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""
+This test ensures that COMMODITY_BALANCE works for (sub-annual) time slices (index of "time" in MESSAGEix)
+at different temporal levels, like seasons, months, etc., and with different duration times.
+
+"""
+
+import pytest
+from itertools import product
+from message_ix import Scenario
+
+
+# A function for generating a simple model with sub-annual time slices
+def model_generator(
+    test_mp,
+    comment,
+    tec_dict,
+    com_dict,
+    time_steps,
+    demand,
+    yr=2020,
+    unit="GWa",
+):
+    """
+
+    Generates a simple model with two technologies, and a flexible number of time slices.
+
+    Parameters
+    ----------
+    test_mp : ixmp.Platform()
+    comment : string
+        Annotation for saving different scenarios and comparing their results.
+    tec_dict : dict
+        A dictionary for a technology and required information for time-related parameters.
+        (e.g., tec_dict = {"gas_ppl": {"time_origin": ["summer"], "time": ["summer"], "time_dest": ["summer"]})
+    com_dict : dict
+        A dictionary for specifying "input" and "output" commodities.
+        (e.g., com_dict = {"gas_ppl": {"input": "fuel", "output": "electr"}})
+    time_steps : list of tuples
+        Information about each time slice, packed in a tuple with four elements,
+        including: time slice name, duration relative to "year", "temporal_lvl", and parent time slice.
+        (e.g., time_steps = [("summer", 1, "season", "year")])
+    demand : dict
+        A dictionary for information of "demand" in each time slice.
+        (e.g., demand = {"summer": 2.5})
+    yr : int, optional
+        Model year. The default is 2020.
+    unit :  string
+        Unit of "demand"
+
+
+    """
+
+    # Building an empty scenario
+    scen = Scenario(test_mp, "test_time", comment, version="new")
+
+    # Adding required sets
+    scen.add_set("node", "node")
+    for c in com_dict.values():
+        scen.add_set("commodity", [x for x in list(c.values()) if x])
+
+    scen.add_set("level", "level")
+    scen.add_set("year", yr)
+    scen.add_set("type_year", yr)
+    scen.add_set("technology", list(tec_dict.keys()))
+    scen.add_set("mode", "mode")
+    scen.add_set("lvl_temporal", [x[2] for x in time_steps])
+    scen.add_set("time", [x[0] for x in time_steps])
+    scen.add_set("time", [x[3] for x in time_steps])
+
+    # Adding "time" and "duration_time" to the model
+    for (h, dur, tmp_lvl, parent) in time_steps:
+        scen.add_set("map_temporal_hierarchy", [tmp_lvl, h, parent])
+        scen.add_par("duration_time", [h], dur, "-")
+
+    # Defining demand
+    for h, value in demand.items():
+        scen.add_par("demand", ["node", "electr", "level", yr, h], value, unit)
+
+    # Adding "input" and "output" parameters of technologies
+    for tec, times in tec_dict.items():
+        if times["time_dest"]:
+            for h1, h2 in zip(times["time"], times["time_dest"]):
+                out_spec = [
+                    yr,
+                    yr,
+                    "mode",
+                    "node",
+                    com_dict[tec]["output"],
+                    "level",
+                    h1,
+                    h2,
+                ]
+                scen.add_par("output", ["node", tec] + out_spec, 1, "-")
+        if times["time_origin"]:
+            for h1, h2 in zip(times["time"], times["time_origin"]):
+                inp_spec = [
+                    yr,
+                    yr,
+                    "mode",
+                    "node",
+                    com_dict[tec]["input"],
+                    "level",
+                    h1,
+                    h2,
+                ]
+                scen.add_par("input", ["node", tec] + inp_spec, 1, "-")
+
+    # Committing and solving
+    scen.commit("scenario was set up.")
+    scen.solve(case=comment)

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -6,8 +6,9 @@ months, etc., and with different duration times.
 
 """
 
-import pytest
 from itertools import product
+
+from ixmp.model.base import ModelError
 from message_ix import Scenario
 
 
@@ -179,19 +180,15 @@ def test_temporal_levels_not_linked(test_mp):
 
     # Check the model not solve if there is no link between fuel supply and power plant
     try:
-        pytest.raises(
-            ValueError,
-            model_generator(
-                test_mp,
-                comment,
-                tec_dict,
-                time_steps=[("summer", 1, "season", "year")],
-                demand={"summer": 2},
-            ),
-        )
+        model_generator(
+            test_mp,
+            comment,
+            tec_dict,
+            time_steps=[("summer", 1, "season", "year")],
+            demand={"summer": 2},
+        ),
 
-    except ValueError:
-        print("Model solves but it should not!")
+    except ModelError:
         pass
 
 
@@ -297,23 +294,19 @@ def test_unlinked_three_temporal_levels(test_mp):
 
     # Check the model shouldn't solve
     try:
-        pytest.raises(
-            ValueError,
-            model_generator(
-                test_mp,
-                comment,
-                tec_dict,
-                time_steps=[
-                    ("Jan", 0.25, "month", "winter"),
-                    ("Feb", 0.25, "month", "winter"),
-                    ("Jun", 0.25, "month", "summer"),
-                    ("Jul", 0.25, "month", "summer"),
-                ],
-                demand={"Jan": 1, "Feb": 1},
-            ),
-        )
-    except ValueError:
-        print("Model solves but it should not!")
+        model_generator(
+            test_mp,
+            comment,
+            tec_dict,
+            time_steps=[
+                ("Jan", 0.25, "month", "winter"),
+                ("Feb", 0.25, "month", "winter"),
+                ("Jun", 0.25, "month", "summer"),
+                ("Jul", 0.25, "month", "summer"),
+            ],
+            demand={"Jan": 1, "Feb": 1},
+        ),
+    except ModelError:
         pass
 
 

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-This test ensures that COMMODITY_BALANCE works for (sub-annual) time slices (index of "time" in MESSAGEix)
-at different temporal levels, i.e., year, seasons, months, etc., and with different duration times.
+This test ensures that COMMODITY_BALANCE works for (sub-annual) time slices
+(index of "time" in MESSAGEix) at different temporal levels, i.e., year, seasons,
+months, etc., and with different duration times.
 
 """
 
@@ -34,7 +35,7 @@ def model_generator(
 ):
     """
 
-    Generates a simple model with two technologies, and a flexible number of time slices.
+    Generates a simple model with two technologies, and a number of time slices.
 
     Parameters
     ----------
@@ -42,12 +43,13 @@ def model_generator(
     comment : string
         Annotation for saving different scenarios and comparing their results.
     tec_dict : dict
-        A dictionary for a technology and required information for time-related parameters.
-        (e.g., tec_dict = {"gas_ppl": {"time_origin": ["summer"], "time": ["summer"], "time_dest": ["summer"]})
+        A dictionary for a technology and required info for time-related parameters.
+        (e.g., tec_dict = {"gas_ppl": {"time_origin": ["summer"],
+                                       "time": ["summer"], "time_dest": ["summer"]})
     time_steps : list of tuples
         Information about each time slice, packed in a tuple with four elements,
-        including: time slice name, duration relative to "year", "temporal_lvl", and parent time slice.
-        (e.g., time_steps = [("summer", 1, "season", "year")])
+        including: time slice name, duration relative to "year", "temporal_lvl",
+        and parent time slice. (e.g., time_steps = [("summer", 1, "season", "year")])
     demand : dict
         A dictionary for information of "demand" in each time slice.
         (e.g., demand = {"summer": 2.5})
@@ -141,7 +143,7 @@ def model_generator(
         == sum(scen.par("demand")["value"])
     )
 
-    # 3) Testing if "CAP" of "gas_ppl" is correctly calculated based on "ACT" in time slices
+    # 3) Test if "CAP" of "gas_ppl" is correctly calculated based on "ACT"
     # i.e., "CAP" = max("ACT" / "duration_time")
     if capacity:
         for h in act.loc[act["technology"] == "gas_ppl"]["time"]:
@@ -155,12 +157,14 @@ def model_generator(
 
 
 # Main tests for commodity balance over temporal levels (and "time" index)
-# In these tests (9 scenarios in total), "demand" is defined in different time slices with different "duration_time",
-# and there is one power plant to meet the demand ("gas_ppl"), which receives fuel from a supply technology ("gas_supply").
-# Different temporal level hierarchies are tested and linkages of "ACT" with "demand" and "CAP" is tested too.
+# In these tests (9 scenarios in total), "demand" is defined in different time slices
+# with different "duration_time", there is one power plant ("gas_ppl") to meet "demand",
+# which receives fuel from a supply technology ("gas_supply").
+# Different temporal level hierarchies are tested and linkages of "ACT" with
+# "demand" and "CAP" is tested too.
 
 # 1) "gas_ppl" is active in "summer" and NOT linked to "gas_supply" in "year"
-# This setup should not solve, as the linkgae between power plant and fuel supply is not made.
+# This setup should not solve, as no linkgae between power plant and fuel supply.
 def test_temporal_levels_not_linked(test_mp):
     comment = "1.not-linked"
     # Dictionary of technology input/output
@@ -173,7 +177,7 @@ def test_temporal_levels_not_linked(test_mp):
         "gas_supply": {"time_origin": [], "time": ["year"], "time_dest": ["year"]},
     }
 
-    # Check the model shouldn't solve if there is no link between fuel supply and power plant
+    # Check the model not solve if there is no link between fuel supply and power plant
     try:
         pytest.raises(
             ValueError,
@@ -186,17 +190,14 @@ def test_temporal_levels_not_linked(test_mp):
             ),
         )
 
-    except:
+    except ValueError:
+        print("Model solves but it should not!")
         pass
 
 
 # 2) Linking "gas_ppl" and "gas_supply" at one temporal level (e.g., "year")
 # Only one "season" (duration = 1) and "demand" is defined only at "summer"
 # Results: Model should solve and the linkage is made ("gas_supply" is active)
-# With "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" = 2, "gas_supply" = 2
-# With "duration_time_rel": CAP of "gas_ppl" = 2
-# Without "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" = 2, "gas_supply" = 2
-# Without "duration_time_rel": CAP of "gas_ppl" = 2
 def test_season_to_year(test_mp):
     comment = "2.linked-one-season-with-year"
     # Dictionary of technology input/output
@@ -220,10 +221,6 @@ def test_season_to_year(test_mp):
 # 3) Meeting "demand" in two time slices: "summer" and "winter" (duration = 0.5)
 # 3a) "gas_supply" and "gas_ppl" linked at "year"
 # Results: Model should solve and the linkage is made ("gas_supply" is active)
-# With "duration_time_rel": "demand" and "ACT" of "gas_ppl" in each "season" = 1, yearly "gas_supply" = 1
-# With "duration_time_rel": CAP of "gas_ppl" = 2
-# Without "duration_time_rel": "demand" and "ACT" of "gas_ppl" in each "season" = 1, yearly "gas_supply" = 2
-# Without "duration_time_rel": CAP of "gas_ppl" = 2
 def test_two_seasons_to_year(test_mp):
     comment = "3a.linked-two-seasons-with-year"
     # Dictionary of technology input/output
@@ -250,10 +247,6 @@ def test_two_seasons_to_year(test_mp):
 
 # 3b) "gas_supply" and "gas_ppl" linked at each season
 # Results: Model should solve and the linkage is made ("gas_supply" is active)
-# With "duration_time_rel":  "demand", "ACT" of "gas_ppl" and "gas_supply" in each "season" = 1
-# With "duration_time_rel": CAP of "gas_ppl" = 2
-# Without "duration_time_rel": "demand", "ACT" of "gas_ppl" and "gas_supply" in each "season" = 1
-# Without "duration_time_rel": CAP of "gas_ppl" = 2
 def test_seasons_to_seasons(test_mp):
     comment = "3b.linked-two-seasons-with-two-seasons"
     # Dictionary of technology input/output
@@ -284,7 +277,8 @@ def test_seasons_to_seasons(test_mp):
 
 # 4) Meeting "demand" through three temporal levels ("month", "season", and "year")
 # 4a) "month" is defined under "season" BUT "season" not linked to "year"
-# Results: Model should not solve (no parent "time" for "season", i.e., no linkage to "gas_supply" at "year")
+# Results: Model should not solve (no parent "time" for "season", i.e., no
+# linkage to "gas_supply" at "year")
 def test_unlinked_three_temporal_levels(test_mp):
     comment = "4a.unlinked-temporal-levels"
     # Dictionary of technology input/output
@@ -318,16 +312,14 @@ def test_unlinked_three_temporal_levels(test_mp):
                 demand={"Jan": 1, "Feb": 1},
             ),
         )
-    except:
+    except ValueError:
+        print("Model solves but it should not!")
         pass
 
 
 # 4b) "month" is defined under "season" AND "season" under "year"
-# Results: Model should solve, linking "month" through "season" to "year" (i.e., "gas_supply" is active)
-# With "duration_time_rel": "demand" and "ACT" of "gas_ppl" in each "month" = 1, yearly "gas_supply" = 0.5
-# With "duration_time_rel": CAP of "gas_ppl" = 4
-# Without "duration_time_rel": "demand" and "ACT" of "gas_ppl" in each "month" = 1, yearly "gas_supply" = 2
-# Without "duration_time_rel": CAP of "gas_ppl" = 4
+# Results: Model should solve, linking "month" through "season" to "year"
+# (i.e., "gas_supply" is active)
 def test_linked_three_temporal_levels(test_mp):
     comment = "4b.linked-temporal-levels"
     # Dictionary of technology input/output
@@ -359,13 +351,10 @@ def test_linked_three_temporal_levels(test_mp):
     )
 
 
-# 4c) input of "gas_ppl" from lowest temporal level ("month") and output to highest ("year")
-# output of "gas_supply" to "month", "demand" at "year"
-# Results: Model should solve, linking "month" through "season" to "year" (i.e., "gas_supply" is active)
-# With "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" in "month" = "gas_supply" = 8
-# With "duration_time_rel": CAP of "gas_ppl" = 32
-# Without "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" in "month" = "gas_supply" = 2
-# Without "duration_time_rel": CAP of "gas_ppl" = 8
+# 4c) input of "gas_ppl" from lowest temporal level ("month") and output to
+# highest ("year") output of "gas_supply" to "month", "demand" at "year"
+# Results: Model should solve, linking "month" through "season" to "year"
+# (i.e., "gas_supply" is active)
 def test_linked_three_temporal_levels_month_to_year(test_mp):
     comment = "4c.linked-temporal-levels-month-to-year"
     # Dictionary of technology input/output
@@ -400,11 +389,8 @@ def test_linked_three_temporal_levels_month_to_year(test_mp):
 
 # 4d) input of "gas_ppl" from "season" and output to "year"
 # output of "gas_supply" to "season", and "demand" at "year"
-# Results: Model should solve, linking "month" through "season" to "year" (i.e., "gas_supply" is active)
-# With "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" in "month"s = 8, "ACT" of "gas_supply" in "season" = 4
-# With "duration_time_rel": CAP of "gas_ppl" = 16
-# Without "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" in "month"s = "gas_supply" = 2
-# Without "duration_time_rel": CAP of "gas_ppl" = 4
+# Results: Model should solve, linking "month" through "season" to "year"
+# (i.e., "gas_supply" is active)
 def test_linked_three_temporal_levels_season_to_year(test_mp):
     comment = "4d.linked-temporal-levels-season-to-year"
     # Dictionary of technology input/output
@@ -439,10 +425,6 @@ def test_linked_three_temporal_levels_season_to_year(test_mp):
 
 # 4e) Meeting demand at "year", "gas_ppl" at two time slices, supply at "year"
 # Results: Model should solve, (i.e., "gas_supply" is active)
-# With "duration_time_rel": "ACT" of "gas_ppl" in each "season" = 2, yearly "ACT" of "gas_supply" = yearly "demand" = 2
-# With "duration_time_rel": CAP of "gas_ppl" = 4
-# Without "duration_time_rel": "ACT" of "gas_ppl" in each "season" = 1, yearly "ACT" of "gas_supply" = yearly "demand" = 2
-# Without "duration_time_rel": CAP of "gas_ppl" = 2
 def test_linked_three__temporal_levels_time_act(test_mp):
     comment = "4e.time-divider-aggregator"
     # Dictionary of technology input/output
@@ -471,13 +453,11 @@ def test_linked_three__temporal_levels_time_act(test_mp):
     )
 
 
-# 4f) input of "gas_ppl" from lowest temporal level ("month") with different duration time
-# and output to highest ("year"), output of "gas_supply" to "month", "demand" at "year"
-# Results: Model should solve, linking "month" through "season" to "year" (i.e., "gas_supply" is active)
-# With "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" in "month" = "gas_supply" = 8
-# With "duration_time_rel": CAP of "gas_ppl" = 32
-# Without "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" in "month" = "gas_supply" = 2
-# Without "duration_time_rel": CAP of "gas_ppl" = 8
+# 4f) input of "gas_ppl" from lowest temporal level ("month")
+# with different duration time, and output to highest ("year"), output of
+# "gas_supply" to "month", "demand" at "year"
+# Results: Model should solve, linking "month" through "season" to "year"
+# (i.e., "gas_supply" is active)
 def test_linked_three_temporal_levels_different_duration(test_mp):
     comment = "4f.linked-temporal-levels-different-duration"
     # Dictionary of technology input/output

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -178,6 +178,7 @@ def test_time_commodity(test_mp):
         pytest.raises(
             ValueError,
             model_generator(
+                test_mp,
                 comment,
                 tec_dict,
                 com_dict,
@@ -199,6 +200,7 @@ def test_time_commodity(test_mp):
     comment = "2.linked-one-season-with-year"
     tec_dict["gas_ppl"]["time_origin"] = ["year"]
     model_generator(
+        test_mp,
         comment,
         tec_dict,
         com_dict,
@@ -220,6 +222,7 @@ def test_time_commodity(test_mp):
         "winter",
     ]
     model_generator(
+        test_mp,
         comment,
         tec_dict,
         com_dict,
@@ -243,6 +246,7 @@ def test_time_commodity(test_mp):
         "winter",
     ]
     model_generator(
+        test_mp,
         comment,
         tec_dict,
         com_dict,
@@ -265,6 +269,7 @@ def test_time_commodity(test_mp):
         pytest.raises(
             ValueError,
             model_generator(
+                test_mp,
                 comment,
                 tec_dict,
                 com_dict,
@@ -288,6 +293,7 @@ def test_time_commodity(test_mp):
     # Without "duration_time_rel": CAP of "gas_ppl" = 4
     comment = "4b.linked-temporal-levels"
     model_generator(
+        test_mp,
         comment,
         tec_dict,
         com_dict,
@@ -317,6 +323,7 @@ def test_time_commodity(test_mp):
         "Feb",
     ]
     model_generator(
+        test_mp,
         comment,
         tec_dict,
         com_dict,
@@ -346,6 +353,7 @@ def test_time_commodity(test_mp):
         "summer",
     ]
     model_generator(
+        test_mp,
         comment,
         tec_dict,
         com_dict,
@@ -371,6 +379,7 @@ def test_time_commodity(test_mp):
     tec_dict["gas_ppl"]["time"] = ["summer", "winter"]
     tec_dict["gas_supply"]["time"] = tec_dict["gas_supply"]["time_dest"] = ["year"]
     model_generator(
+        test_mp,
         comment,
         tec_dict,
         com_dict,

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -10,6 +10,13 @@ from itertools import product
 from message_ix import Scenario
 
 
+# A function for adding required parameters for representing "capacity"
+def add_cap_par(scen, years, tec, data={"inv_cost": 0.1, "technical_lifetime": 5}):
+
+    for year, (parname, val) in product(years, data.items()):
+        scen.add_par(parname, ["node", tec, year], val, "-")
+
+
 # A function for generating a simple model with sub-annual time slices
 def model_generator(
     test_mp,
@@ -19,6 +26,7 @@ def model_generator(
     time_steps,
     demand,
     yr=2020,
+    capacity=True,
     unit="GWa",
 ):
     """
@@ -45,6 +53,8 @@ def model_generator(
         (e.g., demand = {"summer": 2.5})
     yr : int, optional
         Model year. The default is 2020.
+    capacity : bool, optional
+        Parameterization of capacity. The default is True.
     unit :  string
         Unit of "demand"
 
@@ -105,6 +115,10 @@ def model_generator(
                     h2,
                 ]
                 scen.add_par("input", ["node", tec] + inp_spec, 1, "-")
+
+    # Adding capacity related parameters
+    if capacity:
+        add_cap_par(scen, [2020], "gas_ppl")
 
     # Committing and solving
     scen.commit("scenario was set up.")

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 This test ensures that COMMODITY_BALANCE works for (sub-annual) time slices (index of "time" in MESSAGEix)
-at different temporal levels, like seasons, months, etc., and with different duration times.
+at different temporal levels, i.e., year, seasons, months, etc., and with different duration times.
 
 """
 
@@ -161,7 +161,7 @@ def model_generator(
 
 # 1) "gas_ppl" is active in "summer" and NOT linked to "gas_supply" in "year"
 # This setup should not solve, as the linkgae between power plant and fuel supply is not made.
-def test_commodity_not_linked(test_mp):
+def test_temporal_levels_not_linked(test_mp):
     comment = "1.not-linked"
     # Dictionary of technology input/output
     tec_dict = {
@@ -285,7 +285,7 @@ def test_seasons_to_seasons(test_mp):
 # 4) Meeting "demand" through three temporal levels ("month", "season", and "year")
 # 4a) "month" is defined under "season" BUT "season" not linked to "year"
 # Results: Model should not solve (no parent "time" for "season", i.e., no linkage to "gas_supply" at "year")
-def test_unlinked_three_temporal(test_mp):
+def test_unlinked_three_temporal_levels(test_mp):
     comment = "4a.unlinked-temporal-levels"
     # Dictionary of technology input/output
     tec_dict = {
@@ -328,7 +328,7 @@ def test_unlinked_three_temporal(test_mp):
 # With "duration_time_rel": CAP of "gas_ppl" = 4
 # Without "duration_time_rel": "demand" and "ACT" of "gas_ppl" in each "month" = 1, yearly "gas_supply" = 2
 # Without "duration_time_rel": CAP of "gas_ppl" = 4
-def test_linked_three_temporal(test_mp):
+def test_linked_three_temporal_levels(test_mp):
     comment = "4b.linked-temporal-levels"
     # Dictionary of technology input/output
     tec_dict = {
@@ -366,7 +366,7 @@ def test_linked_three_temporal(test_mp):
 # With "duration_time_rel": CAP of "gas_ppl" = 32
 # Without "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" in "month" = "gas_supply" = 2
 # Without "duration_time_rel": CAP of "gas_ppl" = 8
-def test_linked_three_levels_month_to_year(test_mp):
+def test_linked_three_temporal_levels_month_to_year(test_mp):
     comment = "4c.linked-temporal-levels-month-to-year"
     # Dictionary of technology input/output
     tec_dict = {
@@ -405,7 +405,7 @@ def test_linked_three_levels_month_to_year(test_mp):
 # With "duration_time_rel": CAP of "gas_ppl" = 16
 # Without "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" in "month"s = "gas_supply" = 2
 # Without "duration_time_rel": CAP of "gas_ppl" = 4
-def test_linked_three_levels_season_to_year(test_mp):
+def test_linked_three_temporal_levels_season_to_year(test_mp):
     comment = "4d.linked-temporal-levels-season-to-year"
     # Dictionary of technology input/output
     tec_dict = {
@@ -443,7 +443,7 @@ def test_linked_three_levels_season_to_year(test_mp):
 # With "duration_time_rel": CAP of "gas_ppl" = 4
 # Without "duration_time_rel": "ACT" of "gas_ppl" in each "season" = 1, yearly "ACT" of "gas_supply" = yearly "demand" = 2
 # Without "duration_time_rel": CAP of "gas_ppl" = 2
-def test_linked_three_levels_time_act(test_mp):
+def test_linked_three__temporal_levels_time_act(test_mp):
     comment = "4e.time-divider-aggregator"
     # Dictionary of technology input/output
     tec_dict = {
@@ -466,6 +466,45 @@ def test_linked_three_levels_time_act(test_mp):
         time_steps=[
             ("summer", 0.5, "season", "year"),
             ("winter", 0.5, "season", "year"),
+        ],
+        demand={"year": 2},
+    )
+
+
+# 4f) input of "gas_ppl" from lowest temporal level ("month") with different duration time
+# and output to highest ("year"), output of "gas_supply" to "month", "demand" at "year"
+# Results: Model should solve, linking "month" through "season" to "year" (i.e., "gas_supply" is active)
+# With "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" in "month" = "gas_supply" = 8
+# With "duration_time_rel": CAP of "gas_ppl" = 32
+# Without "duration_time_rel": "demand" = 2, "ACT" of "gas_ppl" in "month" = "gas_supply" = 2
+# Without "duration_time_rel": CAP of "gas_ppl" = 8
+def test_linked_three_temporal_levels_different_duration(test_mp):
+    comment = "4f.linked-temporal-levels-different-duration"
+    # Dictionary of technology input/output
+    tec_dict = {
+        "gas_ppl": {
+            "time_origin": ["Jan", "Feb"],
+            "time": ["Jan", "Feb"],
+            "time_dest": ["year"],
+        },
+        "gas_supply": {
+            "time_origin": [],
+            "time": ["Jan", "Feb"],
+            "time_dest": ["Jan", "Feb"],
+        },
+    }
+
+    model_generator(
+        test_mp,
+        comment,
+        tec_dict,
+        time_steps=[
+            ("summer", 0.5, "season", "year"),
+            ("winter", 0.5, "season", "year"),
+            ("Jan", 0.4, "month", "winter"),
+            ("Feb", 0.1, "month", "winter"),
+            ("Jun", 0.3, "month", "summer"),
+            ("Jul", 0.2, "month", "summer"),
         ],
         demand={"year": 2},
     )

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -178,7 +178,7 @@ def model_generator(
 
 
 # Main tests for commodity balance over various temporal levels (and "time" index)
-# In these tests (9 + 2 scenarios in total), "demand" is defined in different time slices
+# In these tests (11 scenarios in total), "demand" is defined in different time slices
 # with different "duration_time", there is one power plant ("gas_ppl") to meet "demand",
 # which receives fuel from a supply technology ("gas_supply").
 # Different temporal level hierarchies are tested, by linkages of "ACT" with

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -102,7 +102,7 @@ def model_generator(
     scen.add_set("time", [x[0] for x in time_steps])
     scen.add_set("time", [x[3] for x in time_steps])
     for x in relative_time:
-        scen.add_set("relative_time", x)
+        scen.add_set("time_relative", x)
 
     # Adding "time" and "duration_time" to the model
     for (h, dur, tmp_lvl, parent) in time_steps:

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -69,11 +69,11 @@ def test_reporter_from_scenario(message_test_mp):
     assert_qty_equal(obs, demand, check_attrs=False)
 
     # ixmp.Reporter pre-populated with only model quantities and aggregates
-    assert len(rep_ix.graph) == 5223
+    assert len(rep_ix.graph) == 5224
 
     # message_ix.Reporter pre-populated with additional, derived quantities
     # This is the same value as in test_tutorials.py
-    assert len(rep.graph) == 12688
+    assert len(rep.graph) == 12689
 
     # Derived quantities have expected dimensions
     vom_key = rep.full_key("vom")

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -51,7 +51,7 @@ tutorials: List[Tuple] = [
     (("westeros", "westeros_addon_technologies"), [], {}),
     (("westeros", "westeros_historical_new_capacity"), [], {}),
     # NB this is the same value as in test_reporter()
-    (("westeros", "westeros_report"), [("len-rep-graph", 12688)], {}),
+    (("westeros", "westeros_report"), [("len-rep-graph", 12689)], {}),
     ((AT, "austria"), [("solve-objective-value", 206321.90625)], {}),
     (
         (AT, "austria_single_policy"),


### PR DESCRIPTION
This PR aims to improve the representation of sub-annual time slices, hereafter simply "time slices", in the GAMS code, and remove inconsistencies across the formulation in relation to the relative duration of time slices represented as `duration_time_rel`. This enhancement will resolve the bug reported in [#Issue 363](https://github.com/iiasa/message_ix/issues/363) and [#371](https://github.com/iiasa/message_ix/issues/371) , and the tests designed in this PR will check the issues discussed in [#Issue 193](https://github.com/iiasa/message_ix/issues/193). More details as follows:

**Background:**
The existing GAMS formulation uses `duration_time_rel` when evaluating _values_ in different MESSAGEix parameters for the index of `time` based on the duration of that time slice relative to the parent time. This means the numbers seen in the parameters and variables with the index of `time` do NOT have the same unit, as the unit will depend on the duration of each time slice _relative_ to the parent time. Let's consider a model with time slices of  "year", "summer", and "hour":
- if a user looks into the GDX files of this model, which do not show the units, they cannot easily compare values, e.g., `ACT` of a technology in different time slices, as these values may have different units, e.g., GWa, GWh, GW-summer, etc.
- parameterization of such scenarios is difficult, e.g., for specifying `var_cost` of a technology in different time slices, the user needs to enter different values with different units, e.g., $/kWa, $/kWh, $/kW-summer.


**Solution proposed here:**

1. This PR suggests adding an option to deactivate `duration_time_rel` in the equations, by making that equal to 1, which makes the units consistent across different time slices. This makes all values across all time slices in MESSAGEix parameters or variables to be in the same unit. This is done by introducing a new set `time_relative()`, by which the user can define which time slices should be relative. This set by default is empty, i.e., no relative time is taken into account unless specified by the user.

2. This PR adds several tests to check `COMMODITY_BALANCE` across different temporal levels with different `duration_time`. The tests are also checking the relationship between `ACT` and `CAP` for scenarios with various temporal levels, which should be established through `CAPACITY_MAINTENANCE`. 

## How to review

For reviewing this PR, the reviewer can run a MESSAGEix model with time slices with different `duration_time`. Alternatively, the reviewer can run the tests designed in this PR. The outcome of the model solution must report `ACT` in different time slices with the values irrespective of the duration of that time slice.

## PR checklist
- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
