### PR TITLE
Adjust documented installation steps for Anaconda

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -91,7 +91,7 @@ Using Anaconda
 8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``).
    This step can take up to ~45 minutes [3]_::
 
-    $ conda install message-ix">1"
+    $ conda install message-ix
 
 Again: at this point, installation is complete.
 You do not need to complete the steps in “Using ``pip``” or “From source”.
@@ -101,7 +101,6 @@ Go to the section `Check that installation was successful`_.
 .. [2] The ‘$’ character at the start of these lines indicates that the command text should be entered in the terminal or prompt, depending on the operating system.
        Do not retype the ‘$’ character itself.
 .. [3] Notice that conda uses the hyphen (‘-’) in package names, different from the underscore (‘_’) used in Python when importing the package.
-       Specifying a version >1 is currently *required* on macOS and Windows, please see issue `#558 <https://github.com/iiasa/message_ix/issues/558>`_.
 .. note:: When using Anaconda (not Miniconda), steps (5) through (8) can also be performed using the graphical Anaconda Navigator.
    See the `Anaconda Navigator documentation`_ for how to perform the various steps.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -88,8 +88,7 @@ Using Anaconda
     $ conda create --name message_env
     $ conda activate message_env
 
-8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``).
-   This step can take up to ~45 minutes [3]_::
+8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``) [3]_::
 
     $ conda install message-ix
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -88,7 +88,7 @@ Using Anaconda
     $ conda create --name message_env
     $ conda activate message_env
 
-8. Install the ``message-ix`` package into the current environment (either ``base``, or another name from step 7, e.g. ``message_env``) [3]_::
+8. Install the ``message-ix`` package into the current environment (either e.g. ``message_env``, or another name from step 7) [3]_::
 
     $ conda install message-ix
 


### PR DESCRIPTION
This PR adjusts the documentation for the steps to install MESSAGEix via Anaconda. 
Since https://github.com/conda-forge/admin-requests/pull/385 got merged the latest version of `message-ix` gets again installed via `conda install message-ix`. Locally the time to solve the environment takes now around ~7 minutes.

## How to review
TBA
<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- Build the documentation and look at a certain page.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
<!--
The following items are all *required* if the PR results in changes to user-
facing behaviour, e.g. new features or fixes to existing behaviour. They are
*optional* if the changes are solely to documentation, CI configuration, etc.

In ambiguous cases, strike them out and add a short explanation, e.g.

- ~Add or expand tests.~ No change in behaviour, simply refactoring.
-->
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
