### PR TITLE
Remove extras_require genno[plotnine]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,8 +55,6 @@ tutorial =
     %(report)s
     jupyter
     matplotlib
-    # TODO move this upstream to ixmp[report]
-    genno[plotnine]
 tests =
     %(docs)s
     %(tutorial)s


### PR DESCRIPTION
This PR removes `genno[plotnine]` from the setup.cfg since it is, when merging  https://github.com/iiasa/ixmp/pull/431 (and releasing `ixmp`), implied by `ixmp[report]` and therefore by `%(report)s`. See ToDo in `message_ix` [here](https://github.com/iiasa/message_ix/blob/main/setup.cfg#L58).


## How to review
- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
<!--

