### PR TITLE
Include Python version 3.10 and remove 3.6 in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
       # This should match the "Latest version testable on GitHub Actions"
       # in pytest.yaml
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,7 +40,7 @@ jobs:
         twine check dist/*
 
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.5.0
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       with:
         user: __token__
@@ -48,7 +48,7 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.5.0
       if: github.event_name == 'release'
       with:
         user: __token__

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
       # This should match the "Latest version testable on GitHub Actions"
       # in pytest.yaml
       # with:
-      #   python-version: "3.9"
+      #   python-version: "3.10"
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Cancel previous runs that have not completed
-      uses: styfle/cancel-workflow-action@0.7.0
+      uses: styfle/cancel-workflow-action@0.9.1
       with:
         access_token: ${{ github.token }}
 
@@ -74,7 +74,7 @@ jobs:
       run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
       shell: bash
 
-    - uses: r-lib/actions/setup-r@master
+    - uses: r-lib/actions/setup-r@v2
       id: setup-r
 
     - name: Use OpenJDK 14 (macOS only)
@@ -145,6 +145,6 @@ jobs:
       run: make --directory=doc html
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v1.2.1
+      uses: codecov/codecov-action@v2
       with:
         root_dir: message_ix

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -77,14 +77,6 @@ jobs:
     - uses: r-lib/actions/setup-r@v2
       id: setup-r
 
-    - name: Use OpenJDK 14 (macOS only)
-      # Using the default OpenJDK 1.8 on the macos-latest runner produces
-      # "Abort trap: 6" when JPype1 starts the JVM
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: '14'
-
     - name: Cache GAMS installer, Python packages, and R packages
       uses: actions/cache@v2
       with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -31,6 +31,11 @@ jobs:
         # build environment, currently out of scope for the message_ix project.
         # - "3.10.0-alpha.1"  # Development version
 
+        exclude:
+        # JPype1 binary wheels are not available for this combination
+        - os: windows-latest
+          python-version: "3.10"
+
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,7 +22,8 @@ jobs:
         python-version:
         - "3.7"
         - "3.8"
-        - "3.9"  # Latest release / latest supported by message_ix
+        - "3.9"
+        - "3.10" # Latest release / latest supported by message_ix
 
         # For development versions of Python, compiled binary wheels are not
         # available for some dependencies, e.g. llvmlite, numba, numpy, and/or

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -20,7 +20,7 @@ jobs:
         - ubuntu-latest
         - windows-latest
         python-version:
-        - "3.6"  # Earliest version supported by message_ix
+        - "3.7"
         - "3.8"
         - "3.9"  # Latest release / latest supported by message_ix
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     click
     ixmp >= 3.4.0
     numpy
-    pandas
+    pandas >= 1.2
     PyYAML
     setuptools >= 41
 setup_requires =


### PR DESCRIPTION
This PR includes Python version 3.10 and removes Python version 3.6 in CI. 
Closes #532 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist


- [ ] Continuous integration checks all ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
