### PR TITLE
Address failing "Install from conda-forge" workflow

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -7,8 +7,8 @@ on:
   schedule:
   - cron: "0 5 * * *"
   # Uncomment to debug
-  # pull_request:
-  #   branches: [ main ]
+  pull_request:
+   branches: [ main ]
 
 jobs:
   conda:

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -17,7 +17,7 @@ jobs:
         os: [windows-latest]
 #        os: [ windows-latest, macos-latest ]
         conda:
-        - {installer: anaconda, version: 2018.12}
+        - {installer: anaconda, version: 2019.03}
 #        - {installer: miniconda, version: py39_4.10.3}
         extra-deps: ["", "JPype1=1.2.1"]
       fail-fast: false
@@ -65,6 +65,7 @@ jobs:
         CONDA_INSTRUMENTATION_ENABLED: 1
       run: |
         conda config --prepend channels conda-forge
+        conda clean --packages
         conda update -n base -c defaults conda
 
         # Also install pytest and packages required for testing. pip/PyPI

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -74,7 +74,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         conda config --prepend channels conda-forge
-        conda config --set channel_priority strict
+        # conda config --set channel_priority strict
         conda update -n base -c defaults conda
 
         # Also install pytest and packages required for testing. pip/PyPI

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -67,7 +67,7 @@ jobs:
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix">1.0.0" ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda create --quiet --name testenv python=3.9.0 message-ix">1.0.0" ${{ matrix.extra-deps }} pytest asyncssh sphinx
         conda list --name testenv
 
     - name: Configure conda channels, create environment, and install message-ix
@@ -79,7 +79,7 @@ jobs:
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix">1.0.0" ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda create --quiet --name testenv python=3.9.0 message-ix">1.0.0" ${{ matrix.extra-deps }} pytest asyncssh sphinx
         conda list --name testenv
 
     - name: Check CLI commands and run test

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -60,8 +60,21 @@ jobs:
       run: conda init ${{ steps.shell.outputs.init }}
 
     - name: Configure conda channels, create environment, and install message-ix
+      if: matrix.os == 'windows-latest'
       run: |
         conda config --prepend channels conda-forge
+        conda update -n base -c defaults conda
+
+        # Also install pytest and packages required for testing. pip/PyPI
+        # supports this via message_ix[testing], but conda does not.
+        conda create --quiet --name testenv message-ix ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda list --name testenv
+
+    - name: Configure conda channels, create environment, and install message-ix
+      if: matrix.os == 'macos-latest'
+      run: |
+        conda config --prepend channels conda-forge
+        conda config --set channel_priority strict
         conda update -n base -c defaults conda
 
         # Also install pytest and packages required for testing. pip/PyPI

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -14,10 +14,11 @@ jobs:
   conda:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-latest]
+#        os: [ windows-latest, macos-latest ]
         conda:
-        - {installer: anaconda, version: 2019.03}
-        - {installer: miniconda, version: py39_4.10.3}
+        - {installer: anaconda, version: 2018.12}
+#        - {installer: miniconda, version: py39_4.10.3}
         extra-deps: ["", "JPype1=1.2.1"]
       fail-fast: false
 

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -63,7 +63,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         conda config --prepend channels conda-forge
-        conda update -n base -c defaults conda
+        conda update --all
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
@@ -75,7 +75,7 @@ jobs:
       run: |
         conda config --prepend channels conda-forge
         # conda config --set channel_priority strict
-        conda update -n base -c defaults conda
+        conda update --all
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -63,7 +63,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         conda config --prepend channels conda-forge
-        conda update --all
+        conda update -n base -c defaults conda
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
@@ -75,7 +75,7 @@ jobs:
       run: |
         conda config --prepend channels conda-forge
         conda config --set channel_priority strict
-        conda update --all
+        conda update -n base -c defaults conda
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -14,7 +14,7 @@ jobs:
   conda:
     strategy:
       matrix:
-        os: [ windows-latest, macos-latest ]
+        os: [windows-latest, macos-latest]
         conda:
         - {installer: anaconda, version: 2021.05}
         - {installer: miniconda, version: py39_4.10.3}
@@ -59,22 +59,18 @@ jobs:
     - name: Initialize shell for "conda activate"
       run: conda init ${{ steps.shell.outputs.init }}
 
-    - name: Configure conda channels, create environment, and install message-ix
-      if: matrix.os == 'windows-latest'
-      run: |
-        conda config --prepend channels conda-forge
-        conda update -n base -c defaults conda
-
-        # Also install pytest and packages required for testing. pip/PyPI
-        # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix ${{ matrix.extra-deps }} pytest asyncssh sphinx
-        conda list --name testenv
-
-    - name: Configure conda channels, create environment, and install message-ix
+    - name: Configure conda channels (macOS)
       if: matrix.os == 'macos-latest'
       run: |
-        conda config --prepend channels conda-forge
-        conda config --set channel_priority strict
+        conda config --prepend channels conda-forge/osx-64
+        conda config --prepend channels conda-forge/noarch
+
+    - name: Condigure conda channels (Windows)
+      if: matrix.os == 'windows-latest'
+      run: conda config --prepend channels conda-forge
+
+    - name: Update conda, create environment, and install message-ix
+      run: |
         conda update -n base -c defaults conda
 
         # Also install pytest and packages required for testing. pip/PyPI

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -60,8 +60,20 @@ jobs:
       run: conda init ${{ steps.shell.outputs.init }}
 
     - name: Configure conda channels, create environment, and install message-ix
+      if: matrix.os == 'windows-latest'
       run: |
         conda config --prepend channels conda-forge
