### PR TITLE
Read GAMS CPLEX solver options for MESSAGE from user config

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,8 +31,8 @@ jobs:
     - uses: actions/setup-python@v2
       # This should match the "Latest version testable on GitHub Actions"
       # in pytest.yaml
-      with:
-        python-version: "3.9"
+      # with:
+      #   python-version: "3.10"
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -40,8 +40,8 @@ jobs:
     - uses: actions/setup-python@v2
       # This should match the "Latest version testable on GitHub Actions"
       # in pytest.yaml
-      with:
-        python-version: "3.9"
+      # with:
+      #   python-version: "3.10"
 
     - name: Cache GAMS installer and Python packages
       uses: actions/cache@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
       # This should match the "Latest version testable on GitHub Actions"
       # in pytest.yaml
       # with:
-      #   python-version: "3.9"
+      #   python-version: "3.10"
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -83,14 +83,6 @@ jobs:
     - uses: r-lib/actions/setup-r@v2
       id: setup-r
 
-    - name: Use OpenJDK 14 (macOS only)
-      # Using the default OpenJDK 1.8 on the macos-latest runner produces
-      # "Abort trap: 6" when JPype1 starts the JVM
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      uses: actions/setup-java@v2
-      with:
-        java-version: '14'
-
     - name: Cache GAMS installer, Python packages, and R packages
       uses: actions/cache@v2
       with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Cancel previous runs that have not completed
-      uses: styfle/cancel-workflow-action@0.7.0
+      uses: styfle/cancel-workflow-action@0.9.1
       with:
         access_token: ${{ github.token }}
 
@@ -80,14 +80,14 @@ jobs:
       run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
       shell: bash
 
