### PR TITLE
Satisfy mypy under numpy >= 1.22

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+  # 05:00 UTC = 06:00 CET = 07:00 CEST
+  - cron: "0 5 * * *"
 
 jobs:
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -47,10 +47,12 @@ coverage.xml
 htmlcov
 prof/
 
+# Editors and IDEs
 # JetBrains IDEs incl. PyCharm
 /**/.idea
 # RStudio
 .Rproj.user
+.vscode
 
 # macOS
 .DS_Store

--- a/message_ix/tests/test_feature_vintage_and_active_years.py
+++ b/message_ix/tests/test_feature_vintage_and_active_years.py
@@ -20,10 +20,10 @@ def _generate_yv_ya(periods: Tuple[int, ...]) -> pd.DataFrame:
     # _s = slice(periods_or_start, end + 1, dp)
     # data = np.mgrid[_s, _s]
 
-    # Create a mesh grid using numpy built-ins
-    data = np.meshgrid(periods, periods, indexing="ij")
-    # Take the upper-triangular portion (setting the rest to 0), reshape
-    data = np.triu(data).reshape((2, -1))
+    # - Create a mesh grid using numpy built-ins
+    # - Take the upper-triangular portion (setting the rest to 0)
+    # - Reshape
+    data = np.triu(np.meshgrid(periods, periods, indexing="ij")).reshape((2, -1))
     # Filter only non-zero pairs
     return pd.DataFrame(
         filter(sum, zip(data[0, :], data[1, :])),


### PR DESCRIPTION
In #451 and https://github.com/iiasa/message_ix/pull/623#issuecomment-1154924231 we discovered that with newer numpy (1.22, 1.23) type errors ocurred in `.tests.test_feature_vintage_and_active_years`. This PR:

- Addresses the new type error.
- Sets the "lint" CI workflow to run nightly, so that these are picked up by the scheduled job rather that during devs' unrelated PRs.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, linting only, no change in behaviour
- ~Update release notes.~