### PR TITLE
Extend documentation of `CAP` and `CAP_NEW`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,6 +10,7 @@ Files compatible with v3.4.0 and earlier will not work with this version and sho
 All changes
 -----------
 
+- Extend documentation on decision variables "CAP_NEW" and "CAP" (:pull:`595`)
 - Correct typo in GAMS formulation, :ref:`equation_renewables_equivalence` (:pull:`581`).
 - Handle zero values in ``capacity_factor`` in models with sub-annual time resolution; expand tests (:issue:`515`, :pull:`561`).
 - Extend explanations, update :func:`.make_df` signature in tutorials (:pull:`524`).

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -60,7 +60,13 @@
 *
 * All decision variables are by year, not by (multi-year) period, except :math:`STOCK_{n,c,l,y}`.
 * In particular, the new capacity variable :math:`CAP\_NEW_{n,t,y}` has to be multiplied by the number of years
-* in a period :math:`|y| = duration\_period_{y}` to determine the available capacity in subsequent periods.
+* in a period :math:`|y| = duration\_period_{y}` to determine the available capacity :math:`CAP_{n,t,y^V,y}`
+* in subsequent periods (assuming the newly build capacity is not immediately decommissioned):
+*
+* :math:`CAP_{n,t,y^V,y} = CAP\_NEW_{n,t,y} * duration\_period_{y}`
+*
+* :math:`CAP\_NEW_{n,t,y}` is therefore the amount of newly installed capacity *in one year* and
+* :math:`CAP_{n,t,y^V,y}` the amount, which is installed at the *end of a (usually multi-year) period*.
 * This formulation gives more flexibility when it comes to using periods of different duration
 * (more intuitive comparison across different periods).
 *


### PR DESCRIPTION
This PR extends the documentation of the decision variables `CAP` and `CAP_NEW`.
Closes #48. 

## How to review

- Read the diff and note that the CI checks all pass.
- Build the documentation and look at "MESSAGE core formulation" > "Variable definitions" > "Decision variables".

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Update release notes.

