### PR TITLE
Tolerate non-default pandas Index in `Scenario.years_active()`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -16,6 +16,7 @@ Migration notes
 All changes
 -----------
 
+- Correct functionality-syntax of :meth:`.vintage_and_active_years` (:pull:`623`).
 - Extend functionality of :meth:`.vintage_and_active_years`; add aliases
   :meth:`.yv_ya`, :meth:`.ya`, and :attr:`.y0` (:pull:`572`).
 - Add scripts and HOWTO for documentation videos (:pull:`396`)

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -593,7 +593,9 @@ class Scenario(ixmp.Scenario):
         filters = dict(node_loc=[node], technology=[tec], year_vtg=[yv])
 
         # Lifetime of the technology at the node and year_vtg
-        lt = self.par("technical_lifetime", filters=filters).at[0, "value"]
+        lt = (
+            self.par("technical_lifetime", filters=filters).reset_index().at[0, "value"]
+        )
 
         # Duration of periods
         data = self.par("duration_period").sort_values(by="year")


### PR DESCRIPTION
This PR introduces the updated syntax to resolve the issue as described in Issue #618 

## How to review

Check code adjustments and ensure all tests pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, syntax correction, no change in behavior
- ~Update release notes.~