### PR TITLE
Add `as_message_df()` reporting computation

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -9,17 +9,16 @@ Migration notes
   To prepare for this change, user code that expects values confined to the time horizon can be altered to use :meth:`.pandas.DataFrame.query`:
 
   .. code-block:: python
-  
+
      df = scen.vintage_and_active_years().query(f"{scen.y0} <= year_vtg")
 
 
 All changes
 -----------
 
-- Correct functionality-syntax of :meth:`.vintage_and_active_years` (:pull:`623`).
-- Extend functionality of :meth:`.vintage_and_active_years`; add aliases
-  :meth:`.yv_ya`, :meth:`.ya`, and :attr:`.y0` (:pull:`572`).
-- Add scripts and HOWTO for documentation videos (:pull:`396`)
+- New reporting computation :func:`.as_message_df` (:pull:`628`).
+- Extend functionality of :meth:`.vintage_and_active_years`; add aliases :meth:`.yv_ya`, :meth:`.ya`, and :attr:`.y0` (:pull:`572`, :pull:`623`).
+- Add scripts and HOWTO for documentation videos (:pull:`396`).
 
 .. _v3.5.0:
 

--- a/doc/reporting.rst
+++ b/doc/reporting.rst
@@ -251,10 +251,11 @@ Computations
 .. automodule:: message_ix.reporting.computations
    :members:
 
-   :mod:`message_ix.reporting` only provides two computations, which are currently only used in the tutorials to produce simple plots.
-   For custom plotting, :mod:`genno.compat.plotnine` is recommended.
+   :mod:`message_ix.reporting` provides a small number of computations.
+   Two of these (:func:`.plot_cumulative` and :func:`.stacked_bar`) are currently only used in the tutorials to produce simple plots; for more flexible plotting, :mod:`genno.compat.plotnine` is recommended instead.
 
    .. autosummary::
+      as_message_df
       plot_cumulative
       stacked_bar
 

--- a/doc/reporting.rst
+++ b/doc/reporting.rst
@@ -264,6 +264,7 @@ Computations
    .. autosummary::
       ~ixmp.reporting.computations.data_for_quantity
       ~ixmp.reporting.computations.map_as_qty
+      ~ixmp.reporting.computations.store_ts
       ~ixmp.reporting.computations.update_scenario
 
    …and by :mod:`genno.computation` and its compatibility modules. See the package documentation for details.
@@ -278,10 +279,16 @@ Computations
       ~genno.computations.combine
       ~genno.computations.concat
       ~genno.computations.disaggregate_shares
+      ~genno.computations.div
       ~genno.computations.group_sum
+      ~genno.computations.index_to
+      ~genno.computations.interpolate
       ~genno.computations.load_file
-      ~genno.computations.product
+      ~genno.computations.mul
+      ~genno.computations.pow
       ~genno.computations.ratio
+      ~genno.computations.relabel
+      ~genno.computations.rename_dims
       ~genno.computations.select
       ~genno.computations.sum
       ~genno.computations.write_report

--- a/doc/reporting.rst
+++ b/doc/reporting.rst
@@ -185,13 +185,13 @@ Other added keys include:
 - Computations to convert internal :func:`Quantity` data format to the IAMC data format, i.e. as :class:`pyam.IamDataFrame` objects.
   These include:
 
-  - ``<name>:pyam`` for most of the above derived quantities.
-  - ``CAP:pyam`` (from ``CAP``)
-  - ``CAP_NEW:pyam`` (from ``CAP_NEW``)
+  - ``<name>::pyam`` for most of the above derived quantities.
+  - ``CAP::pyam`` (from ``CAP``)
+  - ``CAP_NEW::pyam`` (from ``CAP_NEW``)
 
 - ``map_<name>`` as "one-hot" or indicator quantities for the respective |MESSAGEix| mapping sets ``cat_<name>``.
