### PR TITLE
Adjust declaration of time_relative(time)

### DIFF
--- a/message_ix/model/MESSAGE/sets_maps_def.gms
+++ b/message_ix/model/MESSAGE/sets_maps_def.gms
@@ -307,7 +307,7 @@ Sets
     cat_emission(type_emission,emission)    mapping of emissions to respective categories
     type_tec_land(type_tec)                 dynamic set whether emissions from land use are included in type_tec
     balance_equality(commodity,level)       mapping of commodities-level where the supply-demand balance must be maintained with equality
-    time_relative(time)                     flag for treating unit of ACT in sub-annual time slices relative to parent 'time' (=activating parameter 'duration_time_rel')
+    time_relative(time)                     flag for treating unit of ACT in sub-annual time slices relative to parent 'time' (activating parameter 'duration_time_rel')
 ;
 
 Alias(type_tec,type_tec_share);


### PR DESCRIPTION
This PR adjusts the declaration of `time_relative(time)` by deleting "=" to address failing tests / scenario runs with GAMS version 24.9.1.
Closes https://github.com/iiasa/message_ix/issues/546.

## How to review

- Read the diff and note that the CI checks all pass.
- Run a scenario via CLI / run pytest locally with GAMS version 24.9.1

## PR checklist

- [x] Continuous integration checks all ✅
