### PR TITLE
Extend feature vintage_and_active_years()

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -32,11 +32,6 @@ jobs:
         # for the message_ix project.
         # - "3.10.0-alpha.1"  # Development version
 
-        exclude:
-        # JPype1 (for ixmp) binary wheels are not available for this combination
-        - os: windows-latest
-          python-version: "3.10"
-
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,29 @@
-# GAMS, R, Python-specific auxiliary files
-*.~gm
-*.bak
-*.egg-info
-*.~op
-*.pyc
-*.gdx
-*.lst
-*.log
-*.lxi
-*.gch
-*.gpr
-/model/2*/**
-/model/$gms*
-*.dat
-*.tmp
-*.RData*
-*.pyc
+# Python, R, etc.
 *-checkpoint.ipynb
+*.bak
+*.dat
+*.egg-info
+*.eggs
+*.lxi
+*.pyc
+*.RData*
+*.tmp
+*#
 *~
 #*
-*#
-.
-*.eggs
 
-# MESSAGEix specifics
+# GAMS
+*.~gm
+*.~op
+*.gch
+*.gdx
+*.gpr
+*.log
+*.lst
+message_ix/model/2*/**
+message_ix/model/$gms*
 message_ix/model/MESSAGE_master.gms
 message_ix/model/cplex.opt
-
-# Apple file system
-.DS_Store
 
 # Sphinx
 doc/_build
@@ -42,16 +37,20 @@ dist
 # testdb
 .cache/**
 tests/data/nightly
-.Rproj.user
 
 # pytest and related
 .benchmarks
 .coverage*
 .mypy_cache
-prof/
 .pytest_cache
 coverage.xml
 htmlcov
+prof/
 
-# JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# JetBrains IDEs incl. PyCharm
 /**/.idea
+# RStudio
+.Rproj.user
+
+# macOS
+.DS_Store

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,8 @@
 .. All changes
 .. -----------
 
+- Extend functionality of :meth:`.vintage_and_active_years` (:pull:`572`)
+
 .. _v3.5.0:
 
 v3.5.0 (2022-05-06)

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,10 +1,23 @@
-.. Next release
-.. ============
+Next release
+============
 
-.. All changes
-.. -----------
+Migration notes
+---------------
 
-- Extend functionality of :meth:`.vintage_and_active_years` (:pull:`572`)
+- The `in_horizon` argument to :meth:`.vintage_and_active_years` is deprecated, and will be removed in :mod:`message_ix` 4.0 or later.
+  At the same time, the behaviour will change to be the equivalent of providing `in_horizon` = :obj:`False`, i.e. the method will no longer filter to the scenario time horizon by default.
+  To prepare for this change, user code that expects values confined to the time horizon can be altered to use :meth:`.pandas.DataFrame.query`:
+
+  .. code-block:: python
+  
+     df = scen.vintage_and_active_years().query(f"{scen.y0} <= year_vtg")
+
+
+All changes
+-----------
+
+- Extend functionality of :meth:`.vintage_and_active_years`; add aliases
+  :meth:`.yv_ya`, :meth:`.ya`, and :attr:`.y0` (:pull:`572`).
 
 .. _v3.5.0:
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -67,6 +67,7 @@ The full API is also available from R; see :doc:`rmessageix`.
       to_excel
       var
       vintage_and_active_years
+      y0
       years_active
       ya
       yv_ya

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -68,6 +68,8 @@ The full API is also available from R; see :doc:`rmessageix`.
       var
       vintage_and_active_years
       years_active
+      ya
+      yv_ya
 
    .. automethod:: add_macro
 

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -455,6 +455,25 @@ class Scenario(ixmp.Scenario):
         -------
         pandas.DataFrame
             with columns 'year_vtg' and 'year_act', in which each row is a valid pair.
+
+        Examples
+        --------
+        :meth:`pandas.DataFrame.query` can be used to further manipulate the data in the
+        returned data frame. To limit the vintage years included:
+
+        >>> base = s.vintage_and_active_years(("node", "tech"))
+        >>> df = base.query("year_vtg >= 2022")
+
+        Limit the active years included:
+
+        >>> df = base.query("year_act >= 2040")
+
+        More complex expressions as a chained call:
+
+        >>> df = s.vintage_and_active_years(
+        ...     ("node", "tech"), in_horizon=True
+        ... ).query("year_act >= 2025 or year_vtg < 2010")
+
         """
         # Predicate for filtering years
         def _valid(elem):

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -563,6 +563,9 @@ class Scenario(ixmp.Scenario):
         # Filter values and convert to data frame
         return pd.DataFrame(filter(_valid, values), columns=["year_vtg", "year_act"])
 
+    #: Alias for :meth:`vintage_and_active_years`.
+    yv_ya = vintage_and_active_years
+
     def years_active(self, node: str, tec: str, yr_vtg: Union[int, str]) -> List[int]:
         """Return periods in which `tec` hnology of `yr_vtg` can be active in `node`.
 
