### PR TITLE
Change precision of GAMS check for parameter "duration_time"

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -9,6 +9,7 @@ All changes
 - Update reference for activity and capacity soft constraints (:pull:`474`).
 - Update :meth:`.years_active` to use sorted results (:pull:`491`).
 - Adjust the Westeros reporting tutorial to pyam 1.0 deprecations (:pull:`492`).
+- Change precision of GAMS check for parameter "duration_time" (:pull:`513`).
 
 
 .. _v3.3.0:

--- a/doc/time.rst
+++ b/doc/time.rst
@@ -55,8 +55,9 @@ Example 4
 
 Duration of sub-annual time slices
 ----------------------------------
-The duration of each sub-annual time slice should be defined relative to the whole year, with
-a value between 0 and 1, using parameter ``duration_time``. For example, in a model with four seasons with the same length, ``duration_time`` of each season will be 0.25.
+The duration of each sub-annual time slice should be defined relative to the whole year, with a value
+between 0 and 1, using parameter ``duration_time``. For example, in a model with four seasons with the same length, ``duration_time`` of each season will be 0.25.
+This information is needed to calculate capacity of a technology that is active in different time slices.
 When there are more than one temporal levels, e.g., "season", "month", "day", etc., ``duration_time`` is defined for each **temporal level** separately.
 The sum of ``duration_time`` at each temporal level must be equal to 1. For example, in a model with 4 time slices as "season" and 10 time slices as "day" under each "season",
 ``duration_time`` of each "season" and "day" should be specified as 0.25 and 0.025, respectively.

--- a/doc/time.rst
+++ b/doc/time.rst
@@ -53,7 +53,15 @@ Example 4
    - The ``time`` element 'summer', **used alone**, refers to a portion of any year.
    - In a |MESSAGEix| parameter indexed by (``year``, ``time``, …), values with the key (``2002``, 'summer', ...) refer to the 'summer' portion of the final year (2002-01-01 to 2002-12-31) within the entire period (2001-01-01 to 2002-12-31) denoted by ``2002``.
 
