### PR TITLE
Un-pin message-ix version in Documentation and Conda CI workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,15 +31,15 @@ For example, one or more of:
 
 <!-- This item is always required. -->
 - [ ] Continuous integration checks all ✅
-<!--
-The following items are all *required* if the PR results in changes to user-
-facing behaviour, e.g. new features or fixes to existing behaviour. They are
-*optional* if the changes are solely to documentation, CI configuration, etc.
+  <!--
+  The following items are all *required* if the PR results in changes to user-
+  facing behaviour, e.g. new features or fixes to existing behaviour. They are
+  *optional* if the changes are solely to documentation, CI configuration, etc.
 
-In ambiguous cases, strike them out and add a short explanation, e.g.
+  In ambiguous cases, strike them out and add a short explanation, e.g.
 
-- ~Add or expand tests.~ No change in behaviour, simply refactoring.
--->
+  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
+  -->
 - [ ] Add or expand tests; coverage checks both ✅
 - [ ] Add, expand, or update documentation.
 - [ ] Update release notes.

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -67,7 +67,7 @@ jobs:
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix=3.4 ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda create --quiet --name testenv message-ix ${{ matrix.extra-deps }} pytest asyncssh sphinx
         conda list --name testenv
 
     - name: Check CLI commands and run test

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -91,7 +91,7 @@ Using Anaconda
 8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``).
    This step can take up to ~45 minutes [3]_::
 
-    $ conda install message-ix">1"
+    $ conda install message-ix
 
 Again: at this point, installation is complete.
 You do not need to complete the steps in “Using ``pip``” or “From source”.
@@ -101,7 +101,6 @@ Go to the section `Check that installation was successful`_.
 .. [2] The ‘$’ character at the start of these lines indicates that the command text should be entered in the terminal or prompt, depending on the operating system.
        Do not retype the ‘$’ character itself.
 .. [3] Notice that conda uses the hyphen (‘-’) in package names, different from the underscore (‘_’) used in Python when importing the package.
-       Specifying a version >1 is currently *required* on macOS and Windows, please see issue `#558 <https://github.com/iiasa/message_ix/issues/558>`_.
 .. note:: When using Anaconda (not Miniconda), steps (5) through (8) can also be performed using the graphical Anaconda Navigator.
    See the `Anaconda Navigator documentation`_ for how to perform the various steps.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -88,8 +88,7 @@ Using Anaconda
     $ conda create --name message_env
     $ conda activate message_env
 
-8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``).
-   This step can take up to ~45 minutes [3]_::
+8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``) [3]_::
 
     $ conda install message-ix
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -88,7 +88,7 @@ Using Anaconda
     $ conda create --name message_env
     $ conda activate message_env
 
-8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``) [3]_::
+8. Install the ``message-ix`` package into the current environment (either e.g. ``message_env``, or another name from step 7) [3]_::
 
     $ conda install message-ix
 


### PR DESCRIPTION
Since https://github.com/conda-forge/admin-requests/pull/385 got merged the latest version of `message-ix` gets again installed via `conda install message-ix`.

This PR 
- adjusts the documentation for the steps to install  `message-ix` via Anaconda and
- un-pins the `message-ix` version in the conda CI workflow.

Closes https://github.com/iiasa/message_ix/issues/558.

FYI: Locally the time to solve the environment takes now around ~7 minutes.

## How to review

Note the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~
- ~Update release notes.~