@@ -606,6 +609,9 @@ class Scenario(ixmp.Scenario):
             .astype(int)
             .tolist()
         )
+
+    #: Alias for :meth:`years_active`.
+    ya = years_active
 
     @property
     def firstmodelyear(self):

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -623,6 +623,10 @@ class Scenario(ixmp.Scenario):
         """
         return int(self.cat("year", "firstmodelyear")[0])
 
+    @property
+    def y0(self):
+        """Alias for :attr:`.firstmodelyear`."""
+
     def clone(self, *args, **kwargs):
         """Clone the current scenario and return the clone.
 

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -503,26 +503,22 @@ class Scenario(ixmp.Scenario):
                 ya = self.years_active(*ya_args)
                 df = pd.DataFrame(filter(_valid, product(ya[0:1], ya)), columns=columns)
             else:
-                df = (
-                    pd.concat(
-                        [
-                            pd.DataFrame(
-                                filter(
-                                    _valid,
-                                    product(
-                                        [y],
-                                        self.years_active(ya_args[0], ya_args[1], y),
-                                    ),
+                df = pd.concat(
+                    [
+                        pd.DataFrame(
+                            filter(
+                                _valid,
+                                product(
+                                    [y],
+                                    self.years_active(ya_args[0], ya_args[1], y),
                                 ),
-                                columns=columns,
-                            )
-                            for y in yv
-                        ]
-                    )
-                    .reset_index()
-                    .drop("index", axis=1)
+                            ),
+                            columns=columns,
+                        )
+                        for y in yv
+                    ],
+                    ignore_index=True,
                 )
-
         else:
             # Product of all years
             tl_max = max(self.set("year"))

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -427,36 +427,37 @@ class Scenario(ixmp.Scenario):
         r"""Return matched pairs of vintage and active years for use in data input.
 
         Each returned pair of (vintage year :math:`y^V`, active year :math:`y^A`)
-        satisfies the following conditions:
+        satisfies all of the following conditions:
 
-        1. :math:`y^V, y^A \in Y`, i.e. both vintage and active year are in the
-           ``year`` set of the Scenario.
-        2. :math:`y^V \leq y^A`, i.e. a technology cannot be active before it is
-           constructed.
-        3. :math:`y^A \geq y_0`, the model's first year; **or** :math:`y^A` is in the
-           smaller subset :meth:`.years_active` for the given `act_lower` **and**
-           :math:`y^A` is within the defined technical lifetime if "ya_args" are passed.
+        1. :math:`y^V, y^A \in Y`: both vintage and active year are in the ``year`` set
+           of the Scenario.
+        2. :math:`y^V \leq y^A`: a technology cannot be active before it is constructed.
+        3. (If `in_horizon` is :obj:`True`) :math:`y^A \geq y_0`, the
+           :attr:`.firstmodelyear`.
+        4. (If `ya_args` are given) :math:`y^A - y^V + \text{duration_period}_{y^V} <
+           \text{technical_lifetime}_{y^V}`; that is, at least part of the active period
+           is within the technical lifetime defined for technology of the corresponding
+           vintage. This is the same condition satisfied by :meth:`years_active`.
 
         Parameters
         ----------
         ya_args : tuple of (node, tec) or (node, tec, yr_vtg), optional
-            If only (node, tec) is provided, then the vintage and active years are
-            returned for all years for which a technical lifetime is defined. If in
-            addition a "yr_vtg" is specified, results will be limited to that vintage
-            year. In all cases, the "year_act" will <= maximum defined
-            ``technical_lifetime`` for the given technology.
+            If all three are provided, they are supplied directly to
+            :meth:`.years_active`, and only the `yr_vtg` will appear in the results. If
+            only (node, tec) are provided, then :meth:`.years_active` is called for
+            every vintage where the (node, tec) has a defined technical lifetime.
         in_horizon : bool, optional
-            Only return year_act within the model horizon (:obj:`firstmodelyear` or
+            Only return year_act within the model horizon (:attr:`.firstmodelyear` or
             later).
         vtg_lower : int, optional
-            Only returns year_vtg from the specified value onwards.
+            Only return year_vtg from the specified value onwards.
         act_lower : int, optional
-            Only returns year_act from the specified value onwards.
+            Only return year_act from the specified value onwards.
 
         Returns
         -------
         pandas.DataFrame
-            with columns 'year_vtg' and 'year_act', in which each row is a valid pair.
+            with columns "year_vtg" and "year_act", in which each row is a valid pair.
 
         Examples
         --------

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -561,7 +561,9 @@ class Scenario(ixmp.Scenario):
             return yv <= ya and ya_min <= ya <= ya_max
 
         # Filter values and convert to data frame
-        return pd.DataFrame(filter(_valid, values), columns=["year_vtg", "year_act"])
+        return pd.DataFrame(
+            filter(_valid, values), columns=["year_vtg", "year_act"], dtype=np.int64
+        )
 
     #: Alias for :meth:`vintage_and_active_years`.
     yv_ya = vintage_and_active_years
@@ -606,7 +608,7 @@ class Scenario(ixmp.Scenario):
             data.where(data.age.shift(1, fill_value=0) < lt)
             .where(data.year >= yv)["year"]
             .dropna()
-            .astype(int)
+            .astype(np.int64)
             .tolist()
         )
 

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -419,7 +419,7 @@ class Scenario(ixmp.Scenario):
 
     def vintage_and_active_years(
         self,
-        ya_args: Union[str, Sequence] = None,
+        ya_args: Sequence = None,
         in_horizon: bool = True,
         vtg_lower: int = 0,
         act_lower: int = 0,
@@ -489,7 +489,6 @@ class Scenario(ixmp.Scenario):
 
         # Prepare lists of vintage (yv) and active (ya) years
         if ya_args:
-            ya_args = [ya_args] if type(ya_args) == str else ya_args
             len_yargs = len(ya_args)
             if len_yargs < 2:
                 raise ValueError("At least 2 arguments are required if using `ya_args`")

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -113,11 +113,7 @@ def test_add_spatial_hierarchy(test_mp):
         (
             ([2030, 2010, 2020],),
             dict(),
-            {
-                "year": [2010, 2020, 2030],
-                "fmy": [2010],
-                "dp": [10, 10, 10],
-            },
+            {"year": [2010, 2020, 2030], "fmy": [2010], "dp": [10, 10, 10],},
         ),
         # Deprecated usage with a dict as the first positional argument
         (
@@ -188,79 +184,9 @@ def test_add_horizon_repeat(test_mp, caplog):
     npt.assert_array_equal([10, 10, 10], scen.par("duration_period")["value"])
 
     with pytest.raises(
-        ValueError,
-        match=r"Scenario has year=\[2010, 2020, 2030\] and related values",
+        ValueError, match=r"Scenario has year=\[2010, 2020, 2030\] and related values",
     ):
         scen.add_horizon([2015, 2020, 2025], firstmodelyear=2010)
-
-
-def test_vintage_and_active_years(test_mp):
-    scen = Scenario(test_mp, **SCENARIO["dantzig"], version="new")
-
-    years = [2000, 2010, 2020]
-    scen.add_horizon(year=years, firstmodelyear=2010)
-    obs = scen.vintage_and_active_years()
-    exp = pd.DataFrame(
-        {
-            "year_vtg": (2000, 2000, 2010, 2010, 2020),
-            "year_act": (2010, 2020, 2010, 2020, 2020),
-        }
-    )
-    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
-
-    # Add a technology, its lifetime, and period durations
-    scen.add_set("node", "foo")
-    scen.add_set("technology", "bar")
-    scen.add_par(
-        "duration_period", pd.DataFrame({"unit": "???", "value": 10, "year": years})
-    )
-    scen.add_par(
-        "technical_lifetime",
-        pd.DataFrame(
-            {
-                "node_loc": "foo",
-                "technology": "bar",
-                "unit": "???",
-                "value": 20,
-                "year_vtg": years,
-            }
-        ),
-    )
-
-    # part is before horizon
-    obs = scen.vintage_and_active_years(ya_args=("foo", "bar", "2000"))
-    exp = pd.DataFrame({"year_vtg": (2000,), "year_act": (2010,)})
-    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
-
-    obs = scen.vintage_and_active_years(
-        ya_args=("foo", "bar", "2000"), in_horizon=False
-    )
-    exp = pd.DataFrame({"year_vtg": (2000, 2000), "year_act": (2000, 2010)})
-    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
-
-    # fully in horizon
-    obs = scen.vintage_and_active_years(ya_args=("foo", "bar", "2010"))
-    exp = pd.DataFrame({"year_vtg": (2010, 2010), "year_act": (2010, 2020)})
-    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
-
-    # part after horizon
-    obs = scen.vintage_and_active_years(ya_args=("foo", "bar", "2020"))
-    exp = pd.DataFrame({"year_vtg": (2020,), "year_act": (2020,)})
-    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
-
-    # Advance the first model year
-    scen.add_cat("year", "firstmodelyear", years[-1], is_unique=True)
-
-    # Empty data frame: only 2000 and 2010 valid year_act for this node/tec;
-    # but both are before the first model year
-    obs = scen.vintage_and_active_years(
-        ya_args=("foo", "bar", years[0]), in_horizon=True
-    )
-    pdt.assert_frame_equal(pd.DataFrame(columns=["year_vtg", "year_act"]), obs)
-
-    # Exception is raised for incorrect arguments
-    with pytest.raises(ValueError, match="3 arguments are required if using `ya_args`"):
-        scen.vintage_and_active_years(ya_args=("foo", "bar"))
 
 
 def test_cat_all(dantzig_message_scenario):
@@ -452,18 +378,12 @@ def test_new_timeseries_long_name64(message_test_mp):
     scen.check_out(timeseries_only=True)
     df = pd.DataFrame(
         {
-            "region": [
-                "India",
-            ],
+            "region": ["India",],
             "variable": [
                 ("Emissions|CO2|Energy|Demand|Transportation|Aviation|" "Domestic|Fre"),
             ],
-            "unit": [
-                "Mt CO2/yr",
-            ],
-            "2012": [
-                0.257009,
-            ],
+            "unit": ["Mt CO2/yr",],
+            "2012": [0.257009,],
         }
     )
     scen.add_timeseries(df)
@@ -476,21 +396,15 @@ def test_new_timeseries_long_name64plus(message_test_mp):
     scen.check_out(timeseries_only=True)
     df = pd.DataFrame(
         {
-            "region": [
-                "India",
-            ],
+            "region": ["India",],
             "variable": [
                 (
                     "Emissions|CO2|Energy|Demand|Transportation|Aviation|"
                     "Domestic|Freight|Oil"
                 ),
             ],
-            "unit": [
-                "Mt CO2/yr",
-            ],
-            "2012": [
-                0.257009,
-            ],
+            "unit": ["Mt CO2/yr",],
+            "2012": [0.257009,],
         }
     )
     scen.add_timeseries(df)

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -113,7 +113,11 @@ def test_add_spatial_hierarchy(test_mp):
         (
             ([2030, 2010, 2020],),
             dict(),
-            {"year": [2010, 2020, 2030], "fmy": [2010], "dp": [10, 10, 10],},
+            {
+                "year": [2010, 2020, 2030],
+                "fmy": [2010],
+                "dp": [10, 10, 10],
+            },
         ),
         # Deprecated usage with a dict as the first positional argument
         (
@@ -184,7 +188,8 @@ def test_add_horizon_repeat(test_mp, caplog):
     npt.assert_array_equal([10, 10, 10], scen.par("duration_period")["value"])
 
     with pytest.raises(
-        ValueError, match=r"Scenario has year=\[2010, 2020, 2030\] and related values",
+        ValueError,
+        match=r"Scenario has year=\[2010, 2020, 2030\] and related values",
     ):
         scen.add_horizon([2015, 2020, 2025], firstmodelyear=2010)
 
@@ -378,12 +383,18 @@ def test_new_timeseries_long_name64(message_test_mp):
     scen.check_out(timeseries_only=True)
     df = pd.DataFrame(
         {
-            "region": ["India",],
+            "region": [
+                "India",
+            ],
             "variable": [
                 ("Emissions|CO2|Energy|Demand|Transportation|Aviation|" "Domestic|Fre"),
             ],
-            "unit": ["Mt CO2/yr",],
-            "2012": [0.257009,],
+            "unit": [
+                "Mt CO2/yr",
+            ],
+            "2012": [
+                0.257009,
+            ],
         }
     )
     scen.add_timeseries(df)
@@ -396,15 +407,21 @@ def test_new_timeseries_long_name64plus(message_test_mp):
     scen.check_out(timeseries_only=True)
     df = pd.DataFrame(
         {
-            "region": ["India",],
+            "region": [
+                "India",
+            ],
             "variable": [
                 (
                     "Emissions|CO2|Energy|Demand|Transportation|Aviation|"
                     "Domestic|Freight|Oil"
                 ),
             ],
-            "unit": ["Mt CO2/yr",],
-            "2012": [0.257009,],
+            "unit": [
+                "Mt CO2/yr",
+            ],
+            "2012": [
+                0.257009,
+            ],
         }
     )
     scen.add_timeseries(df)

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -68,11 +68,15 @@ def test_vintage_and_active_years(test_mp):
     obs = scen.vintage_and_active_years(
         ya_args=("foo", "bar", years[0]), in_horizon=True
     )
-    pdt.assert_frame_equal(pd.DataFrame(columns=["year_vtg", "year_act"]), obs)
+    pdt.assert_frame_equal(
+        pd.DataFrame(columns=["year_vtg", "year_act"]), obs, check_dtype=False
+    )
 
     # Exception is raised for incorrect arguments
-    with pytest.raises(ValueError, match="3 arguments are required if using `ya_args`"):
-        scen.vintage_and_active_years(ya_args=("foo", "bar"))
+    with pytest.raises(
+        ValueError, match="At least 2 arguments are required if using `ya_args`"
+    ):
+        scen.vintage_and_active_years(ya_args=("foo"))
 
 
 def test_vintage_and_active_years_upd(test_mp):

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -1,9 +1,9 @@
 import pandas as pd
 import pandas.testing as pdt
+import pytest
 
 from message_ix import Scenario
 from message_ix.testing import SCENARIO
-import pytest
 
 
 def test_vintage_and_active_years(test_mp):

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -1,0 +1,272 @@
+import pandas as pd
+import pandas.testing as pdt
+
+from message_ix import Scenario
+from message_ix.testing import SCENARIO
+import pytest
+
+
+def test_vintage_and_active_years(test_mp):
+    scen = Scenario(test_mp, **SCENARIO["dantzig"], version="new")
+
+    years = [2000, 2010, 2020]
+    scen.add_horizon(year=years, firstmodelyear=2010)
+    obs = scen.vintage_and_active_years()
+    exp = pd.DataFrame(
+        {
+            "year_vtg": (2000, 2000, 2010, 2010, 2020),
+            "year_act": (2010, 2020, 2010, 2020, 2020),
+        }
+    )
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    # Add a technology, its lifetime, and period durations
+    scen.add_set("node", "foo")
+    scen.add_set("technology", "bar")
+    scen.add_par(
+        "duration_period", pd.DataFrame({"unit": "???", "value": 10, "year": years})
+    )
+    scen.add_par(
+        "technical_lifetime",
+        pd.DataFrame(
+            {
+                "node_loc": "foo",
+                "technology": "bar",
+                "unit": "???",
+                "value": 20,
+                "year_vtg": years,
+            }
+        ),
+    )
+
+    # part is before horizon
+    obs = scen.vintage_and_active_years(ya_args=("foo", "bar", "2000"))
+    exp = pd.DataFrame({"year_vtg": (2000,), "year_act": (2010,)})
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    obs = scen.vintage_and_active_years(
+        ya_args=("foo", "bar", "2000"), in_horizon=False
+    )
+    exp = pd.DataFrame({"year_vtg": (2000, 2000), "year_act": (2000, 2010)})
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    # fully in horizon
+    obs = scen.vintage_and_active_years(ya_args=("foo", "bar", "2010"))
+    exp = pd.DataFrame({"year_vtg": (2010, 2010), "year_act": (2010, 2020)})
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    # part after horizon
+    obs = scen.vintage_and_active_years(ya_args=("foo", "bar", "2020"))
+    exp = pd.DataFrame({"year_vtg": (2020,), "year_act": (2020,)})
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    # Advance the first model year
+    scen.add_cat("year", "firstmodelyear", years[-1], is_unique=True)
+
+    # Empty data frame: only 2000 and 2010 valid year_act for this node/tec;
+    # but both are before the first model year
+    obs = scen.vintage_and_active_years(
+        ya_args=("foo", "bar", years[0]), in_horizon=True
+    )
+    pdt.assert_frame_equal(pd.DataFrame(columns=["year_vtg", "year_act"]), obs)
+
+    # Exception is raised for incorrect arguments
+    with pytest.raises(ValueError, match="3 arguments are required if using `ya_args`"):
+        scen.vintage_and_active_years(ya_args=("foo", "bar"))
+
+
+def test_vintage_and_active_years_upd(test_mp):
+    scen = Scenario(test_mp, **SCENARIO["dantzig"], version="new")
+
+    # Add years of differing time length
+    years = [2000, 2005, 2010, 2015, 2020, 2030]
+    scen.add_horizon(year=years, firstmodelyear=2010)
+
+    # Check if default function call is valid
+    obs = scen.vintage_and_active_years()
+    exp = pd.DataFrame(
+        {
+            "year_vtg": (
+                2000,
+                2000,
+                2000,
+                2000,
+                2005,
+                2005,
+                2005,
+                2005,
+                2010,
+                2010,
+                2010,
+                2010,
+                2015,
+                2015,
+                2015,
+                2020,
+                2020,
+                2030,
+            ),
+            "year_act": (
+                2010,
+                2015,
+                2020,
+                2030,
+                2010,
+                2015,
+                2020,
+                2030,
+                2010,
+                2015,
+                2020,
+                2030,
+                2015,
+                2020,
+                2030,
+                2020,
+                2030,
+                2030,
+            ),
+        }
+    )
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    # Add a technology, its lifetime, and period durations
+    scen.add_set("node", "foo")
+    scen.add_set("technology", "bar")
+    scen.add_par(
+        "duration_period",
+        pd.DataFrame({"unit": "???", "value": [5, 5, 5, 5, 5, 10], "year": years}),
+    )
+    scen.add_par(
+        "technical_lifetime",
+        pd.DataFrame(
+            {
+                "node_loc": "foo",
+                "technology": "bar",
+                "unit": "???",
+                "value": 20,
+                "year_vtg": years,
+            }
+        ),
+    )
+
+    # Check standard functionality with different period duration lengths
+    obs = scen.vintage_and_active_years(ya_args=("foo", "bar", "2010"))
+    exp = pd.DataFrame(
+        {"year_vtg": (2010, 2010, 2010, 2010), "year_act": (2010, 2015, 2020, 2030)}
+    )
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    # Check if no vintge-year is passed, that all values corresponding
+    # to technical lifetime are passed if the active years >= 2010
+    obs = scen.vintage_and_active_years(ya_args=("foo", "bar"))
+    exp = pd.DataFrame(
+        {
+            "year_vtg": (
+                2000,
+                2000,
+                2005,
+                2005,
+                2005,
+                2010,
+                2010,
+                2010,
+                2010,
+                2015,
+                2015,
+                2015,
+                2020,
+                2020,
+                2030,
+            ),
+            "year_act": (
+                2010,
+                2015,
+                2010,
+                2015,
+                2020,
+                2010,
+                2015,
+                2020,
+                2030,
+                2015,
+                2020,
+                2030,
+                2020,
+                2030,
+                2030,
+            ),
+        }
+    )
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    # Check if no vintge-year is passed, that all values corresponding
+    # to technical lifetime are passed if the active years >= 2010
+    obs = scen.vintage_and_active_years(ya_args=("foo", "bar"), in_horizon=False)
+    exp = pd.DataFrame(
+        {
+            "year_vtg": (
+                2000,
+                2000,
+                2000,
+                2000,
+                2005,
+                2005,
+                2005,
+                2005,
+                2010,
+                2010,
+                2010,
+                2010,
+                2015,
+                2015,
+                2015,
+                2020,
+                2020,
+                2030,
+            ),
+            "year_act": (
+                2000,
+                2005,
+                2010,
+                2015,
+                2005,
+                2010,
+                2015,
+                2020,
+                2010,
+                2015,
+                2020,
+                2030,
+                2015,
+                2020,
+                2030,
+                2020,
+                2030,
+                2030,
+            ),
+        }
+    )
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    # Check if no vintge-year is passed, that all values corresponding
+    # to technical lifetime are passed if the vintage years >= 2010
+    obs = scen.vintage_and_active_years(ya_args=("foo", "bar"), vtg_lower=2010)
+    exp = pd.DataFrame(
+        {
+            "year_vtg": (2010, 2010, 2010, 2010, 2015, 2015, 2015, 2020, 2020, 2030),
+            "year_act": (2010, 2015, 2020, 2030, 2015, 2020, 2030, 2020, 2030, 2030),
+        }
+    )
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order
+
+    # Check if no vintge-year is passed, that all values corresponding
+    # to technical lifetime are passed if the active years >= 2020
+    obs = scen.vintage_and_active_years(ya_args=("foo", "bar"), act_lower=2020)
+    exp = pd.DataFrame(
+        {
+            "year_vtg": (2005, 2010, 2010, 2015, 2015, 2020, 2020, 2030),
+            "year_act": (2020, 2020, 2030, 2020, 2030, 2020, 2030, 2030),
+        }
+    )
+    pdt.assert_frame_equal(exp, obs, check_like=True)  # ignore col order

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -131,7 +131,7 @@ def test_vintage_and_active_years1(test_mp):
             ya_args=("foo", "bar", years[0]), in_horizon=True
         )
     assert_frame_equal(
-        pd.DataFrame(columns=["year_vtg", "year_act"]), obs, check_dtype=False
+        pd.DataFrame(columns=["year_vtg", "year_act"], dtype=np.int64), obs
     )
 
     # Exception is raised for incorrect arguments

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -178,11 +178,27 @@ def test_vintage_and_active_years2(test_mp):
     exp = _q(yvya_all, f"year_vtg >= {fmy}")
     assert_frame_equal(exp, obs)
 
+    # Alternative to the above
+    assert_frame_equal(
+        exp,
+        scen.vintage_and_active_years(ya_args=("foo", "bar"))
+        .query("year_vtg >= 2010")
+        .reset_index(drop=True),
+    )
+
     # Check if no vintge-year is passed, that all values corresponding to technical
     # lifetime are passed if the active years >= 2020
     obs = scen.vintage_and_active_years(ya_args=("foo", "bar"), act_lower=2020)
     exp = _q(yvya_all, "2020 <= year_act and year_act - year_vtg < 20", extra)
     assert_frame_equal(exp, obs)
+
+    # Alternative to the above
+    assert_frame_equal(
+        exp,
+        scen.vintage_and_active_years(ya_args=("foo", "bar"))
+        .query("year_act >= 2020")
+        .reset_index(drop=True),
+    )
 
 
 def test_vintage_and_active_years3(test_mp):

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -135,9 +135,7 @@ def test_vintage_and_active_years1(test_mp):
     )
 
     # Exception is raised for incorrect arguments
-    with pytest.raises(
-        ValueError, match="At least 2 arguments are required if using `ya_args`"
-    ):
+    with pytest.raises(ValueError, match=r"got \('foo',\) of length 1"):
         scen.vintage_and_active_years(ya_args=("foo",))
 
 

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -221,3 +221,26 @@ def test_vintage_and_active_years3(test_mp):
     obs = scen.vintage_and_active_years(ya_args=("foo", "bar"))
     exp = _q(yvya_all, f"{fmy} <= year_act <= {y_max} and year_act - year_vtg < 20")
     assert_frame_equal(exp, obs)
+
+
+def test_vintage_and_active_years4(test_mp):
+    """Technology with 'gaps'.
+
+    In this test, no ``technical_lifetime`` is designated for the 2020 and 2030
+    vintages. The technology thus cannot be vintaged in these periods, or active in the
+    2030 period, so these should not appear in the results.
+    """
+    years = (2000, 2010, 2020, 2030, 2040, 2050, 2060)
+    fmy = years[1]
+
+    # Set up scenario, tech, and retrieve valid (yv, ya) pairs
+    scen, yvya_all = _setup(test_mp, years, fmy)
+
+    # Change the technical_lifetime of the technology
+    tl = "technical_lifetime"
+    data = scen.par(tl)
+    scen.remove_par(tl, data.query("year_vtg == 2020 or year_vtg == 2030"))
+
+    obs = scen.vintage_and_active_years(("foo", "bar"))
+    assert 2030 not in obs["year_act"]
+    assert not any(y in obs["year_vtg"] for y in (2020, 2030))

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -11,27 +11,16 @@ from message_ix.testing import SCENARIO
 
 
 @lru_cache()
-def _generate_yv_ya(
-    start_or_periods: Union[Tuple[int, ...], int],
-    end: Optional[int] = None,
-    dp: Optional[int] = None,
-) -> pd.DataFrame:
-    """All meaningful combinations of (vintage year, active year).
+def _generate_yv_ya(periods: Tuple[int, ...]) -> pd.DataFrame:
+    """All meaningful combinations of (vintage year, active year) given `periods`."""
+    # commented: currently unused, this does the same as the line below, using (start
+    # period, final period, uniform ``duration_period). The intermediate periods are
+    # inferred
+    # _s = slice(periods_or_start, end + 1, dp)
+    # data = np.mgrid[_s, _s]
 
-    Can be called one of two ways:
-
-    1. (start, end, dp): the values are the start period, final period, and (single)
-       value for ``duration_period``. The intermediate periods are inferred.
-    2. A sequence (tuple) of periods: the values are used directly as the periods.
-    """
     # Create a mesh grid using numpy built-ins
-    if isinstance(start_or_periods, int):
-        assert end is not None
-        _s = slice(start_or_periods, end + 1, dp)
-        data = np.mgrid[_s, _s]
-    else:
-        assert end is None and dp is None
-        data = np.meshgrid(start_or_periods, start_or_periods, indexing="ij")
+    data = np.meshgrid(periods, periods, indexing="ij")
     # Take the upper-triangular portion (setting the rest to 0), reshape
     data = np.triu(data).reshape((2, -1))
     # Filter only non-zero pairs
@@ -77,12 +66,19 @@ def _setup(
 def _q(
     df: pd.DataFrame, query: str, append: Optional[pd.DataFrame] = None
 ) -> pd.DataFrame:
-    """Shorthand to query the results of :func:`_generate_yv_ya`."""
+    """Shorthand to query the results of :func:`_generate_yv_ya`.
+
+    1. :meth:`pandas.DataFrame.query` is called with the `query` argument.
+    2. Any additional rows in `append` are appended.
+    3. The index is reset.
+    """
     result = df.query(query).reset_index(drop=True)
+
     if append is not None:
         result = pd.concat([result, append]).sort_values(
             ["year_vtg", "year_act"], ignore_index=True
         )
+
     return result
 
 

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -138,7 +138,7 @@ def test_vintage_and_active_years1(test_mp):
     with pytest.raises(
         ValueError, match="At least 2 arguments are required if using `ya_args`"
     ):
-        scen.vintage_and_active_years(ya_args=("foo"))
+        scen.vintage_and_active_years(ya_args=("foo",))
 
 
 def test_vintage_and_active_years2(test_mp):

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -12,7 +12,7 @@ from message_ix.testing import SCENARIO
 
 
 @lru_cache()
-def _generate_yv_ya(periods: Tuple[int, ...], dtype) -> pd.DataFrame:
+def _generate_yv_ya(periods: Tuple[int, ...]) -> pd.DataFrame:
     """All meaningful combinations of (vintage year, active year) given `periods`."""
     # commented: currently unused, this does the same as the line below, using (start
     # period, final period, uniform ``duration_period). The intermediate periods are
@@ -28,7 +28,7 @@ def _generate_yv_ya(periods: Tuple[int, ...], dtype) -> pd.DataFrame:
     return pd.DataFrame(
         filter(sum, zip(data[0, :], data[1, :])),
         columns=["year_vtg", "year_act"],
-        dtype=dtype,
+        dtype=np.int64,
     )
 
 
@@ -63,9 +63,7 @@ def _setup(
         ),
     )
 
-    return scenario, _generate_yv_ya(
-        years, dtype=scenario.par("duration_period").dtypes["year"]
-    )
+    return scenario, _generate_yv_ya(years)
 
 
 def _q(

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -12,7 +12,7 @@ from message_ix.testing import SCENARIO
 
 
 @lru_cache()
-def _generate_yv_ya(periods: Tuple[int, ...]) -> pd.DataFrame:
+def _generate_yv_ya(periods: Tuple[int, ...], dtype) -> pd.DataFrame:
     """All meaningful combinations of (vintage year, active year) given `periods`."""
     # commented: currently unused, this does the same as the line below, using (start
     # period, final period, uniform ``duration_period). The intermediate periods are
@@ -26,7 +26,9 @@ def _generate_yv_ya(periods: Tuple[int, ...]) -> pd.DataFrame:
     data = np.triu(data).reshape((2, -1))
     # Filter only non-zero pairs
     return pd.DataFrame(
-        filter(sum, zip(data[0, :], data[1, :])), columns=["year_vtg", "year_act"]
+        filter(sum, zip(data[0, :], data[1, :])),
+        columns=["year_vtg", "year_act"],
+        dtype=dtype,
     )
 
 
@@ -61,7 +63,9 @@ def _setup(
         ),
     )
 
-    return scenario, _generate_yv_ya(years)
+    return scenario, _generate_yv_ya(
+        years, dtype=scenario.par("duration_period").dtypes["year"]
+    )
 
 
 def _q(


### PR DESCRIPTION
This PR extends the features of the function `vintage_and_active_years()` based on issue #571 

## How to review

- Read the diff and note that the CI checks all pass.
- Build the documentation and look at a description of `vintage_and_active_years()`
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