-
+Duration of sub-annual time slices
+----------------------------------
+The duration of each sub-annual time slice should be defined relative to the whole year, with
+a value between 0 and 1, using parameter ``duration_time``. For example, in a model with four seasons with the same length, ``duration_time`` of each season will be 0.25.
+When there are more than one temporal levels, e.g., "season", "month", "day", etc., ``duration_time`` is defined for each **temporal level** separately.
+The sum of ``duration_time`` at each temporal level must be equal to 1. For example, in a model with 4 time slices as "season" and 10 time slices as "day" under each "season",
+``duration_time`` of each "season" and "day" should be specified as 0.25 and 0.025, respectively.
+season
+ 
 Discounting
 ===========
 

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -201,8 +201,8 @@ if (check,
 * check for validity of temporal resolution
 loop(lvl_temporal,
     loop(time2$( sum(time, map_temporal_hierarchy(lvl_temporal,time,time2) ) ),
-        check = 1$( sum( time$( map_temporal_hierarchy(lvl_temporal,time,time2) ),
-            duration_time(time) ) ne duration_time(time2) ) ;
+        check = 1$( abs( sum( time$( map_temporal_hierarchy(lvl_temporal,time,time2) ),
+            duration_time(time) ) - duration_time(time2) ) > 1e-9 );
     ) ;
 ) ;
 if (check,

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -202,7 +202,7 @@ if (check,
 loop(lvl_temporal,
     loop(time2$( sum(time, map_temporal_hierarchy(lvl_temporal,time,time2) ) ),
         check = 1$( abs( sum( time$( map_temporal_hierarchy(lvl_temporal,time,time2) ),
-            duration_time(time) ) - duration_time(time2) ) > 1e-9 );
+            duration_time(time) ) - duration_time(time2) ) > 1e-12 );
     ) ;
 ) ;
 if (check,

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -198,7 +198,7 @@ if (check,
     abort "There is a problem with the definition of the technical lifetime!" ;
 ) ;
 
-* check for validity of temporal resolution
+* check for validity of temporal resolution with an accepted difference in the scale of 1e-12, due to the different percision between GAMS and python values.
 loop(lvl_temporal,
     loop(time2$( sum(time, map_temporal_hierarchy(lvl_temporal,time,time2) ) ),
         check = 1$( abs( sum( time$( map_temporal_hierarchy(lvl_temporal,time,time2) ),

--- a/message_ix/tests/test_feature_duration_time.py
+++ b/message_ix/tests/test_feature_duration_time.py
@@ -35,9 +35,7 @@ def model_generator(
         A dictionary for mapping a technology to its input/output temporal levels.
     demand_time : dict
         A dictionary for mapping the total "demand" specified at a temporal level.
-        e.g., {"season": 100}, means the sum of demand in all "time"
-        slices at the level of "season" must be 100.
-    time_steps : list of lists
+    time_steps : list of tuples
         Information about each time slice, packed in a tuple with three elements,
         including: "temporal_lvl", number of time slices, and the parent time slice.
     com_dict : dict
@@ -136,7 +134,7 @@ def model_generator(
     # Testing if the model solves in GAMS
     scen.solve(case=comment)
 
-    # Testing if sum of duration_time is almost 1
+    # Testing if sum of "duration_time" is almost 1
     for tmp_lvl in scen.set("lvl_temporal"):
         times = scen.set("map_temporal_hierarchy", {"lvl_temporal": tmp_lvl})[
             "time"
@@ -160,7 +158,7 @@ def test_season(test_mp, n_time=[4, 12, 50]):
 
     for t in n_time:
         time_steps = [("season", t, "year")]
-        # Check the model solves without error and sum of duration times = 1
+        # Check the model solves without error and sum of "duration_time" = 1
         model_generator(test_mp, comment, tec_time, demand_time, time_steps, com_dict)
 
 

--- a/message_ix/tests/test_feature_duration_time.py
+++ b/message_ix/tests/test_feature_duration_time.py
@@ -7,10 +7,7 @@ months; and different number of time slices at each level are tested.
 
 """
 
-import os
 from itertools import product
-
-import pytest
 
 from message_ix import Scenario
 

--- a/message_ix/tests/test_feature_duration_time.py
+++ b/message_ix/tests/test_feature_duration_time.py
@@ -159,7 +159,7 @@ def model_generator(
 # to meet demand, which receives fuel from a supply technology.
 
 # 1) Testing one temporal level ("season") and different number of time slices
-def test_season(test_mp, n_time=[4, 12, 50, 122, 360, 2240]):
+def test_season(test_mp, n_time=[4, 12, 50, 122]):
     comment = "season"
     com_dict = {"power-plant": {"input": [], "output": "electr"}}
     # Dictionary of technology and input and output temporal levels
@@ -174,7 +174,7 @@ def test_season(test_mp, n_time=[4, 12, 50, 122, 360, 2240]):
 
 
 # 2) Testing one temporal level ("season") linked to "year" with a technology
-def test_year_season(test_mp, n_time=[4, 12, 50, 122, 360, 2240]):
+def test_year_season(test_mp, n_time=[4, 365, 2400]):
     comment = "year_season"
     com_dict = {
         "power-plant": {"input": "fuel", "output": "electr"},
@@ -244,6 +244,38 @@ def test_year_season_day(test_mp):
     demand_time = {"day": 100}
     # List of info for time slices: [temporal level, number, parent level]
     time_steps = [["season", 4, "year"], ["day", 60, "season"]]
+
+    # Check the model solves without error and sumof duration times = 1
+    model_generator(test_mp, comment, tec_time, demand_time, time_steps, com_dict)
+
+
+# 6) Testing four temporal levels (year, season, day, hour) with four technologies
+def test_year_season_day_hour(test_mp):
+    n_season = 4
+    n_day = 2
+    n_hour = 6
+    comment = "y_4s_2d_6h"
+    com_dict = {
+        "power-plant": {"input": "fuel", "output": "electr"},
+        "fuel-transport": {"input": "fuel", "output": "fuel"},
+        "fuel-processing": {"input": "raw fuel", "output": "fuel"},
+        "fuel-supply": {"input": [], "output": "raw fuel"},
+    }
+    # Dictionary of technology and temporal levels
+    tec_time = {
+        "power-plant": ["day", "hour"],
+        "fuel-transport": ["season", "day"],
+        "fuel-processing": ["year", "season"],
+        "fuel-supply": ["year", "year"],
+    }
+    # Total demand in a temporal level
+    demand_time = {"hour": 100}
+    # List of info for time slices: [temporal level, number, parent level]
+    time_steps = [
+        ["season", n_season, "year"],
+        ["day", n_day, "season"],
+        ["hour", n_hour, "day"],
+    ]
 
     # Check the model solves without error and sumof duration times = 1
     model_generator(test_mp, comment, tec_time, demand_time, time_steps, com_dict)


### PR DESCRIPTION
This PR changes the way the GAMS formulation checks the sum of `duration_time` of sub-annual time slices (hereafter "time slices"). At the moment, GAMS checks that the sum of `duration_time` at a temporal level is equal to 1. However, as the precision differs between GAMS and python values, in some cases a very small, negligible difference in the scale of 1e-12 triggers an error.  This PR changes the way this check, is done in GAMS, i.e., from equality to 1 to check if the difference is smaller than 1e-12.

## How to review

For testing this PR a model with time slices should be used, preferably with many time slices with different `duration_time`. The review can use the tests designed in this PR, change the number of time slices per year and see if the check for the sum of `duration_time` in GAMS works.

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
