### PR TITLE
Add Reporter.add_tasks()

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- Split :meth:`.Reporter.add_tasks` for use without an underlying :class:.`Scenario` (:pull:`567`).
 - Allow setting the “model_dir” and “solve_options” options for :class:`.GAMSModel` (and subclasses :class:`.MESSAGE`, :class:`.MACRO`, and :class:`.MESSAGE_MACRO`) through the user's ixmp configuration file; expand documentation (:pull:`557`).
 
 .. _v3.4.0:

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -1,5 +1,6 @@
 import logging
-from functools import partial
+from functools import lru_cache, partial
+from typing import Mapping, Sequence, Tuple, Union, cast
 
 import genno
 from ixmp.reporting import (
@@ -166,6 +167,50 @@ MAPPING_SETS = [
 ]
 
 
+@lru_cache(1)
+def get_tasks() -> Sequence[Tuple[Tuple, Mapping]]:
+    """Return a list of tasks describing MESSAGE reporting calculations."""
+    # Assemble queue of items to add. Each element is a 2-tuple of (positional, keyword)
+    # arguments for Reporter.add()
+    to_add = []
+
+    # Helper to add elements to the queue
+    def put(*args, **kwargs):
+        to_add.append((args, kwargs))
+
+    # Quantities that represent mapping sets
+    for name, full_set in MAPPING_SETS:
+        put("map_as_qty", f"map_{name}", f"cat_{name}", full_set, strict=True)
+
+    # Product quantities
+    for name, quantities in PRODUCTS:
+        put("product", name, *quantities)
+
+    # Derived quantities
+    for key, args in DERIVED:
+        put(key, *args, strict=True, index=True, sums=True)
+
+    # Conversions to IAMC-format (pyam) objects
+    for qty, year_dim, collapse_kw in PYAM_CONVERT:
+        # Standard renaming from dimensions to column names
+        rename = dict(n="region", nl="region")
+        # Column to set as year or time dimension
+        rename[year_dim] = "year" if year_dim.lower().startswith("y") else "time"
+        # Callback function to further collapse other columns into IAMC columns
+        collapse_cb = partial(collapse_message_cols, **collapse_kw)
+
+        put("convert_pyam", qty, "pyam", rename=rename, collapse=collapse_cb)
+
+    # Standard reports
+    for group, pyam_keys in REPORTS.items():
+        put("concat", group, *pyam_keys, strict=True)
+
+    # Add all standard reporting to the default message node
+    put("concat", "message:default", *REPORTS.keys(), strict=True)
+
+    return to_add
+
+
 class Reporter(IXMPReporter):
     """MESSAGEix Reporter."""
 
@@ -200,55 +245,19 @@ class Reporter(IXMPReporter):
         # Invoke the ixmp method
         rep = super().from_scenario(scenario, **kwargs)
 
+        # Add the MESSAGEix calculations
+        rep.add_tasks(fail_action)
+
+        return rep
+
+    def add_tasks(self, fail_action: Union[int, str] = "raise") -> None:
+        """Add the pre-defined MESSAGEix reporting tasks to the Reporter."""
         # Ensure that genno.compat.pyam is usable
-        rep.require_compat("pyam")
+        self.require_compat("pyam")
 
         # Use a queue pattern via Reporter.add_queue(). This is more forgiving; e.g.
         # 'addon ACT' from PRODUCTS depends on 'addon conversion::full'; but the latter
-        # is added to the queue later (from DERIVED). Using strict=True below means
-        # that this will raise an exception; so the failed item is re-appended to the
-        # queue and tried 1 more time later.
-
-        # Assemble queue of items to add. Each element is a 2-tuple:
-        # - Positional arguments for Reporter.add();
-        # - Keyword arguments
-        to_add = []
-
-        def put(*args, **kwargs):
-            """Helper to add elements to the queue."""
-            to_add.append((args, kwargs))
-
-        # Quantities that represent mapping sets
-        for name, full_set in MAPPING_SETS:
-            put("map_as_qty", f"map_{name}", f"cat_{name}", full_set, strict=True)
-
-        # Product quantities
-        for name, quantities in PRODUCTS:
-            put("product", name, *quantities)
-
-        # Derived quantities
-        for key, args in DERIVED:
-            put(key, *args, strict=True, index=True, sums=True)
-
-        # Conversions to IAMC format/pyam objects
-        for qty, year_dim, collapse_kw in PYAM_CONVERT:
-            # Standard renaming from dimensions to column names
-            rename = dict(n="region", nl="region")
-            # Column to set as year or time dimension
-            rename[year_dim] = "year" if year_dim.lower().startswith("y") else "time"
-            # Callback function to further collapse other columns into IAMC columns
-            collapse_cb = partial(collapse_message_cols, **collapse_kw)
-
-            put("convert_pyam", qty, "pyam", rename=rename, collapse=collapse_cb)
-
-        # Standard reports
-        for group, pyam_keys in REPORTS.items():
-            put("concat", group, *pyam_keys, strict=True)
-
-        # Add all standard reporting to the default message node
-        put("concat", "message:default", *REPORTS.keys(), strict=True)
-
-        # Use Computer.add_queue() to process the entries. Retry at most once.
-        rep.add_queue(to_add, max_tries=2, fail=fail_action)
-
-        return rep
+        # is added to the queue later (from DERIVED). Using strict=True in the various
+        # add() calls means that that this will raise an exception; so the failed item
+        # is re-appended to the queue and tried at most 1 more time later.
+        self.add_queue(get_tasks(), max_tries=2, fail=fail_action)

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -141,8 +141,8 @@ PYAM_CONVERT = [
 ]
 
 
-#: Automatic reports that :meth:`~computations.concat` quantities converted to
-#: IAMC format.
+#: Automatic reports that :meth:`~computations.concat` quantities converted to IAMC
+#: format.
 REPORTS = {
     "message:system": ["out:pyam", "in:pyam", "CAP:pyam", "CAP_NEW:pyam"],
     "message:costs": ["inv:pyam", "fom:pyam", "vom:pyam", "tom:pyam"],
@@ -150,18 +150,16 @@ REPORTS = {
 }
 
 
-#: MESSAGE mapping sets, converted to reporting quantities via
-#: :meth:`~.map_as_qty`.
+#: MESSAGE mapping sets, converted to reporting quantities via :meth:`~.map_as_qty`.
 #:
-#: For instance, the mapping set ``cat_addon`` is available at the reporting
-#: key ``map_addon``, which produces a :class:`.Quantity` with the two
-#: dimensions ``type_addon`` and ``ta`` (short form of ``technology_addon``).
-#: This Quantity contains the value 1 at every valid (type_addon, ta) location,
-#: and 0 elsewhere.
+#: For instance, the mapping set ``cat_addon`` is available at the reporting key
+#: ``map_addon``, which produces a :class:`.Quantity` with the two dimensions
+#: ``type_addon`` and ``ta`` (short form of ``technology_addon``). This Quantity
+#: contains the value 1 at every valid (type_addon, ta) location, and 0 elsewhere.
 MAPPING_SETS = [
     ("addon", "t"),  # Mapping name, and full target set
     ("emission", "e"),
-    # 'node',  # Automatic addition fails because 'map_node' is defined
+    # 'node',  # Automatic addition fails because 'map_node' is defined explicitly
     ("tec", "t"),
     ("year", "y"),
 ]

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -249,7 +249,13 @@ class Reporter(IXMPReporter):
         return rep
 
     def add_tasks(self, fail_action: Union[int, str] = "raise") -> None:
-        """Add the pre-defined MESSAGEix reporting tasks to the Reporter."""
+        """Add the pre-defined MESSAGEix reporting tasks to the Reporter.
+
+        Parameters
+        ----------
+        fail_action : “raise” or logging level
+            Passed to the `fail` argument of :meth:`.Reporter.add_queue`.
+        """
         # Ensure that genno.compat.pyam is usable
         self.require_compat("pyam")
 

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -216,7 +216,7 @@ class Reporter(IXMPReporter):
     modules = list(IXMPReporter.modules) + [computations]
 
     @classmethod
-    def from_scenario(cls, scenario, **kwargs):
+    def from_scenario(cls, scenario, **kwargs) -> "Reporter":
         """Create a Reporter by introspecting `scenario`.
 
         Warnings are logged if `scenario` does not have a solution. In this case, any
@@ -236,12 +236,12 @@ class Reporter(IXMPReporter):
                 f'Scenario "{scenario.model}/{scenario.scenario}" has no solution'
             )
             log.warning("Some reporting may not function as expected")
-            fail_action = logging.DEBUG
+            fail_action: Union[int, str] = logging.DEBUG
         else:
             fail_action = "raise"
 
         # Invoke the ixmp method
-        rep = super().from_scenario(scenario, **kwargs)
+        rep = cast("Reporter", super().from_scenario(scenario, **kwargs))
 
         # Add the MESSAGEix calculations
         rep.add_tasks(fail_action)


### PR DESCRIPTION
This PR splits the part of Reporter.from_scenario() that populates the graph with tasks for MESSAGE-specific reporting calculations.

This change makes it possible to add/use these tasks via a Reporter _without_ any underlying Scenario object, e.g. with simulated model output data for quantities like `CAP:nl-t-ya` instead of operations that read these values from a Scenario.

In support of iiasa/message_data#296.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.