### PR TITLE
Address failing copying of GAMS files

### DIFF
--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -42,7 +42,7 @@ def copy_model(path, overwrite, set_default):
     src_dir = Path(__file__).parent / "model"
     for src in src_dir.rglob("*.*"):
         # Skip certain files
-        if src.suffix in (".gdx", ".log", ".lst") or re.search("225", str(src)):
+        if src.suffix in (".gdx", ".log", ".lst") or re.search("225[a-z]+", str(src)):
             continue
 
         # Destination path

--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import click
@@ -41,7 +42,7 @@ def copy_model(path, overwrite, set_default):
     src_dir = Path(__file__).parent / "model"
     for src in src_dir.rglob("*"):
         # Skip certain files
-        if src.suffix in (".gdx", ".log", ".lst"):
+        if src.suffix in (".gdx", ".log", ".lst") or re.search("(225)", src.stem):
             continue
 
         # Destination path

--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -55,7 +55,7 @@ def copy_model(path, overwrite, set_default):
             continue
 
         # Display output
-        if dst.exists:
+        if dst.exists():
             if not overwrite:
                 print("{} exists, will not overwrite".format(dst))
 

--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -42,7 +42,7 @@ def copy_model(path, overwrite, set_default):
     src_dir = Path(__file__).parent / "model"
     for src in src_dir.rglob("*.*"):
         # Skip certain files
-        if src.suffix in (".gdx", ".log", ".lst") or re.search("(225)", src.stem):
+        if src.suffix in (".gdx", ".log", ".lst") or re.search("225", str(src)):
             continue
 
         # Destination path

--- a/message_ix/cli.py
+++ b/message_ix/cli.py
@@ -40,7 +40,7 @@ def copy_model(path, overwrite, set_default):
     path = Path(path).resolve()
 
     src_dir = Path(__file__).parent / "model"
-    for src in src_dir.rglob("*"):
+    for src in src_dir.rglob("*.*"):
         # Skip certain files
         if src.suffix in (".gdx", ".log", ".lst") or re.search("(225)", src.stem):
             continue

--- a/message_ix/tests/test_cli.py
+++ b/message_ix/tests/test_cli.py
@@ -31,7 +31,7 @@ def test_copy_model(message_ix_cli, tmp_path, tmp_env):
     # Check if specific directory will be skipped
     model_path = Path(message_ix.__file__).parent / "model" / "225" / "test.txt"
     model_path.mkdir(parents=True, exist_ok=True)
-    message_ix_cli("copy-model", "--overwrite", str(tmp_path))
+    message_ix_cli("copy-model", str(tmp_path))
     assert Path(tmp_path / "225").exists() is False
     shutil.rmtree(Path(message_ix.__file__).parent / "model" / "225")
 

--- a/message_ix/tests/test_cli.py
+++ b/message_ix/tests/test_cli.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 from pathlib import Path
 
 import pytest
@@ -26,6 +27,13 @@ def test_copy_model(message_ix_cli, tmp_path, tmp_env):
     r = message_ix_cli("copy-model", "--set-default", str(tmp_path))
     assert r.exit_code == 0
     assert config.get("message model dir") == tmp_path
+
+    # Check if specific directory will be skipped
+    model_path = Path(message_ix.__file__).parent / "model" / "225" / "test.txt"
+    model_path.mkdir(parents=True, exist_ok=True)
+    message_ix_cli("copy-model", "--overwrite", str(tmp_path))
+    assert Path(tmp_path / "225").exists() is False
+    shutil.rmtree(Path(message_ix.__file__).parent / "model" / "225")
 
 
 @pytest.mark.parametrize(

--- a/message_ix/tests/test_cli.py
+++ b/message_ix/tests/test_cli.py
@@ -29,11 +29,19 @@ def test_copy_model(message_ix_cli, tmp_path, tmp_env):
     assert config.get("message model dir") == tmp_path
 
     # Check if specific directory will be skipped
-    model_path = Path(message_ix.__file__).parent / "model" / "225" / "test.txt"
-    model_path.mkdir(parents=True, exist_ok=True)
+
+    # Create a GAMS runtime directory; these have names like "225a", etc.
+    model_path = Path(message_ix.__file__).parent.joinpath("model", "225c", "test.txt")
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    model_path.write_text("foo")
+
     message_ix_cli("copy-model", str(tmp_path))
-    assert Path(tmp_path / "225").exists() is False
-    shutil.rmtree(Path(message_ix.__file__).parent / "model" / "225")
+
+    # Directory is ignored
+    assert not Path(tmp_path / "225c").exists()
+
+    # Clean up
+    shutil.rmtree(model_path.parent)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adjusts the CLI `message-ix copy-model` function. 
Closes #560. 

## How to review

- Read the diff and note that the CI checks all pass.
- Run `message-ix copy-model --set-default "PATH"` to check if CLI works.


Estimated time: < 3 minutes

## PR checklist

- [x] Continuous integration checks all ✅
