### PR TITLE
Ensure MESSAGE.enforce() runs for MESSAGE_MACRO

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -67,4 +67,4 @@ jobs:
       # Also install type stubs and full packages that provide type hints
       run: |
         pip install mypy genno sphinx types-pkg_resources types-requests types-PyYAML
-        mypy .
+        mypy --show-error-codes .

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -4,8 +4,8 @@ name: Test MESSAGEix-GLOBIOM scenarios
 
 on:
   # Uncomment these two lines for debugging, but leave them commented on 'main'
-  # pull_request:
-  #   branches: [ main ]
+  pull_request:
+    branches: [ main ]
   schedule:
   # 05:00 UTC = 06:00 CET = 07:00 CEST
   - cron: "0 5 * * *"

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -335,9 +335,8 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
     @staticmethod
     def enforce(scenario):
         """Enforce data consistency in `scenario`."""
-        # Implemented in MESSAGE sub-class, below
+        # No-op; implemented in MESSAGE sub-class, below
         # TODO make this an optional method of the ixmp.model.base.Model abstract class
-        pass
 
     def __init__(self, name=None, **model_options):
         # Update the default options with any user-provided options
@@ -410,8 +409,6 @@ class MESSAGE(GAMSModel):
 
             if existing.equals(expected):
                 continue  # Contents are as expected; do nothing
-            # else:
-            #     scenario.add_set(set_name, expected)
 
             # Not consistent; empty and then re-populate the set
             with scenario.transact(f"Enforce consistency of {set_name} and {par_name}"):
@@ -452,7 +449,7 @@ class MACRO(GAMSModel):
         cls.initialize_items(scenario, items)
 
 
-class MESSAGE_MACRO(MACRO):
+class MESSAGE_MACRO(MESSAGE, MACRO):
     """Model class for MESSAGE_MACRO."""
 
     name = "MESSAGE-MACRO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,12 @@ module = [
 ]
 ignore_missing_imports = true
 
+# Workaround for iiasa/ixmp#449
+# TODO remove once fixed upstream
+[[tool.mypy.overrides]]
+module = ["ixmp.core.scenario"]
+ignore_errors = true
+
 [tool.pytest.ini_options]
 # Disable faulthandler plugin on Windows to prevent spurious console noise
 addopts = """


### PR DESCRIPTION
Closes #591 by ensuring that the MESSAGE.enforce() method, ensuring consistency of internal sets and parameters, is called when a scenario is solved using the MESSAGE_MACRO class.

Note that this demonstrates the workflow described at https://github.com/iiasa/message_ix/pull/603#issuecomment-1123486549:
> 1. Author opens a PR with some commits. Status in our tracker is "In progress".
> 2. Identifying that their PR ~touches the GAMS implementation~ involves the nightly tests, author pushes a commit uncommenting these lines: https://github.com/iiasa/message_ix/blob/b572ccee45c293a88f1f2acf91a0811d50cf6593/.github/workflows/nightly.yaml#L6-L8 with a message like `TEMPORARY Enable nightly workflow for PR.`
> 3. Author develops their PR, pushing commits, noting and ensuring that the "pytest", "lint" **and** "nightly" checks pass.
> 4. Author requests a review; status is "In review".
> 5. Reviewer does the review, possibly requesting changes.
> 6. Review and author interact until reviewer is satisfied.
> 7. Reviewer approves.
> 8. Author or maintainer performs `git rebase -i` on the branch to `drop` the "TEMPORARY" commit from step 2.
> 9. Merge.

## How to review

- Read the diff and note that the CI checks all pass.
- Run specific scenarios as described at https://github.com/iiasa/message_ix/issues/591#issuecomment-1136024937 and ensure the behaviour remains the same as prior to the merge of #561 

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, fix bug to restore intended/documented behaviour
- [x] Update release notes.