### PR TITLE
Correct index of "time" in equation RENEWABLES_EQUIVALENCE

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,7 +10,7 @@ Files compatible with v3.4.0 and earlier will not work with this version and sho
 All changes
 -----------
 
-- Correct typo in GAMS formulation, eq. `RENEWABLE_EQUIVALENCE` (:pull:`581`).
+- Correct typo in GAMS formulation, :ref:`equation_renewables_equivalence` (:pull:`581`).
 - Improve configurability of :mod:`.macro`; see the :doc:`documentation <macro>` (:pull:`327`).
 - Split :meth:`.Reporter.add_tasks` for use without an underlying :class:.`Scenario` (:pull:`567`).
 - Allow setting the “model_dir” and “solve_options” options for :class:`.GAMSModel` (and subclasses :class:`.MESSAGE`, :class:`.MACRO`, and :class:`.MESSAGE_MACRO`) through the user's ixmp configuration file; expand documentation (:pull:`557`).

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,6 +10,7 @@ Files compatible with v3.4.0 and earlier will not work with this version and sho
 All changes
 -----------
 
+- Correct typo in GAMS formulation, eq. `RENEWABLE_EQUIVALENCE` (:pull:`581`).
 - Improve configurability of :mod:`.macro`; see the :doc:`documentation <macro>` (:pull:`327`).
 - Split :meth:`.Reporter.add_tasks` for use without an underlying :class:.`Scenario` (:pull:`567`).
 - Allow setting the “model_dir” and “solve_options” options for :class:`.GAMSModel` (and subclasses :class:`.MESSAGE`, :class:`.MACRO`, and :class:`.MESSAGE_MACRO`) through the user's ixmp configuration file; expand documentation (:pull:`557`).

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -813,7 +813,7 @@ RENEWABLES_EQUIVALENCE(node,renewable_tec,commodity,year,time)$(
                  map_tec_act(node,renewable_tec,year,mode,time)
                  AND map_tec_lifetime(node,renewable_tec,vintage,year) ),
         input(location,renewable_tec,vintage,year,mode,node,commodity,level_renewable,time_act,time)
-        * ACT(location,renewable_tec,vintage,year,mode,time) ) ;
+        * ACT(location,renewable_tec,vintage,year,mode,time_act) ) ;
 
 ***
 * .. _equation_renewables_potential_constraint:

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -810,7 +810,7 @@ RENEWABLES_EQUIVALENCE(node,renewable_tec,commodity,year,time)$(
         map_tec(node,renewable_tec,year) AND map_ren_com(node,renewable_tec,commodity,year) )..
     SUM(grade$( map_ren_grade(node,commodity,grade,year) ), REN(node,renewable_tec,commodity,grade,year,time) )
     =E= SUM((location,vintage,mode,level_renewable,time_act)$(
-                 map_tec_act(node,renewable_tec,year,mode,time)
+                 map_tec_act(node,renewable_tec,year,mode,time_act)
                  AND map_tec_lifetime(node,renewable_tec,vintage,year) ),
         input(location,renewable_tec,vintage,year,mode,node,commodity,level_renewable,time_act,time)
         * ACT(location,renewable_tec,vintage,year,mode,time_act) ) ;


### PR DESCRIPTION
There is a typo in GAMS equations specified in issue #521, which is corrected through this PR. The inline documentation is already correct and does not need any change. This PR does not need any additional test.

## How to review

**Required:** 
Please look at equation `RENEWABLES_EQUIVALENCE` in `model_core.gms`. Parameter `input` is indexed with `time_act` and `time`, multiplied by variable `ACT` which is indexed by `time`. Here, the correct index of time for ` ACT` must be `time_act`. To check this, one needs to know if the order of indexes of `time_act` and `time` in parameter `input` is correct or not. This can be checked, for example, by running a command `scenario.idx_names("input")`.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
<!--
The following items are all *required* if the PR results in changes to user-
facing behaviour, e.g. new features or fixes to existing behaviour. They are
*optional* if the changes are solely to documentation, CI configuration, etc.

In ambiguous cases, strike them out and add a short explanation, e.g.

- ~Add or expand tests.~ No change in behaviour, simply refactoring.
-->
- [x] Add or expand tests; coverage checks both ✅ ==> Not needed
- [x] Add, expand, or update documentation ==> Not needed
- [x] Update release notes.