-    - uses: r-lib/actions/setup-r@master
+    - uses: r-lib/actions/setup-r@v2
       id: setup-r
 
     - name: Use OpenJDK 14 (macOS only)
       # Using the default OpenJDK 1.8 on the macos-latest runner produces
       # "Abort trap: 6" when JPype1 starts the JVM
       if: ${{ startsWith(matrix.os, 'macos') }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: '14'
 
@@ -151,6 +151,6 @@ jobs:
       run: make --directory=doc html
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v1.2.1
+      uses: codecov/codecov-action@v2
       with:
-        root_dir: message_ix
+        directory: message_ix

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -20,15 +20,22 @@ jobs:
         - ubuntu-latest
         - windows-latest
         python-version:
-        - "3.6"  # Earliest version supported by message_ix
+        - "3.7"  # Earliest version supported by message_ix
         - "3.8"
-        - "3.9"  # Latest release / latest supported by message_ix
+        - "3.9"
+        - "3.10"  # Latest release / latest supported by message_ix
 
-        # For development versions of Python, compiled binary wheels are not
-        # available for some dependencies, e.g. llvmlite, numba, numpy, and/or
-        # pandas. Compiling these on the job runner requires a more elaborate
-        # build environment, currently out of scope for the message_ix project.
+        # For freshy released or development versions of Python, compiled
+        # binary wheels are not available for some dependencies, e.g. llvmlite,
+        # numba, numpy, and/or pandas. Compiling these on the job runner
+        # requires a more elaborate build environment, currently out of scope
+        # for the message_ix project.
         # - "3.10.0-alpha.1"  # Development version
+
+        exclude:
+        # JPype1 (for ixmp) binary wheels are not available for this combination
+        - os: windows-latest
+          python-version: "3.10"
 
       fail-fast: false
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,8 +1,10 @@
-.. Next release
-.. ============
+Next release
+============
 
-.. All changes
-.. -----------
+All changes
+-----------
+
+- Allow setting the “model_dir” and “solve_options” options for :class:`.GAMSModel` (and subclasses :class:`.MESSAGE`, :class:`.MACRO`, and :class:`.MESSAGE_MACRO`) through the user's ixmp configuration file; expand documentation (:pull:`557`).
 
 .. _v3.4.0:
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -93,49 +93,111 @@ Model classes
 
    These configure the GAMS CPLEX solver (or another solver, if selected); see `the solver documentation <https://www.gams.com/latest/docs/S_CPLEX.html>`_ for possible values.
 
+.. autoclass:: GAMSModel
+   :members:
+   :exclude-members: defaults
+
+   The :class:`.MESSAGE`, :class:`MACRO`, and :class:`MESSAGE_MACRO` child classes encapsulate the GAMS code for the core MESSAGE (or MACRO) mathematical formulation.
+
+   The class receives `model_options` via :meth:`.Scenario.solve`. Some of these are passed on to the parent class :class:`ixmp.model.gams.GAMSModel` (see there for a list); others are handled as described below.
+
+   The “model_dir” option may be set in the user's :ref:`ixmp configuration file <ixmp:configuration>` using the key “message model dir”.
+   If not set, it defaults to “message_ix/model” below the directory where :mod:`message_ix` is installed.
+
+   The “solve_options” option may be set in the user's ixmp configuration file using the key “message solve options”.
+   If not set, it defaults to :data:`.DEFAULT_CPLEX_OPTIONS`.
+
+   For example, with the following configuration file:
+
+   .. code-block:: yaml
+
+      {
+        "platform": {
+          "default": "my-platform",
+          "my-platform": {"backend": "jdbc", "etc": "etc"},
+        },
+        "message model dir": "/path/to/custom/gams/source/files",
+        "message solve options": {"lpmethod": 4},
+      }
+
+   The following are equivalent:
+
+   .. code-block:: python
+
+      # Model options given explicitly
+      scen.solve(
+          model_dir="/path/to/custom/gams/source/files",
+          solve_options=dict(lpmethod=4),
+      )
+
+      # Model options are read from configuration file
+      scen.solve()
+
+   The following tables list all model options:
+
+   .. list-table:: Options in :class:`message_ix.models.GAMSModel` or overridden from :mod:`ixmp`
+      :widths: 20 40 40
+      :header-rows: 1
+
+      * - Option
+        - Usage
+        - Default value
+      * - **model_dir**
+        - Path to GAMS source files.
+        - See above.
+      * - **model_file**
+        - Path to GAMS source file.
+        - ``'{model_dir}/{model_name}_run.gms'``
+      * - **in_file**
+        - Path to write GDX input file.
+        - ``'{model_dir}/data/MsgData_{case}.gdx'``
+      * - **out_file**
+        - Path to read GDX output file.
+        - ``'{model_dir}/output/MsgOutput_{case}.gdx'``
+      * - **solve_args**
+        - Arguments passed directly to GAMS.
+        - .. code-block::
+
+             [
+                 '--in="{in_file}"',
+                 '--out="{out_file}"',
+                 '--iter="{model_dir}/output/MsgIterationReport_{case}.gdx"'
+             ]
+      * - **solve_options**
+        - Options for the GAMS LP solver.
+        - :data:`.DEFAULT_CPLEX_OPTIONS`
+
+   .. list-table:: Option defaults inherited from :class:`ixmp.model.gams.GAMSModel`
+      :widths: 20 80
+      :header-rows: 1
+
+      * - Option
+        - Default value
+      * - **case**
+        - ``'{scenario.model}_{scenario.scenario}'``
+      * - **gams_args**
+        - ``['LogOption=4']``
+      * - **check_solution**
+        - :obj:`True`
+      * - **comment**
+        - :obj:`None`
+      * - **equ_list**
+        - :obj:`None`
+      * - **var_list**
+        - :obj:`None`
+
 .. autoclass:: MESSAGE
    :members: initialize
    :exclude-members: defaults
    :show-inheritance:
 
-   The MESSAGE Python class encapsulates the GAMS code for the core MESSAGE mathematical formulation.
-   The *model_options* arguments are received from :meth:`.Scenario.solve`, and—except for *solve_options*—are passed on to the parent class :class:`~ixmp.model.gams.GAMSModel`; see there for a full list of options.
-
    .. autoattribute:: name
-
-   .. autoattribute:: defaults
-      :annotation: = dict(...)
-
-      The paths to MESSAGE GAMS source files use the ``MODEL_PATH`` configuration setting.
-      ``MODEL_PATH``, in turn, defaults to "message_ix/model" inside the directory where :mod:`message_ix` is installed.
-
-      ================== ===
-      Key                Value
-      ================== ===
-      MESSAGE defaults
-      ----------------------
-      **model_file**     ``'{MODEL_PATH}/{model_name}_run.gms'``
-      **in_file**        ``'{MODEL_PATH}/data/MsgData_{case}.gdx'``
-      **out_file**       ``'{MODEL_PATH}/output/MsgOutput_{case}.gdx'``
-      **solve_args**     ``['--in="{in_file}"', '--out="{out_file}"', '--iter="{MODEL_PATH}/output/MsgIterationReport_{case}.gdx"']``
-      ------------------ ---
-      Inherited from :class:`~ixmp.model.gams.GAMSModel`
-      ----------------------
-      **case**           ``'{scenario.model}_{scenario.scenario}'``
-      **gams_args**      ``['LogOption=4']``
-      **check_solution** :obj:`True`
-      **comment**        :obj:`None`
-      **equ_list**       :obj:`None`
-      **var_list**       :obj:`None`
-      ================== ===
-
 
 .. autoclass:: MACRO
    :members:
    :show-inheritance:
 
    .. autoattribute:: name
-
 
 .. autoclass:: MESSAGE_MACRO
    :members:
@@ -158,11 +220,6 @@ Model classes
 
    .. autoattribute:: name
 
-.. autoclass:: GAMSModel
-   :members:
-   :exclude-members: defaults
-   :show-inheritance:
-
 .. autodata:: MESSAGE_ITEMS
    :annotation: = dict(…)
 
@@ -170,7 +227,6 @@ Model classes
    These include all items listed in the MESSAGE mathematical specification, i.e. :ref:`sets_maps_def` and :ref:`parameter_def`.
 
    .. seealso:: :meth:`.MESSAGE.initialize`, :data:`.MACRO_ITEMS`
-
 
 .. currentmodule:: message_ix.macro
 
@@ -180,7 +236,6 @@ Model classes
    All of the items in the MACRO mathematical formulation.
 
    .. seealso:: :data:`.MESSAGE_ITEMS`
-
 
 
 .. _utils:

--- a/doc/time.rst
+++ b/doc/time.rst
@@ -58,33 +58,33 @@ Duration of sub-annual time slices
 The duration of each sub-annual time slice should be defined relative to the whole year, with a value between 0 and 1, using parameter ``duration_time``.
 For example, in a model with four seasons with the same length, ``duration_time`` of each season will be 0.25.
 Please note that the duration of time slices does not need to be equal to each other.
-This information is needed to calculate capacity of a technology that is active in different time slices. 
+This information is needed to calculate capacity of a technology that is active in different time slices.
 Time slices can be represented at different temporal levels, using sets ``lvl_temporal`` and ``map_temporal_hierarchy``.
 This helps introducing a flexible temporal resolution, e.g., by representing some technologies at finer time resolution while others at ``year``.
 When there are more than one temporal levels, e.g., "year", "season", "month", "day", etc., ``duration_time`` is defined for time slices at each **temporal level** separately.
 The sum of ``duration_time`` of time slices at each temporal level must be equal to 1.
 For example, in a model with 4 time slices as "season" and 10 time slices as "day" under each "season", ``duration_time`` of each "season" and "day" can be specified as 0.25 and 0.025, respectively.
 
-By default, the unit of ``ACT`` is treated per year in the GAMS formulation for different time slices. This means values reported
-in time slice "year" and "month" both have the same unit (e.g., GWa). However, the user can report the values across parameters
-and variables with different units relative to the length of the full year. For example, the user can report ``ACT`` in units of
-"GWa" and "GWh" for time slices of "year" and "hour", respectively, in the same model. To activate this feature, the parent time slice
-for which the relative units are desired should be specified by set ``time_relative``. This will ensure that parameter ``duration_time_rel`` 
-is effective. Otherwise, this parameter is filled by value of 1, meaning that the units will be treated uniformly across
-different sub-annual time slices.
+By default, the unit of ``ACT`` is treated per year in the GAMS formulation for different time slices.
+This means values reported in time slice "year" and "month" both have the same unit (e.g., GWa).
+However, the user can report the values across parameters and variables with different units relative to the length of the full year.
+For example, the user can report ``ACT`` in units of "GWa" and "GWh" for time slices of "year" and "hour", respectively, in the same model.
+To activate this feature, the parent time slice for which the relative units are desired should be specified by set ``time_relative``.
+This will ensure that parameter ``duration_time_rel``  is effective.
+Otherwise, this parameter is filled by value of 1, meaning that the units will be treated uniformly across different sub-annual time slices.
 
 Discounting
 ===========
 
-The ``interest_rate`` in |MESSAGEix| is defined for a period of one year, therefore, for periods of more than a year, the discounting is performed in a cumulative manner. 
+The ``interest_rate`` in |MESSAGEix| is defined for a period of one year, therefore, for periods of more than a year, the discounting is performed in a cumulative manner.
 
 Example 5
    Using the same setup as Example 2:
-   
+
    - Discounting for the element ``1010`` involves discounting for years ``1001``, ``1002``, ... , ``1010``.
    - Using the standard PV formula, we have that, for the year ``1001`` the discount factor would be :math:`(1 + interest_rate)^(1000 - 1001)`, for the year  ``1002`` the discount factor would be :math:`(1 + interest_rate)^(1000 - 1002)`, and so on.
    - Therefore, the period discount factor for the element ``1010`` is :math:`df_1010 = (1 + interest_rate)^(1000 - 1001) + (1 + interest_rate)^(1000 - 1002) + ... + (1 + interest_rate)^(1000 - 1010)`
    - Analogously, the period discount factor for the element ``1020`` is :math:`df_1020 = (1 + interest_rate)^(1000 - 1011) + (1 + interest_rate)^(1000 - 1012) + ... + (1 + interest_rate)^(1000 - 1020)`
    - So, if we have a cost of ``K_1010`` for the element ``1010``, its discounted value would be ``df_1010 * K_1010``, which means, all the years in  element ``1010`` have a representative cost of ``K_1010`` that is discounted up to the initial ``year`` of the setup, namely, the year ``1000``.
-  
-In practice, since the representative year of a period is always its final year, the actual calculation of the period discount factor within the model is performed backwards, i.e., starting from the final year of the period until the initial year. 
+
+In practice, since the representative year of a period is always its final year, the actual calculation of the period discount factor within the model is performed backwards, i.e., starting from the final year of the period until the initial year.

--- a/message_ix/__init__.py
+++ b/message_ix/__init__.py
@@ -30,6 +30,8 @@ except DistributionNotFound:
 
 # Register configuration keys with ixmp core and set default
 config.register("message model dir", Path, Path(__file__).parent / "model")
+# FIXME this overwrites a value loaded from the user's config file
+# config.register("message solve options", dict, None)
 
 # Register models with ixmp core
 MODELS["MACRO"] = MACRO

--- a/message_ix/__init__.py
+++ b/message_ix/__init__.py
@@ -30,8 +30,7 @@ except DistributionNotFound:
 
 # Register configuration keys with ixmp core and set default
 config.register("message model dir", Path, Path(__file__).parent / "model")
-# FIXME this overwrites a value loaded from the user's config file
-# config.register("message solve options", dict, None)
+config.register("message solve options", dict)
 
 # Register models with ixmp core
 MODELS["MACRO"] = MACRO

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -59,8 +59,8 @@ def item(ix_type, expr):
     ...     idx_names=["node_loc", "technology", "year_act"]
     ... )
     """
-    # Split expr on spaces. For each dimension, use an abbreviation (if one)
-    # exists, else the set name for both idx_sets and idx_names
+    # Split expr on spaces. For each dimension, use an abbreviation (if one) exists,
+    # else the set name for both idx_sets and idx_names
     sets, names = zip(*[_ABBREV.get(dim, (dim, dim)) for dim in expr.split()])
 
     # Assemble the result
@@ -105,8 +105,8 @@ MESSAGE_ITEMS = {
     #
     # Indexed sets
     "addon": dict(ix_type="set", idx_sets=["technology"]),
-    # commented: in test_solve_legacy_scenario(), ixmp_source complains that
-    # the item already exists
+    # commented: in test_solve_legacy_scenario(), ixmp_source complains that the item
+    # already exists
     # "balance_equality": item("set", "c l"),
     "cat_addon": dict(
         ix_type="set",
@@ -257,9 +257,9 @@ MESSAGE_ITEMS = {
     "time_order": dict(ix_type="par", idx_sets=["lvl_temporal", "time"]),
     "var_cost": item("par", "nl t yv ya m h"),
     #
-    # commented: for both variables and equations, ixmp_source requires that
-    # the `idx_sets` and `idx_names` parameters be empty, but then internally
-    # uses the correct sets and names to initialize.
+    # commented: for both variables and equations, ixmp_source requires that the
+    # `idx_sets` and `idx_names` parameters be empty, but then internally uses the
+    # correct sets and names to initialize.
     # TODO adjust ixmp_source to accept these values, then uncomment.
     #
     # Variables
@@ -313,8 +313,8 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
                     _template("output", "MsgIterationReport_{case}.gdx")
                 ),
             ],
-            # Disable the feature to put input/output GDX files, list files, etc.
-            # in a temporary directory
+            # Disable the feature to put input/output GDX files, list files, etc. in a
+            # temporary directory
             "use_temp_dir": False,
         },
         ixmp.model.gams.GAMSModel.defaults,
@@ -343,21 +343,19 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
     def run(self, scenario):
         """Execute the model.
 
