### PR TITLE
Extend documentation on historical capacity and activity values

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,6 +10,7 @@ Files compatible with v3.4.0 and earlier will not work with this version and sho
 All changes
 -----------
 
+- Extend documentation on historical capacity and activity values (:pull:`496`)
 - Extend documentation on decision variables "CAP_NEW" and "CAP" (:pull:`595`)
 - Extend documentation to guide users through the Westeros tutorials (:pull:`594`).
 - Add new logo and diagram to the documentation (:pull:`597`).

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -500,7 +500,12 @@ Parameters
 * Historical capacity and activity values
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
-* Historical data on new capacity and activity levels are included in |MESSAGEix| for
+* To model the transition of an energy system, one must start with the existing system.
+* The historical activity and the historical new capacity define the energy mix before
+* the model horizon - therefore the current energy system. These parameters have to be defined
+* in order to limit the capacity in the first model period.
+*
+* Historical data on new capacity and activity levels are therefore included in |MESSAGEix| for
 * correct accounting of the vintage portfolio and a seamless implementation of dynamic constraints from
 * historical years to model periods.
 *
@@ -514,6 +519,25 @@ Parameters
 *      - ``node_loc`` | ``tec`` | ``year_vtg``
 *    * - historical_activity [#hist]_
 *      - ``node_loc`` | ``tec`` | ``year_act`` | ``mode`` | ``time``
+*
+*
+* The activity in the historic period can be defined with
+*
+* .. math::
+*    \sum_{m} \text{ACT}_{n,t,y^V,y,m,h} \leq \text{duration_time}_{h} \cdot \text{capacity_factor}_{n,t,y^V,y,h} \\
+*    \cdot \text{CAP}_{n,t,y^V,y} \quad t \ \in \ T^{INV}
+*
+* and the historic new capacity with
+*
+* .. math::
+*    \text{CAP_NEW}_{n,t,y^V} = \frac{\text{CAP}_{n,t,y^V,y}}{\text{duration_period}_{y}}
+*
+* Both equations are equally valid for model periods, however to calculate ``historical_new_capacity``
+* and ``historical_activity`` all parameters must describe the historic period.
+*
+* The ``duration_period`` of the first period (historic period) is set to the value that appears
+* most frequently in the model. If, for example, the majority of periods in an energy system
+* consists of 10 years, the ``duration_period`` of the first period is likewise 10 years.
 *
 ***
 

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -500,10 +500,9 @@ Parameters
 * Historical capacity and activity values
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
-* To model the transition of an energy system, one must start with the existing system.
-* The historical activity and the historical new capacity define the energy mix before
-* the model horizon - therefore the current energy system. These parameters have to be defined
-* in order to limit the capacity in the first model period.
+* To model the transition of an energy system, the initial energy system with its energy mix
+* needs to be defined first. The historical activity and the historical new capacity do this.
+* These parameters have to be defined in order to limit the capacity in the first model period.
 *
 * Historical data on new capacity and activity levels are therefore included in |MESSAGEix| for
 * correct accounting of the vintage portfolio and a seamless implementation of dynamic constraints from
@@ -527,16 +526,16 @@ Parameters
 *    \sum_{m} \text{ACT}_{n,t,y^V,y,m,h} \leq \text{duration_time}_{h} \cdot \text{capacity_factor}_{n,t,y^V,y,h} \\
 *    \cdot \text{CAP}_{n,t,y^V,y} \quad t \ \in \ T^{INV}
 *
-* and the historic new capacity with
+* and the historical new capacity with
 *
 * .. math::
 *    \text{CAP_NEW}_{n,t,y^V} = \frac{\text{CAP}_{n,t,y^V,y}}{\text{duration_period}_{y}}
 *
-* Both equations are equally valid for model periods, however to calculate ``historical_new_capacity``
+* Both equations are equally valid for model periods. However, to calculate ``historical_new_capacity``
 * and ``historical_activity`` all parameters must describe the historic period.
 *
 * The ``duration_period`` of the first period (historic period) is set to the value that appears
-* most frequently in the model. If, for example, the majority of periods in an energy system
+* most frequently in the model. If, for example, the majority of periods in the model
 * consists of 10 years, the ``duration_period`` of the first period is likewise 10 years.
 *
 ***


### PR DESCRIPTION
This PR extends the documentation on historical capacity and activity values.
Closes #496 

## How to review

- Read the diff and note that the CI checks all pass.
- Build the documentation and look at the parameter definitions "Historical capacity and activity values"

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
