### PR TITLE
Fix CI failures in the run "Check typing with mypy" of the lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -65,6 +65,9 @@ jobs:
       env:
         MYPYPATH: "../ixmp/"
       # Also install type stubs and full packages that provide type hints
+      # and ensure the installation of the latest packages
       run: |
+        pip install llvmlite==0.37.0 numba==0.54.1 scipy==1.7.1
+
         pip install mypy genno sphinx types-pkg_resources types-requests types-PyYAML
         mypy .


### PR DESCRIPTION
As part of #523, the "Check typing with mypy" run of the lint workflow began to fail. 
Closes #528. 

## How to review

No review/FYI only: changes to CI.

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
- [ ] ~Add or expand tests;~ coverage checks both ✅