-        GAMSModel creates a file named ``cplex.opt`` in the model directory
-        containing the options in :obj:`DEFAULT_CPLEX_OPTIONS`, or any
-        overrides passed to :meth:`~message_ix.Scenario.solve`.
+        GAMSModel creates a file named ``cplex.opt`` in the model directory containing
+        the options in :obj:`DEFAULT_CPLEX_OPTIONS`, or any overrides passed to
+        :meth:`~message_ix.Scenario.solve`.
 
-        .. warning:: GAMSModel can solve Scenarios in two or more Python
-           processes simultaneously; but using *different* CPLEX options in
-           each process may produced unexpected results.
+        .. warning:: GAMSModel can solve Scenarios in two or more Python processes
+           simultaneously; but using *different* CPLEX options in each process may
+           produce unexpected results.
         """
-        # If two runs are kicked off simulatenously with the same
-        # self.model_dir, then they will try to write the same optfile, and may
-        # write different contents.
+        # If two runs are kicked off simulatenously with the same self.model_dir, then
+        # they will try to write the same optfile, and may write different contents.
         #
-        # TODO Re-enable the 'use_temp_dir' feature from ixmp.GAMSModel
-        #      (disabled above). Then cplex.opt will be specific to that
-        #      directory.
+        # TODO Re-enable the 'use_temp_dir' feature from ixmp.GAMSModel (disabled above)
+        #      so that cplex.opt will be specific to that directory.
 
         # Write CPLEX options into an options file
         optfile = Path(self.model_dir).joinpath("cplex.opt")
@@ -368,11 +366,10 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
         try:
             result = super().run(scenario)
         finally:
-            # Remove the optfile regardless of whether the run completed
-            # without error. The file may have been removed already by another
-            # run (in a separate process) that completed before this one.
-            # py37 compat: check for existence instead of using
-            # unlink(missing_ok=True)
+            # Remove the optfile regardless of whether the run completed without error.
+            # The file may have been removed already by another run (in a separate
+            # process) that completed before this one.
+            # py37 compat: check for existence instead of using unlink(missing_ok=True)
             if optfile.exists():
                 optfile.unlink()
 
@@ -390,29 +387,26 @@ class MACRO(GAMSModel):
 
     name = "MACRO"
 
-    #: MACRO uses the GAMS ``break;`` statement, and thus requires GAMS 24.8.1
-    #: or later.
+    #: MACRO uses the GAMS ``break;`` statement, and thus requires GAMS 24.8.1 or later.
     GAMS_min_version = "24.8.1"
 
     def __init__(self, *args, **kwargs):
         version = ixmp.model.gams.gams_version()
         if version < self.GAMS_min_version:
-            message = (
-                "{0.name} requires GAMS >= {0.GAMS_min_version}; " "found {1}"
-            ).format(self, version)
-            raise RuntimeError(message)
+            raise RuntimeError(
+                f"{self.name} requires GAMS >= {self.GAMS_min_version}; found {version}"
+            )
 
         super().__init__(*args, **kwargs)
 
     @classmethod
     def initialize(cls, scenario, with_data=False):
         """Initialize the model structure."""
-        # NB some scenarios already have these items. This method simply adds
-        #    any missing items.
+        # NB some scenarios already have these items. This method simply adds any
+        #    missing items.
 
-        # FIXME the Java code under the JDBCBackend (ixmp_source) refuses to
-        #       initialize these items with specified idx_sets—even if the
-        #       sets are correct.
+        # FIXME the Java code under the JDBCBackend (ixmp_source) refuses to initialize
+        #       these items with specified idx_sets—even if the sets are correct.
         items = deepcopy(MACRO_ITEMS)
         for name in "C", "COST_NODAL", "COST_NODAL_NET", "DEMAND", "GDP", "I":
             items[name].pop("idx_sets")
@@ -427,8 +421,8 @@ class MESSAGE_MACRO(MACRO):
     name = "MESSAGE-MACRO"
 
     def __init__(self, *args, **kwargs):
-        # Remove M-M iteration options from kwargs and convert to GAMS
-        # command-line options
+        # Remove M-M iteration options from kwargs and convert to GAMS command-line
+        # options
         mm_iter_args = []
         for name in "convergence_criterion", "max_adjustment", "max_iteration":
             try:

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -19,10 +19,6 @@ DEFAULT_CPLEX_OPTIONS = {
     "epopt": 1e-6,
 }
 
-# Set default value of "message model options" config key.
-# NB this should be in message_ix/__init__.py, but see FIXME there
-config.values.setdefault("message model options", dict())
-
 # Abbreviations for index sets and index names; the same used in the inline
 # documentation of the GAMS code.
 _ABBREV = {

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -335,7 +335,7 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
         # Update the default options with any user-provided options
         model_options.setdefault("model_dir", config.get("message model dir"))
         self.cplex_opts = copy(DEFAULT_CPLEX_OPTIONS)
-        self.cplex_opts.update(config.get("message solve options"))
+        self.cplex_opts.update(config.get("message solve options") or dict())
         self.cplex_opts.update(model_options.pop("solve_options", {}))
 
         super().__init__(name, **model_options)

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -344,8 +344,7 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
         """Execute the model.
 
         GAMSModel creates a file named ``cplex.opt`` in the model directory containing
