### PR TITLE
Document approx. installation time with conda

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -88,7 +88,8 @@ Using Anaconda
     $ conda create --name message_env
     $ conda activate message_env
 
-8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``) [3]_::
+8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``).
+   This step can take up to ~45 minutes [3]_::
 
     $ conda install message-ix">1"
 


### PR DESCRIPTION
This PR documents the approximately installation time with conda due to #558.
Closes #562 

## How to review

- Read the diff and note that the CI checks all pass.
- Build the documentation and look at the installation page using Anaconda at "Step 8".

Estimated time <2 min.

## PR checklist

- [x] Continuous integration checks all ✅