-- Standard reports ``message:system``, ``message:costs``, and ``message:emissions`` per :data:`REPORTS`.
-- The report ``message:default``, collecting all of the above reports.
+- Standard reports ``message::system``, ``message::costs``, and ``message::emissions`` per :data:`REPORTS`.
+- The report ``message::default``, collecting all of the above reports.
 
 These automatic contents are prepared using:
 

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -13,7 +13,6 @@ from ixmp.reporting import (
 from ixmp.reporting import Reporter as IXMPReporter
 from ixmp.reporting import configure
 
-from . import computations
 from .pyam import collapse_message_cols
 
 __all__ = [
@@ -212,8 +211,12 @@ def get_tasks() -> Sequence[Tuple[Tuple, Mapping]]:
 class Reporter(IXMPReporter):
     """MESSAGEix Reporter."""
 
-    # Module containing predefined computations, including those defined by message_ix
-    modules = list(IXMPReporter.modules) + [computations]
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Append message_ix.reporting.computations to the modules in which the Computer
+        # will look up computations names.
+        self.require_compat("message_ix.reporting.computations")
 
     @classmethod
     def from_scenario(cls, scenario, **kwargs) -> "Reporter":

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -143,9 +143,9 @@ PYAM_CONVERT = [
 #: Automatic reports that :meth:`~computations.concat` quantities converted to IAMC
 #: format.
 REPORTS = {
-    "message:system": ["out:pyam", "in:pyam", "CAP:pyam", "CAP_NEW:pyam"],
-    "message:costs": ["inv:pyam", "fom:pyam", "vom:pyam", "tom:pyam"],
-    "message:emissions": ["emi:pyam"],
+    "message::system": ["out::pyam", "in::pyam", "CAP::pyam", "CAP_NEW::pyam"],
+    "message::costs": ["inv::pyam", "fom::pyam", "vom::pyam", "tom::pyam"],
+    "message::emissions": ["emi::pyam"],
 }
 
 

--- a/message_ix/reporting/computations.py
+++ b/message_ix/reporting/computations.py
@@ -45,6 +45,7 @@ def as_message_df(
     pandas.DataFrame
         if `wrap` is :data:`False`.
     """
+    name = getattr(name, "data", name)  # Unwrap dask.core.literal
     base = qty.to_series().reset_index(name="value")
     df = make_df(
         name,

--- a/message_ix/reporting/computations.py
+++ b/message_ix/reporting/computations.py
@@ -1,7 +1,59 @@
+from typing import Mapping, Union
+
+import pandas as pd
+from ixmp.reporting import Quantity
+
+from message_ix.util import make_df
+
 __all__ = [
+    "as_message_df",
     "plot_cumulative",
     "stacked_bar",
 ]
+
+
+def as_message_df(
+    qty: Quantity, name: str, dims: Mapping, common: Mapping, wrap: bool = True
+) -> Union[pd.DataFrame, dict]:
+    """Convert `qty` to an :mod:`ixmp.add_par`-ready data frame using :func:`make_df`.
+
+    The resulting data frame has:
+
+    - A "value" column populated with the values of `qty`.
+    - A "unit" column with the string representation of the units of `qty`.
+    - Other dimensions/key columns filled with labels of `qty` according to `dims`.
+    - Other dimensions/key columns filled with uniform values from `common`.
+
+    Parameters
+    ----------
+    qty : :class:`.genno.Quantity`
+    name : str
+        Name of the :ref:`MESSAGEix parameter <parameter_def>` to prepare.
+    dims : mapping (str → str)
+        Each key corresponds to a dimension of the target parameter `name`, e.g.
+        "node_loc"; the label corresponds to a dimension of `qty`, e.g. "nl".
+    common : mapping (str → Any)
+        Each key corresponds to a dimension of the target parameter; values are used
+        literally, as if passed to :func:`.make_df`.
+    wrap : bool, optional
+        See below.
+
+    Returns
+    -------
+    length-1 :class:`dict` of `name` → pandas.DataFrame
+        if `wrap` is :data:`True`, the default; or
+    pandas.DataFrame
+        if `wrap` is :data:`False`.
+    """
+    base = qty.to_series().reset_index(name="value")
+    df = make_df(
+        name,
+        unit=f"{qty.units:~}",
+        value=base["value"],
+        **{k1: base[k2] for k1, k2 in dims.items()},
+        **common,
+    )
+    return {name: df} if wrap else df
 
 
 def plot_cumulative(x, y, labels):

--- a/message_ix/tests/reporting/test_computations.py
+++ b/message_ix/tests/reporting/test_computations.py
@@ -25,6 +25,13 @@ def test_as_message_df(test_mp):
     # Can be called directly
     result0 = computations.as_message_df(q, *args, wrap=False)
     assert not result0.isna().any().any()
+    # Values appear with the correct indices
+    assert (
+        q.sel(c="c2", h="h1", nl="nl4").item()
+        == result0.query("commodity == 'c2' and time == 'h1' and node == 'nl4'")[
+            "value"
+        ].iloc[0]
+    )
 
     # Through a Reporter, with default wrap=True
     r = Reporter()

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -184,7 +184,7 @@ def test_reporter_convert_pyam(caplog, tmp_path, dantzig_reporter):
     key2 = rep.convert_pyam(ACT, "iamc", rename=rename, collapse=add_tm)
 
     # Keys of added node(s) are returned
-    assert ACT.name + ":iamc" == key2
+    assert ACT.name + "::iamc" == key2
 
     caplog.clear()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ profile = "black"
 # Packages/modules for which no type hints are available.
 module = [
   "asyncssh",
+  "dask.core",
   "matplotlib.*",
   "pandas.*",
   "pyam",

--- a/tutorial/westeros/westeros_report.ipynb
+++ b/tutorial/westeros/westeros_report.ipynb
@@ -15,6 +15,7 @@
     "\n",
     "**Pre-requisites**\n",
     "- You have the *MESSAGEix* framework installed and working.\n",
+    "  In particular, you should have installed ``message_ix[report]``, which requires ``ixmp[report]``, ``genno[compat]``, and ``plotnine``.\n",
     "- Complete tutorial Part 1 (``westeros_baseline.ipynb``)\n",
     "  - Understand the following MESSAGEix terms: ‘variable’, ‘parameter’.\n",
     "- Open the [‘Reporting’ page in the MESSAGEix documentation](https://docs.messageix.org/en/stable/reporting.html); bookmark it or keep it open in a tab.\n",
@@ -59,8 +60,8 @@
     "The core class used for reporting is ``message_ix.Reporter``, which extends the class ``ixmp.Reporter``.\n",
     "A reporting workflow has two steps:\n",
     "\n",
-    "1. Describe all computations the Reporter may handle, using ``Reporter.add()`` and other helper methods.\n",
-    "2. Triggering the computation of one or more quantities or reports, using ``Reporter.get()``.\n",
+    "1. **Prepare** or describe all computations the Reporter may possibly handle, using ``Reporter.add()`` and other helper methods.\n",
+    "2. **Execute** a subset of these computations using ``Reporter.get()``, in order to generate one or more quantities or reports.\n",
     "\n",
     "This two-step process allows the Reporter to deliver good performance, by excluding unneeded computations and avoiding re-computing intermediate results that are used in multiple places."
    ]
@@ -71,7 +72,7 @@
    "source": [
     "## Concepts: The Graph\n",
     "\n",
-    "``ixmp.Reporter`` is built around a **graph** of *nodes* and *edges*; specifically, a *directed, acyclic graph*.\n",
+    "``ixmp.Reporter`` is built around a **graph** of *nodes* and *edges*; specifically, a *directed, acyclic graph* (DAG).\n",
     "This means:\n",
     "- Every edge has a direction; *from* one node *to* another.\n",
     "- There are no recursive loops in the graph; i.e. no node is its own ancestor.\n",
@@ -93,7 +94,7 @@
     "- An edge from \"A\" to \"C\", indicating that the value of A is an input to C.\n",
     "- An edge from \"B\" to \"C\".\n",
     "\n",
-    "We use the Reporter to describe this equation (step 1):"
+    "We use the Reporter to describe this equation (step 1 in the 2-step workflow):"
    ]
   },
   {
@@ -108,7 +109,7 @@
     "rep = Reporter()\n",
     "\n",
     "# Add two nodes\n",
-    "# These have no outputs; they only return a literal value.\n",
+    "# These have no inputs and don't execute any code; they only return a literal value.\n",
     "rep.add(\"A\", 1)\n",
     "rep.add(\"B\", 2)\n",
     "\n",
@@ -130,9 +131,9 @@
     "  \n",
     "    Let's break that down further:\n",
     "    - The first item, ``lambda *inputs: sum(inputs)``, is an anonymous function ([read more](https://doc.python.org/3/tutorial/controlflow.html#lambda-expressions)) that computes the sum of its inputs.\n",
-    "    - All the remaining items, `\"A\", B\"`, are keys for other nodes in the graph.\n",
+    "    - All the remaining items, `\"A\", \"B\"`, are keys for other nodes in the graph.\n",
     "\n",
-    "Next, let's trigger the calculation of `\"C\"` (step 1), which gives the expected value:"
+    "Next, let's trigger the calculation of `\"C\"` (step 2 in the 2-step workflow), which gives the expected value:"
    ]
   },
   {
@@ -183,7 +184,7 @@
     "\n",
     "In more realistic examples, the graph can have:\n",
     "- Long chains of calculations, each depending on the output of its ancestors, and/or\n",
-    "- Multiple connection, so that \"A\" is used by more than one child calculations.\n",
+    "- Multiple connection, so that e.g. \"A\" is used by more than one child calculations.\n",
     "\n",
     "However, the Reporter still follows the same procedure to traverse the graph and calculate the results."
    ]
@@ -313,7 +314,7 @@
     "For some calculations, we may not care about some of these dimensions.\n",
     "\n",
     "For instance, $\\text{output}$ has ten dimensions: $\\text{output}^{n^Lty^Vymnclh^Ah}$.\n",
-    "But we may be interested in the total output in a given year ($y$), but not concerned about different vintages of a technology ($y^V$).\n",
+    "But we may be interested in the total output in a given period ($y$), but not concerned about different vintages of a technology ($y^V$).\n",
     "In this case, we don't really want the 10-dimensional quantity—but its **partial sum** over all values of $y^V$.\n",
     "\n",
     "**Notation.**\n",
@@ -321,8 +322,8 @@
     "We define partial sums over every possible combination of dimensions:\n",
     "\n",
     "$$\n",
-    "\\begin{array}\n",
-    "AA^{ij} = \\left[ a_{i,j} \\right],\n",
+    "\\begin{align}\n",
+    "A^{ij} = \\left[ a_{i,j} \\right],\n",
     "  & a_{i,j} = \\sum_{k}{a_{i,j,k}} \\ \\forall \\ i, j\n",
     "  & \\text{similarly } A^{ik}, A^{jk} \\\\\n",
     "A^{i} = \\left[ a_i \\right],\n",
@@ -330,21 +331,21 @@
     "  & \\text{similarly } A^j, A^k \\\\\n",
     "& \\qquad A = \\sum_i\\sum_j\\sum_k{a_{i,j,k}}\n",
     "  & \\text{(a scalar)}\n",
-    "\\end{array}\n",
+    "\\end{align}\n",
     "$$\n",
     "\n",
     "Note that $A$ and $B$ share one dimension, $k$, but the other dimensions are distinct.\n",
     "We specify that simple arithmetic operations result in a quantity whose dimensions are the union of the dimensions of the operands. In other words:\n",
     "\n",
     "$$\n",
-    "\\begin{array}\n",
-    "CC + A^{i} = X^{i} = \\left[ x_{i} \\right],\n",
+    "\\begin{align}\n",
+    "C + A^{i} = X^{i} = \\left[ x_{i} \\right],\n",
     "  & x_{i} = C + a_{i} \\ \\forall \\ i \\\\\n",
     "A^{jk} \\times B^{kl} = Y^{jkl} = \\left[ y_{j,k,l} \\right],\n",
     "  & y_{j,k,l} = a_{j,k} \\times b_{k,l} \\ \\forall \\ j, k, l \\\\\n",
     "A^{j} - B^{j} = Z^{j} = \\left[ z_{j} \\right],\n",
     "  & z_{j} = a_{j} - b_{j} \\ \\forall \\ j \\\\\n",
-    "\\end{array}\n",
+    "\\end{align}\n",
     "$$\n",
     "\n",
     "As a result of this rule:\n",
@@ -471,7 +472,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Almost 8000 nodes!\n",
+    "Almost 12,700 nodes!\n",
     "\n",
     "Remember: `rep` simply *describes* these operations; none of them is executed until or unless you `get()` them.\n",
     "\n",
@@ -718,7 +719,7 @@
    "source": [
     "Note that nothing was computed. (We're still in step 1 of the reporting workflow!)\n",
     "However, the method did return a new key for the node added to the graph.\n",
-    "This key has the **tag** `':iamc'` added at the end.\n",
+    "This key has the **tag** `'iamc'` added at the end.\n",
     "\n",
     "We describe the added computation, then execute it to get a `pyam.IamDataFrame`:"
    ]


### PR DESCRIPTION
This allows simple, 1-step conversion of `genno.Quantity()` into a pd.DataFrame suitable for `Scenario.add_par()` or `ixmp.reporting.computations.update_scenario`.

Also closes #239 and adds improvements from the June 2022 workshop.

## How to review

- Read the documentation of the new computation; ensure it is clear.
- See e.g. https://github.com/iiasa/message_data/blob/601df5c74a55054782ed4ccf1d6f6d2bddaa92b6/message_data/model/transport/demand.py#L351-L358 for a usage of the new function to convert a genno.Quantity `fv:n-y` to the MESSAGE `demand` parameter, mapping some dimensions and filling others.
- Confirm the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.