-        the options in :obj:`DEFAULT_CPLEX_OPTIONS`, or any overrides passed to
-        :meth:`~message_ix.Scenario.solve`.
+        the “solve_options”, as described above.
 
         .. warning:: GAMSModel can solve Scenarios in two or more Python processes
            simultaneously; but using *different* CPLEX options in each process may

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -360,7 +360,7 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
         #      directory.
 
         # Write CPLEX options into an options file
-        optfile = self.model_dir / "cplex.opt"
+        optfile = Path(self.model_dir).joinpath("cplex.opt")
         lines = ("{} = {}".format(*kv) for kv in self.cplex_opts.items())
         optfile.write_text("\n".join(lines))
         log.info(f"Use CPLEX options {self.cplex_opts}")

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -11,8 +11,8 @@ AT = "Austrian_energy_system"
 
 # Common marks for some test cases
 mark0 = pytest.mark.skipif(
-    condition=sys.version_info.minor <= 6 and sys.platform != "linux",
-    reason="R/reticulate link fails on GitHub Actions runners for Python 3.6",
+    condition="GITHUB_ACTIONS" in os.environ and sys.platform == "linux",
+    reason="IR kernel times out on GitHub Actions Ubuntu runners ",
 )
 
 # This mark does *not* affect macos-latest-py3.9, which must still pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,10 +18,10 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: R
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Information Analysis
@@ -35,7 +35,7 @@ install_requires =
     click
     ixmp >= 3.4.0
     numpy
-    pandas
+    pandas >= 1.2
     PyYAML
     setuptools >= 41
 setup_requires =


### PR DESCRIPTION
This file adds a new recognized key, `"message model options"`, in the user configuration file (~/.local/share/ixmp/config.json or similar), that corresponds to passing options to `Scenario.solve(…)` ([docs](https://docs.messageix.org/en/stable/api.html#message_ix.Scenario.solve)).

So, for instance, with the following in config.json:
```json
{
  "my-platform": {"backend": "jdbc", "etc": "etc"},
  "...": "...",
  "message solve options": {"lpmethod": 4},
}
```
…then:
```py
s.solve()
```
is updated to have the same effect as:
```py
s.solve(solve_options={"lpmethod": 4})
```

Also:
- #532
- iiasa/ixmp#415 fixed the issue underlying “message model dir” not working as described here.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Open a corresponding PR upstream (in `ixmp`) to address the FIXME in the added comment → iiasa/ixmp#435.
- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.