+
+        # Also install pytest and packages required for testing. pip/PyPI
+        # supports this via message_ix[testing], but conda does not.
+        conda create --quiet --name testenv message-ix ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda list --name testenv
+
+    - name: Configure conda channels, create environment, and install message-ix
+      if: matrix.os == 'macos-latest'
+      run: |
+        conda config --prepend channels conda-forge
+        conda config --set channel_priority strict
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -66,7 +66,7 @@ jobs:
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda create --quiet --name testenv message-ix">1.0.0" ${{ matrix.extra-deps }} pytest asyncssh sphinx
         conda list --name testenv
 
     - name: Configure conda channels, create environment, and install message-ix
@@ -77,7 +77,7 @@ jobs:
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda create --quiet --name testenv message-ix">1.0.0" ${{ matrix.extra-deps }} pytest asyncssh sphinx
         conda list --name testenv
 
     - name: Check CLI commands and run test

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -60,26 +60,15 @@ jobs:
       run: conda init ${{ steps.shell.outputs.init }}
 
     - name: Configure conda channels, create environment, and install message-ix
-      if: matrix.os == 'windows-latest'
+      env:
+        CONDA_INSTRUMENTATION_ENABLED: 1
       run: |
         conda config --prepend channels conda-forge
-        conda update --all
+        conda update -n base -c defaults conda
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv python=3.9.0 message-ix">1.0.0" ${{ matrix.extra-deps }} pytest asyncssh sphinx
-        conda list --name testenv
-
-    - name: Configure conda channels, create environment, and install message-ix
-      if: matrix.os == 'macos-latest'
-      run: |
-        conda config --prepend channels conda-forge
-        # conda config --set channel_priority strict
-        conda update --all
-
-        # Also install pytest and packages required for testing. pip/PyPI
-        # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv python=3.9.0 message-ix">1.0.0" ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda create --quiet --name testenv message-ix">1.0.0" ${{ matrix.extra-deps }} pytest asyncssh sphinx
         conda list --name testenv
 
     - name: Check CLI commands and run test

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -14,11 +14,10 @@ jobs:
   conda:
     strategy:
       matrix:
-        os: [windows-latest]
-#        os: [ windows-latest, macos-latest ]
+        os: [ windows-latest, macos-latest ]
         conda:
         - {installer: anaconda, version: 2021.05}
-#        - {installer: miniconda, version: py39_4.10.3}
+        - {installer: miniconda, version: py39_4.10.3}
         extra-deps: ["", "JPype1=1.2.1"]
       fail-fast: false
 
@@ -61,16 +60,13 @@ jobs:
       run: conda init ${{ steps.shell.outputs.init }}
 
     - name: Configure conda channels, create environment, and install message-ix
-      env:
-        CONDA_INSTRUMENTATION_ENABLED: 1
       run: |
         conda config --prepend channels conda-forge
-        conda clean --packages
         conda update -n base -c defaults conda
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix">1.0.0" ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda create --quiet --name testenv message-ix ${{ matrix.extra-deps }} pytest asyncssh sphinx
         conda list --name testenv
 
     - name: Check CLI commands and run test

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -47,35 +47,35 @@ jobs:
       id: shell
       run: |
         init, profile = {
-          "macos": ("bash", "source ~/.bash_profile"),
-          "windows": ("powershell", ""),
+            "macos": ("bash", "source ~/.bash_profile"),
+            "windows": ("powershell", ""),
         }.get("${{ matrix.os }}".split("-")[0])
         print(f"""
-          ::set-output name=init::{init}
-          ::set-output name=profile::{profile}
+            ::set-output name=init::{init}
+            ::set-output name=profile::{profile}
         """)
       shell: python
 
     - name: Initialize shell for "conda activate"
       run: conda init ${{ steps.shell.outputs.init }}
 
-    - name: Configure conda channels (macOS)
-      if: matrix.os == 'macos-latest'
+    - name: Determine conda version spec
+      id: spec
       run: |
-        conda config --prepend channels conda-forge/osx-64
-        conda config --prepend channels conda-forge/noarch
+        print(
+            "::set-output name=version::" +
+            (">1" if "${{ matrix.os }}".split("-")[0] == "macos" else "")
+        )
+      shell: python
 
-    - name: Condigure conda channels (Windows)
-      if: matrix.os == 'windows-latest'
-      run: conda config --prepend channels conda-forge
-
-    - name: Update conda, create environment, and install message-ix
+    - name: Configure conda channels, update, create environment, and install message-ix
       run: |
+        conda config --prepend channels conda-forge
         conda update -n base -c defaults conda
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda create --quiet --name testenv "message-ix${{ steps.spec.outputs.version }}" ${{ matrix.extra-deps }} pytest asyncssh sphinx
         conda list --name testenv
 
     - name: Check CLI commands and run test

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -17,7 +17,7 @@ jobs:
         os: [windows-latest]
 #        os: [ windows-latest, macos-latest ]
         conda:
-        - {installer: anaconda, version: 2019.03}
+        - {installer: anaconda, version: 2021.05}
 #        - {installer: miniconda, version: py39_4.10.3}
         extra-deps: ["", "JPype1=1.2.1"]
       fail-fast: false

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -63,6 +63,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         conda config --prepend channels conda-forge
+        conda update --all
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
@@ -74,6 +75,7 @@ jobs:
       run: |
         conda config --prepend channels conda-forge
         conda config --set channel_priority strict
+        conda update --all
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -7,8 +7,8 @@ on:
   schedule:
   - cron: "0 5 * * *"
   # Uncomment to debug
-  pull_request:
-   branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
 
 jobs:
   conda:


### PR DESCRIPTION
This PR solves the failing "Install from conda-forge" workflow.
Further discussion and insights related to this PR/issue can be found in the [MESSAGEix slack channel thread](https://iiasa-ece.slack.com/archives/CD0GBHHA4/p1642694884041600 ).
Closes issue #540. 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅

