### PR TITLE
Enhancing storage equations by considering `mode` and `lvl_temporal`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -19,6 +19,16 @@ All changes
 - Ensure `levelized_cost` are also calculated for technologies with only variable costs (:pull:`653`).
 - Correct calculation of `COST_NODAL_NET` for standalone MESSAGE (:pull:`648`)
 - Account for difference in period-length in equations `NEW_CAPACITY_CONSTRAINT_LO` and `NEW_CAPACITY_CONSTRAINT_UP` (:pull:`654`)
+- Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
+- Extend functionality of storage solutions to include "mode" and temporal level (:pull:`633`).
+
+Migration notes
+---------------
+
+- The index sets in :meth:`.map_tec_storage` will be extended to include "mode" of operation of storage technologies and the temporal level ("lvl_temporal") of a storage container in :mod:`message_ix` 4.0.
+  Therefore, if this set is already populated in a scenario without the indexes of "mode" and "lvl_temporal", the enhanced mathematical equation in GAMS will not work.
+  To resolve this, the user needs to populate :meth:`.map_tec_storage` again, by adding the "mode" of operation for both charger-discharge technologies, and adding "mode" and "lvl_temporal" for the corresponding storage device.
+  Furthermore, parameters "storage_initial" and "storage_self_discharge" should be updated as well by including "mode" for each storage device.
 
 .. _v3.6.0:
 
@@ -41,11 +51,6 @@ Migration notes
 
   This matches fixed behaviour upstream in :mod:`genno` version 1.12 to avoid unintended confusion with keys like ``A:i``: ``i`` (after the first colon) is the name for the sole dimension of a 1-dimensional quantity, whereas ``default`` in ``message::default`` is a tag.
 
-- The index sets in :meth:`.map_tec_storage` are extended to include "mode" of operation and temporal level of a storage container ("lvl_temporal").
-  Therefore, if this set is already populated in a scenario without "mode" and "lvl_temporal", the updated mathematical equation does not work.
-  To resolve this, the user needs to populate this set again, by adding the "mode" of operation for both charger-discharge technologies, and adding "mode" and "lvl_temporal" for the storage device.
-  Furthermore, parameters "storage_initial" and "storage_self_discharge" should be updated as well by including "mode" for each storage device.
-
 All changes
 -----------
 
@@ -53,7 +58,6 @@ All changes
 - New reporting computation :func:`.as_message_df` (:pull:`628`).
 - Extend functionality of :meth:`.vintage_and_active_years`; add aliases :meth:`.yv_ya`, :meth:`.ya`, and :attr:`.y0` (:pull:`572`, :pull:`623`).
 - Add scripts and HOWTO for documentation videos (:pull:`396`).
-- Extend functionality of storage solutions to include "mode" and temporal level (:pull:`633`).
 
 .. _v3.5.0:
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -9,33 +9,34 @@ Migration notes
   In order to use the previous default `lpmethod`, the user-specific default setting can be set through the user's ixmp configuration file.
   Alternatively, the `lpmethod` can be specified directly as an argument when solving a scenario.
   Both of these configuration methods are further explained :meth:`here <message_ix.models.GAMSModel>`.
-The dimensionality of one set and two parameters (``map_tec_storage``, ``storage_initial``, and ``storage_self_discharge``) are extended to allow repesentation of the mode of operation of storage technologies and the temporal level of storage containers.
-If these items are already populated with data in a Scenario, this data will be incompatible with the MESSAGE GAMS implementation in this release; a :class:`UserWarning` will be emitted when the :class:`.Scenario` is instantiated, and :meth:`~.message_ix.Scenario.solve` will raise a :class:`ValueError`.
-(If these items are empty, their dimensions will be updated automatically.
-New Scenarios are unaffected.)
 
-Users must update data for these items, specifically:
+- The dimensionality of one set and two parameters (``map_tec_storage``, ``storage_initial``, and ``storage_self_discharge``) are extended to allow repesentation of the mode of operation of storage technologies and the temporal level of storage containers.
+  If these items are already populated with data in a Scenario, this data will be incompatible with the MESSAGE GAMS implementation in this release; a :class:`UserWarning` will be emitted when the :class:`.Scenario` is instantiated, and :meth:`~.message_ix.Scenario.solve` will raise a :class:`ValueError`.
+  (If these items are empty, their dimensions will be updated automatically.
+  New Scenarios are unaffected.)
 
-==========================  ============================================
-Existing parameter or set   Dimension(s) to add
-==========================  ============================================
-``map_tec_storage``         ``mode``, ``storage_mode``, ``lvl_temporal``
-``storage_initial``         ``mode``
-``storage_self_discharge``  ``mode``
-==========================  ============================================
+  Users must update data for these items, specifically:
 
-For the set ``map_tec_storage``, values for the new dimensions represent, respectively, the ``mode`` of operation for charge/discharge technologies, and the ``storage_mode`` and ``lvl_temporal`` for the corresponding storage device.
-For the two parameters, :func:`.expand_dims` is provided to help:
+  ==========================  ============================================
+  Existing parameter or set   Dimension(s) to add
+  ==========================  ============================================
+  ``map_tec_storage``         ``mode``, ``storage_mode``, ``lvl_temporal``
+  ``storage_initial``         ``mode``
+  ``storage_self_discharge``  ``mode``
+  ==========================  ============================================
 
-.. code-block:: python
+  For the set ``map_tec_storage``, values for the new dimensions represent, respectively, the ``mode`` of operation for charge/discharge technologies, and the ``storage_mode`` and ``lvl_temporal`` for the corresponding storage device.
+  For the two parameters, :func:`.expand_dims` is provided to help:
 
-    from message_ix import Scenario
-    from message_ix.util import expand_dims
+  .. code-block:: python
 
-    scen, platform = Scenario.from_url("…")
+      from message_ix import Scenario
+      from message_ix.util import expand_dims
 
-    # Re-use the existing data in `scen`, adding the `mode` dimension
-    expand_dims(scen, "storage_initial", mode="an existing mode")
+      scen, platform = Scenario.from_url("…")
+
+      # Re-use the existing data in `scen`, adding the `mode` dimension
+      expand_dims(scen, "storage_initial", mode="an existing mode")
 
 
 All changes

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -9,6 +9,34 @@ Migration notes
   In order to use the previous default `lpmethod`, the user-specific default setting can be set through the user's ixmp configuration file.
   Alternatively, the `lpmethod` can be specified directly as an argument when solving a scenario.
   Both of these configuration methods are further explained :meth:`here <message_ix.models.GAMSModel>`.
+The dimensionality of one set and two parameters (``map_tec_storage``, ``storage_initial``, and ``storage_self_discharge``) are extended to allow repesentation of the mode of operation of storage technologies and the temporal level of storage containers.
+If these items are already populated with data in a Scenario, this data will be incompatible with the MESSAGE GAMS implementation in this release; a :class:`UserWarning` will be emitted when the :class:`.Scenario` is instantiated, and :meth:`~.message_ix.Scenario.solve` will raise a :class:`ValueError`.
+(If these items are empty, their dimensions will be updated automatically.
+New Scenarios are unaffected.)
+
+Users must update data for these items, specifically:
+
+==========================  ============================================
+Existing parameter or set   Dimension(s) to add
+==========================  ============================================
+``map_tec_storage``         ``mode``, ``storage_mode``, ``lvl_temporal``
+``storage_initial``         ``mode``
+``storage_self_discharge``  ``mode``
+==========================  ============================================
+
+For the set ``map_tec_storage``, values for the new dimensions represent, respectively, the ``mode`` of operation for charge/discharge technologies, and the ``storage_mode`` and ``lvl_temporal`` for the corresponding storage device.
+For the two parameters, :func:`.expand_dims` is provided to help:
+
+.. code-block:: python
+
+    from message_ix import Scenario
+    from message_ix.util import expand_dims
+
+    scen, platform = Scenario.from_url("…")
+
+    # Re-use the existing data in `scen`, adding the `mode` dimension
+    expand_dims(scen, "storage_initial", mode="an existing mode")
+
 
 All changes
 -----------
@@ -21,14 +49,6 @@ All changes
 - Account for difference in period-length in equations `NEW_CAPACITY_CONSTRAINT_LO` and `NEW_CAPACITY_CONSTRAINT_UP` (:pull:`654`)
 - Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
 - Extend functionality of storage solutions to include "mode" and temporal level (:pull:`633`).
-
-Migration notes
----------------
-
-- The index sets in :meth:`.map_tec_storage` will be extended to include "mode" of operation of storage technologies and the temporal level ("lvl_temporal") of a storage container in :mod:`message_ix` 4.0.
-  Therefore, if this set is already populated in a scenario without the indexes of "mode" and "lvl_temporal", the enhanced mathematical equation in GAMS will not work.
-  To resolve this, the user needs to populate :meth:`.map_tec_storage` again, by adding the "mode" of operation for both charger-discharge technologies, and adding "mode" and "lvl_temporal" for the corresponding storage device.
-  Furthermore, parameters "storage_initial" and "storage_self_discharge" should be updated as well by including "mode" for each storage device.
 
 .. _v3.6.0:
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -41,6 +41,9 @@ Migration notes
 
   This matches fixed behaviour upstream in :mod:`genno` version 1.12 to avoid unintended confusion with keys like ``A:i``: ``i`` (after the first colon) is the name for the sole dimension of a 1-dimensional quantity, whereas ``default`` in ``message::default`` is a tag.
 
+- The index sets in :meth:`.map_tec_storage` are extended to include "mode" of operation and temporal level of a storage container ("lvl_temporal").
+  Therefore, if this set is parameterized in a scenario without "mode" and "lvl_temporal", the mathematical equation does not work.
+  The user needs to add the "mode" of operation for both charger-discharge technologies and the storage device in this mapping set.
 
 All changes
 -----------
@@ -49,6 +52,7 @@ All changes
 - New reporting computation :func:`.as_message_df` (:pull:`628`).
 - Extend functionality of :meth:`.vintage_and_active_years`; add aliases :meth:`.yv_ya`, :meth:`.ya`, and :attr:`.y0` (:pull:`572`, :pull:`623`).
 - Add scripts and HOWTO for documentation videos (:pull:`396`).
+- Extend functionality of storage solutions to include "mode" and "temporal level" (:pull:`396`).
 
 .. _v3.5.0:
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -48,7 +48,6 @@ All changes
 - Ensure `levelized_cost` are also calculated for technologies with only variable costs (:pull:`653`).
 - Correct calculation of `COST_NODAL_NET` for standalone MESSAGE (:pull:`648`)
 - Account for difference in period-length in equations `NEW_CAPACITY_CONSTRAINT_LO` and `NEW_CAPACITY_CONSTRAINT_UP` (:pull:`654`)
-- Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
 - Extend functionality of storage solutions to include "mode" and temporal level (:pull:`633`).
 
 .. _v3.6.0:

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -42,8 +42,9 @@ Migration notes
   This matches fixed behaviour upstream in :mod:`genno` version 1.12 to avoid unintended confusion with keys like ``A:i``: ``i`` (after the first colon) is the name for the sole dimension of a 1-dimensional quantity, whereas ``default`` in ``message::default`` is a tag.
 
 - The index sets in :meth:`.map_tec_storage` are extended to include "mode" of operation and temporal level of a storage container ("lvl_temporal").
-  Therefore, if this set is parameterized in a scenario without "mode" and "lvl_temporal", the mathematical equation does not work.
-  The user needs to add the "mode" of operation for both charger-discharge technologies and the storage device in this mapping set.
+  Therefore, if this set is already populated in a scenario without "mode" and "lvl_temporal", the updated mathematical equation does not work.
+  To resolve this, the user needs to populate this set again, by adding the "mode" of operation for both charger-discharge technologies, and adding "mode" and "lvl_temporal" for the storage device.
+  Furthermore, parameters "storage_initial" and "storage_self_discharge" should be updated as well by including "lvl_temporal" for each storage device.
 
 All changes
 -----------
@@ -52,7 +53,7 @@ All changes
 - New reporting computation :func:`.as_message_df` (:pull:`628`).
 - Extend functionality of :meth:`.vintage_and_active_years`; add aliases :meth:`.yv_ya`, :meth:`.ya`, and :attr:`.y0` (:pull:`572`, :pull:`623`).
 - Add scripts and HOWTO for documentation videos (:pull:`396`).
-- Extend functionality of storage solutions to include "mode" and "temporal level" (:pull:`396`).
+- Extend functionality of storage solutions to include "mode" and temporal level (:pull:`633`).
 
 .. _v3.5.0:
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -44,7 +44,7 @@ Migration notes
 - The index sets in :meth:`.map_tec_storage` are extended to include "mode" of operation and temporal level of a storage container ("lvl_temporal").
   Therefore, if this set is already populated in a scenario without "mode" and "lvl_temporal", the updated mathematical equation does not work.
   To resolve this, the user needs to populate this set again, by adding the "mode" of operation for both charger-discharge technologies, and adding "mode" and "lvl_temporal" for the storage device.
-  Furthermore, parameters "storage_initial" and "storage_self_discharge" should be updated as well by including "lvl_temporal" for each storage device.
+  Furthermore, parameters "storage_initial" and "storage_self_discharge" should be updated as well by including "mode" for each storage device.
 
 All changes
 -----------

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -240,7 +240,7 @@ Utility methods
 ---------------
 
 .. automodule:: message_ix.util
-   :members: make_df
+   :members: expand_dims, make_df
 
 
 Testing utilities

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -168,11 +168,11 @@ emission_scaling(type_emission,emission)$( cat_emission(type_emission,emission)
 map_time_commodity_storage(node,tec,level,commodity,mode,year_all,time)$( storage_tec(tec) AND
     SUM( (node2,year_all2,time_act), input(node2,tec,year_all,year_all2,mode,node,commodity,level,time_act,time) ) ) = yes;
 
-* mapping of sequence of sub-annual timesteps in a period and temporal level
+* mapping of sequence of sub-annual time slices in a period and temporal level
 map_time_period(year_all,lvl_temporal,time,time2)$( time_order(lvl_temporal,time) AND
      time_order(lvl_temporal,time) + 1 = time_order(lvl_temporal,time2) ) = yes;
 
-* mapping of sequence of the last sub-annual timestep to the first to create a close the order of timesteps
+* mapping of sequence of the last sub-annual time slice to the first to create a close the order of time slices
 map_time_period(year_all,lvl_temporal,time,time2)$( time_order(lvl_temporal,time) AND
      time_order(lvl_temporal,time) = SMAX(time3,time_order(lvl_temporal,time3) ) AND time_order(lvl_temporal,time2) = 1 ) = yes;
 *----------------------------------------------------------------------------------------------------------------------*

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -288,7 +288,7 @@ Equations
     RELATION_CONSTRAINT_LO          lower bound of relations (linear constraints)
     STORAGE_CHANGE                  change in the state of charge of storage
     STORAGE_BALANCE                 balance of the state of charge of storage
-    STORAGE_BALANCE_INIT            balance of the state of charge of storage at sub-annual time steps with initial storage content
+    STORAGE_BALANCE_INIT            balance of the state of charge of storage at sub-annual time slices with initial storage content
     STORAGE_INPUT                   connecting an input commodity to maintain the activity of storage container (not stored commodity)
 ;
 *----------------------------------------------------------------------------------------------------------------------*
@@ -2184,7 +2184,7 @@ RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,yea
 * storage level. Where:
 *
 * - :math:`t^{C}` is a charging technology and :math:`t^{D}` is the corresponding discharger.
-* - :math:`h-1` is the time step prior to :math:`h`.
+* - :math:`h-1` is the time slice prior to :math:`h`.
 * - :math: `l^{T}` is `lvl_temporal`, i.e., the temporal level at which storage is operating
 *
 *   .. math::

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -51,8 +51,8 @@
 * :math:`REL_{r,n,y} \in \mathbb{R}`                       Auxiliary variable for left-hand side of relations (linear constraints)
 * :math:`COMMODITY\_USE_{n,c,l,y} \in \mathbb{R}`          Auxiliary variable for amount of commodity used at specific level
 * :math:`COMMODITY\_BALANCE_{n,c,l,y,h} \in \mathbb{R}`    Auxiliary variable for right-hand side of :ref:`commodity_balance`
-* :math:`STORAGE_{n,t,l,c,y,h} \in \mathbb{R}`             State of charge or content of storage at each sub-annual timestep
-* :math:`STORAGE\_CHARGE_{n,t,l,c,y,h} \in \mathbb{R}`     Charging of storage in each sub-annual timestep (negative for discharging)
+* :math:`STORAGE_{n,t,l,c,y,h} \in \mathbb{R}`             State of charge or content of storage at each sub-annual time slice
+* :math:`STORAGE\_CHARGE_{n,t,l,c,y,h} \in \mathbb{R}`     Charging of storage in each sub-annual time slice (negative for discharging)
 * ======================================================== ====================================================================================
 *
 * The index :math:`y^V` is the year of construction (vintage) wherever it is necessary to
@@ -106,7 +106,7 @@ Positive Variables
 * land-use model emulator
     LAND(node,land_scenario,year_all) relative share of land-use scenario
 * content of storage
-    STORAGE(node,tec,mode,level,commodity,year_all,time)       state of charge (SoC) of storage at each sub-annual timestep (positive)
+    STORAGE(node,tec,mode,level,commodity,year_all,time)       state of charge (SoC) of storage at each sub-annual time slice (positive)
 ;
 
 Variables
@@ -123,7 +123,7 @@ Variables
 * auxiliary variable for left-hand side of relations (linear constraints)
     REL(relation,node,year_all)                  auxiliary variable for left-hand side of user-defined relations
 * change in the content of storage device
-    STORAGE_CHARGE(node,tec,mode,level,commodity,year_all,time)    charging of storage in each timestep (negative for discharge)
+    STORAGE_CHARGE(node,tec,mode,level,commodity,year_all,time)    charging of storage in each time slice (negative for discharge)
 ;
 
 ***
@@ -1591,12 +1591,12 @@ NEW_CAPACITY_CONSTRAINT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 *   .. math::
 *      CAP\_NEW\_UP_{n,t,y} \leq \sum_{y-1} CAP\_NEW_{n^L,t,y-1} & \text{if } y \neq 'first\_period' \\
 *                                + \sum_{y-1} historical\_new\_capacity_{n^L,t,y-1} & \text{if } y = 'first\_period' \\
-*                           \quad \forall \ t \ \in \ T^{INV}   
+*                           \quad \forall \ t \ \in \ T^{INV}
 *
 ***
 NEW_CAPACITY_SOFT_CONSTRAINT_UP(node,inv_tec,year)$( soft_new_capacity_up(node,inv_tec,year) )..
     CAP_NEW_UP(node,inv_tec,year) =L=
-        SUM(year2$( seq_period(year2,year) ), 
+        SUM(year2$( seq_period(year2,year) ),
             CAP_NEW(node,inv_tec,year2)) $ (NOT first_period(year))
       + SUM(year_all2$( seq_period(year_all2,year) ),
             historical_new_capacity(node,inv_tec,year_all2)) $ first_period(year)
@@ -1665,14 +1665,14 @@ NEW_CAPACITY_CONSTRAINT_LO(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 *   .. math::
 *      CAP\_NEW\_LO_{n,t,y} \leq \sum_{y-1} CAP\_NEW_{n^L,t,y-1} & \text{if } y \neq 'first\_period' \\
 *                                + \sum_{y-1} historical\_new\_capacity_{n^L,t,y-1} & \text{if } y = 'first\_period' \\
-*                           \quad \forall \ t \ \in \ T^{INV}  
+*                           \quad \forall \ t \ \in \ T^{INV}
 *
 ***
 NEW_CAPACITY_SOFT_CONSTRAINT_LO(node,inv_tec,year)$( soft_new_capacity_lo(node,inv_tec,year) )..
     CAP_NEW_LO(node,inv_tec,year) =L=
         SUM(year2$( seq_period(year2,year) ),
             CAP_NEW(node,inv_tec,year2) ) $ (NOT first_period(year))
-      + SUM(year_all2$( seq_period(year_all2,year) ), 
+      + SUM(year_all2$( seq_period(year_all2,year) ),
             historical_new_capacity(node,inv_tec,year_all2) ) $ first_period(year)
 ;
 
@@ -1733,7 +1733,7 @@ ACTIVITY_CONSTRAINT_UP(node,tec,year,time)$( map_tec_time(node,tec,year,time)
 *   .. math::
 *      ACT\_UP_{n,t,y,h} \leq \sum_{y^V \leq y,m,y-1} ACT_{n^L,t,y^V,y-1,m,h} & \text{if } y \neq 'first\_period' \\
 *                             + \sum_{m,y-1} historical\_activity_{n^L,t,y-1,m,h} & \text{if } y = 'first\_period'
-*      
+*
 *
 ***
 ACTIVITY_SOFT_CONSTRAINT_UP(node,tec,year,time)$( soft_activity_up(node,tec,year,time) )..
@@ -2151,27 +2151,33 @@ RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,yea
 * Storage section
 * ---------------
 *
-* Storage technologies can be used to store a commodity (e.g., water, heat, electricity, etc.)
-* and shift it over sub-annual time slices. The storage solution presented here has three
-* distinctive parts: (i) Charger: a technology for charging a commodity to the storage container,
+* MESSAGEix offers a set of equations to represent a wide range of storage solutions flexibly.
+* Storage solutions are modeled as "technologies" that can be used to store a "commodity" (e.g., water, heat, electricity, etc.)
+* and shift it over sub-annual time slices within one model period. The storage solution presented here has three
+* distinct parts: (i) Charger: a technology for charging a commodity to the storage container,
 * for example, a pump in a pumped hydropower storage (PHS) plant. (ii) Discharger: a technology
 * to convert the stored commodity to the output commodity, e.g., a turbine in PHS.
 * (iii) Storage container: a device for storing a commodity over time, such as a water reservoir in PHS.
+* If desired, the user can combine charger and discharger parts into one technology, using two different "modes" of operation
+* for that technology like turbo-machinery in PHS. This way the capacity related information, like investment cost, lifetime, capacity factor, etc.,
+* will be defined only for one technology (i.e., charger-discharger), as opposed to modeling these two parts separately.
 *
 * .. figure:: ../../_static/storage.png
 *
 * Storage equations
 * ^^^^^^^^^^^^^^^^^
 * The content of storage device depends on three factors: charge or discharge in
-* one time step (represented by `Equation STORAGE_CHANGE`_), the state of charge in the previous
-* time step, and storage losses between two consecutive time steps.
+* one time slice (represented by `Equation STORAGE_CHANGE`_), linked to the state of charge in the previous
+* time slice and storage losses between these two consecutive time slices (represented by `Equation STORAGE_BALANCE`_).
+* Moreover, the storage device can be optionally filled with an initial value as percentage of its capacity (see more details under `Equation STORAGE_BALANCE_INIT`_).
+* Another option is to link a commodity for maintaining the operation of storage device over time (see `Equation STORAGE_INPUT`_).
 *
 * .. _equation_storage_change:
 *
 * Equation STORAGE_CHANGE
 * """""""""""""""""""""""
 * This equation shows the change in the content of the storage container in each
-* sub-annual timeslice. This change is based on the activity of charger and discharger
+* sub-annual time slice. This change is based on the activity of charger and discharger
 * technologies connected to that storage container. The notation :math:`S^{storage}`
 * represents the mapping set `map_tec_storage` denoting charger-discharger
 * technologies connected to a specific storage container in a specific node and
@@ -2190,7 +2196,7 @@ RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,yea
 ***
 STORAGE_CHANGE(node,storage_tec,mode,level_storage,commodity,year,time)$sum(
                (tec,mode2,lvl_temporal), map_tec_storage(node,tec,mode2,storage_tec,mode,level_storage,commodity,lvl_temporal) ) ..
-* change in the content of storage in the examined timeslice
+* change in the content of storage in the examined time slice
     STORAGE_CHARGE(node,storage_tec,mode,level_storage,commodity,year,time) =E=
 * increase in the content of storage due to the activity of charging technologies
         SUM( (location,vintage,tec,mode2,time2,time3,lvl_temporal)$(
@@ -2212,26 +2218,26 @@ STORAGE_CHANGE(node,storage_tec,mode,level_storage,commodity,year,time)$sum(
 * """"""""""""""""""""""""
 *
 * This equation ensures the commodity balance of storage technologies, where the commodity is shifted between sub-annual
-* timeslices within a model period. If the state of charge of storage is set exogenously in one timeslice through
-* :math:`\storageinitial_{ntlcyh}`, the content from the previous timeslice is not carried over to this timeslice.
+* time slices within a model period. If the state of charge of storage is set exogenously in one time slice through
+* :math:`\storageinitial_{ntlcyh}`, the content from the previous time slice is not carried over to this time slice.
 *
 * .. math::
-*    \STORAGE_{ntlcyh} =\ & \STORAGECHARGE_{ntlcyh} + \\
-*    & \STORAGE_{ntlcy(h-1)} \cdot (1 - \storageselfdischarge_{ntly(h-1)}) \\
+*    \STORAGE_{ntlcyh} =\ & \STORAGECHARGE_{ntlcyh} \\
+*    & + \STORAGE_{ntlcy(h-1)} \cdot (1 - \storageselfdischarge_{ntly(h-1)}) \\
 *    \forall\ & t \in T^{STOR}, l \in L^{STOR}, \storageinitial_{ntlcyh} = 0
 ***
 STORAGE_BALANCE(node,storage_tec,mode,level,commodity,year,time2,lvl_temporal)$ (
     SUM((tec,mode2), map_tec_storage(node,tec,mode2,storage_tec,mode,level,commodity,lvl_temporal) )
 *    AND NOT storage_initial(node,storage_tec,mode,level,commodity,year,time2)
 )..
-* Showing the the state of charge of storage at each timeslice
+* Showing the the state of charge of storage at each time slice
     STORAGE(node,storage_tec,mode,level,commodity,year,time2) =E=
-* change in the content of storage in the examined timeslice
+* change in the content of storage in the examined time slice
     + STORAGE_CHARGE(node,storage_tec,mode,level,commodity,year,time2)
-* storage content in the previous subannual timeslice
+* storage content in the previous subannual time slice
     + SUM(time$map_time_period(year,lvl_temporal,time,time2),
         STORAGE(node,storage_tec,mode,level,commodity,year,time)
-* considering storage self-discharge losses due to keeping the storage media between two subannual timeslices
+* considering storage self-discharge losses due to keeping the storage media between two subannual time slices
         * (1 - storage_self_discharge(node,storage_tec,mode,level,commodity,year,time) ) ) ;
 
 ***
@@ -2241,20 +2247,22 @@ STORAGE_BALANCE(node,storage_tec,mode,level,commodity,year,time2,lvl_temporal)$ 
 * """""""""""""""""""""""""""""
 *
 * Where :math:`\storageinitial_{ntlyh}` has a non-zero value, this equation ensures that the amount of commodity stored
-* at the end of the period is equal to the initial content of storage.
+* at the end of a sub-annual time slice is equal or greater than the initialized content of storage in the following time slice.
+* The values in parameter :math:`\storageinitial_{ntlyh}` are percentages showing
+* a fraction of installed capacity of storage device (container) that can be filled initially.
 *
 * .. math::
-*    \STORAGE_{ntlcyh} =\ & \storageinitial_{ntlcyh} + \STORAGECHARGE_{ntlcyh} \\
-*    \forall\ & \storageinitial_{ntlcyh} \neq 0
+*    \STORAGE_{ntlcy(h-1)} \geq &  \storageinitial_{ntlcyh} \cdot duration\_time_{h} \cdot capacity\_factor_{n,t,y^V,y,h} \cdot CAP_{n,t,y^V,y}  \\
+*    \quad \forall \ t \ \in \ T^{INV}, \forall\ & \storageinitial_{ntlcyh} \neq 0
 ***
 
 STORAGE_BALANCE_INIT(node,storage_tec,mode,level,commodity,year,time,time2)$ (
     SUM((tec,mode2,lvl_temporal), map_tec_storage(node,tec,mode2,storage_tec,mode,level,commodity,lvl_temporal)
         AND map_time_period(year,lvl_temporal,time,time2) )
     AND storage_initial(node,storage_tec,mode,level,commodity,year,time2) )..
-* Showing the state of charge of storage at a timeslice with an initial storage content
-    STORAGE(node,storage_tec,mode,level,commodity,year,time) =L=
-* initial content of storage in the examined timeslice as a multiplier in available capacity of storage
+* Showing the state of charge of storage at a time slice prior to a time slice that has initial storage content
+    STORAGE(node,storage_tec,mode,level,commodity,year,time) =G=
+* Initial content of storage in the examined time slice as a percentage multiplier in available capacity of storage
         storage_initial(node,storage_tec,mode,level,commodity,year,time2)
         * SUM(vintage$( map_tec_lifetime(node,storage_tec,vintage,year) ), capacity_factor(node,storage_tec,vintage,year,time2)
              * CAP(node,storage_tec,vintage,year) / duration_time(time2)  )
@@ -2265,8 +2273,10 @@ STORAGE_BALANCE_INIT(node,storage_tec,mode,level,commodity,year,time,time2)$ (
 * Equation STORAGE_INPUT
 * """"""""""""""""""""""""""""
 *
-* This equation links :math:`\STORAGE` to an input commodity to maintain the activity (:math:`\ACT`) for each active storage *container* technology
-* :math:`t`; this is distinct from the *(dis)charge* technologies :math:`t^C,t^D` appearing in
+* This equation links :math:`\STORAGE` to an input commodity to maintain the activity (:math:`\ACT`) of each active storage *container* technology
+* :math:`t`. This input commodity is distinct from the stored commodity. For example, in a pumped hydro storage solution, a user can link heating
+* for keeping the stored water warm. In this case, the input commodity is not a function of charge or discharge, but the amount of stored media in the container over time.
+* Therefore, the input commodity specified here is distinct from the one stored and discharged by *(dis)charge* technologies :math:`t^C,t^D` appearing in
 * :ref:`equation_storage_change`.
 *
 * .. math::

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -51,8 +51,8 @@
 * :math:`REL_{r,n,y} \in \mathbb{R}`                       Auxiliary variable for left-hand side of relations (linear constraints)
 * :math:`COMMODITY\_USE_{n,c,l,y} \in \mathbb{R}`          Auxiliary variable for amount of commodity used at specific level
 * :math:`COMMODITY\_BALANCE_{n,c,l,y,h} \in \mathbb{R}`    Auxiliary variable for right-hand side of :ref:`commodity_balance`
-* :math:`STORAGE_{n,t,l,c,y,h} \in \mathbb{R}`             State of charge or content of storage at each sub-annual time slice
-* :math:`STORAGE\_CHARGE_{n,t,l,c,y,h} \in \mathbb{R}`     Charging of storage in each sub-annual time slice (negative for discharging)
+* :math:`STORAGE_{n,t,m,l,c,y,h} \in \mathbb{R}`             State of charge or content of storage at each sub-annual time slice
+* :math:`STORAGE\_CHARGE_{n,t,m,l,c,y,h} \in \mathbb{R}`     Charging of storage in each sub-annual time slice (negative for discharging)
 * ======================================================== ====================================================================================
 *
 * The index :math:`y^V` is the year of construction (vintage) wherever it is necessary to
@@ -2186,9 +2186,10 @@ RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,yea
 * - :math:`t^{C}` is a charging technology and :math:`t^{D}` is the corresponding discharger.
 * - :math:`h-1` is the time slice prior to :math:`h`.
 * - :math: `l^{T}` is `lvl_temporal`, i.e., the temporal level at which storage is operating
-*
+* - :math: `m^{S}` is `mode` of operation for storage container technology
+
 *   .. math::
-*      STORAGE\_CHARGE_{n,t,l,c,y,h} =
+*      STORAGE\_CHARGE_{n,t,m^s,l,c,y,h} =
 *          \sum_{\substack{n^L,m,h-1 \\ y^V \leq y, (n,t^C,t,l,y) \sim S^{storage}}} output_{n^L,t^C,y^V,y,m,n,c,l,h-1,h}
 *             \cdot & ACT_{n^L,t^C,y^V,y,m,h-1} \\
 *          - \sum_{\substack{n^L,m,c,h-1 \\ y^V \leq y, (n,t^D,t,l,y) \sim S^{storage}}} input_{n^L,t^D,y^V,y,m,n,c,l,h-1,h}
@@ -2222,9 +2223,9 @@ STORAGE_CHANGE(node,storage_tec,mode,level_storage,commodity,year,time)$sum(
 * :math:`\storageinitial_{ntlcyh}`, the content from the previous time slice is not carried over to this time slice.
 *
 * .. math::
-*    \STORAGE_{ntlcyh} =\ & \STORAGECHARGE_{ntlcyh} \\
-*    & + \STORAGE_{ntlcy(h-1)} \cdot (1 - \storageselfdischarge_{ntly(h-1)}) \\
-*    \forall\ & t \in T^{STOR}, l \in L^{STOR}, \storageinitial_{ntlcyh} = 0
+*    \STORAGE_{ntmlcyh} =\ & \STORAGECHARGE_{ntmlcyh} \\
+*    & + \STORAGE_{ntmlcy(h-1)} \cdot (1 - \storageselfdischarge_{ntmly(h-1)}) \\
+*    \forall\ & t \in T^{STOR}, l \in L^{STOR}, \storageinitial_{ntmlcyh} = 0
 ***
 STORAGE_BALANCE(node,storage_tec,mode,level,commodity,year,time2,lvl_temporal)$ (
     SUM((tec,mode2), map_tec_storage(node,tec,mode2,storage_tec,mode,level,commodity,lvl_temporal) )
@@ -2252,8 +2253,8 @@ STORAGE_BALANCE(node,storage_tec,mode,level,commodity,year,time2,lvl_temporal)$ 
 * a fraction of installed capacity of storage device (container) that can be filled initially.
 *
 * .. math::
-*    \STORAGE_{ntlcy(h-1)} \geq &  \storageinitial_{ntlcyh} \cdot duration\_time_{h} \cdot capacity\_factor_{n,t,y^V,y,h} \cdot CAP_{n,t,y^V,y}  \\
-*    \quad \forall \ t \ \in \ T^{INV}, \forall\ & \storageinitial_{ntlcyh} \neq 0
+*    \STORAGE_{ntmlcy(h-1)} \geq &  \storageinitial_{ntmlcyh} \cdot duration\_time_{h} \cdot capacity\_factor_{n,t,y^V,y,h} \cdot CAP_{n,t,y^V,y}  \\
+*    \quad \forall \ t \ \in \ T^{INV}, \forall\ & \storageinitial_{ntmlcyh} \neq 0
 ***
 
 STORAGE_BALANCE_INIT(node,storage_tec,mode,level,commodity,year,time,time2)$ (
@@ -2280,7 +2281,7 @@ STORAGE_BALANCE_INIT(node,storage_tec,mode,level,commodity,year,time,time2)$ (
 * :ref:`equation_storage_change`.
 *
 * .. math::
-*    \STORAGE_{ntlcy^Ah} =\ & \sum_{\{n^Ly^Vh^O \vert K\}} \durationtimerel_{hh^O} \times \ACT_{n^Lty^Vy^Amh^O} \\
+*    \STORAGE_{ntmlcy^Ah} =\ & \sum_{\{n^Ly^Vh^O \vert K\}} \durationtimerel_{hh^O} \times \ACT_{n^Lty^Vy^Amh^O} \\
 *    \forall\ & n,t,l,c,m,y^A,h \vert t \in T^{STOR} \\
 *    K:\ & \input_{n^Lty^Vy^Amn^Oclhh^O} \neq 0
 *

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -416,12 +416,12 @@ Parameters
 * The |MESSAGEix| formulation includes "storage" solutions to model sub-annual, inter-temporal storage of commodities in each period.
 * This feature can be used to model electricity storage (pumped hydro, batteries, compressed air energy storage, etc.), thermal energy storage,
 * demand side management, and in general any technology for storing commodities (gas, hydrogen, water, etc.) over sub-annual timesteps.
-* The user defines the chronological order of sub-annual time steps by assigning a number to them in parameter ``time_order``.
+* The user defines the chronological order of sub-annual time slices by assigning a number to them in parameter ``time_order``.
 * This order is used by storage equations to shift the stored commodity in a correct timeline, e.g., from Jan through to Dec, and not vice versa.
-* The last sub-annual timestep is linked to the first one to close the loop of the year. Parameter ``storage_initial`` is to set an initial amount
-* for the content of storage in any desirable timestep (optionally). This initial value is a cost-free stored media that storage can discharge
-* in the same or following timesteps. ``storage_self_discharge`` represents the self-discharge (loss) of storage as % of the level of stored media
-* in each timestep. This allows to model time-related losses in storage separately, in addition to charging and discharging losses.
+* The last sub-annual time slice is linked to the first one to close the loop of the year. Parameter ``storage_initial`` is to set an initial amount
+* for the content of storage in any desirable time slice (optionally). This initial value is a cost-free stored media that storage can discharge
+* in the same or following time slices. ``storage_self_discharge`` represents the self-discharge (loss) of storage as % of the level of stored media
+* in each time slice. This allows to model time-related losses in storage separately, in addition to charging and discharging losses.
 *
 * .. list-table::
 *    :widths: 20 80
@@ -440,8 +440,8 @@ Parameters
 
 Parameters
     storage_initial(node,tec,mode,level,commodity,year_all,time)                       initial content of storage
-    storage_self_discharge(node,tec,mode,level,commodity,year_all,time)                self-discharge (loss) of storage as % of storage level in each timestep
-    time_order(lvl_temporal,time)                                                 sequence of subannual timesteps
+    storage_self_discharge(node,tec,mode,level,commodity,year_all,time)                self-discharge (loss) of storage as % of storage level in each time slice
+    time_order(lvl_temporal,time)                                                 sequence of subannual time slices
 ;
 
 *----------------------------------------------------------------------------------------------------------------------*

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -439,8 +439,8 @@ Parameters
 ***
 
 Parameters
-    storage_initial(node,tec,level,commodity,year_all,time)                       initial content of storage
-    storage_self_discharge(node,tec,level,commodity,year_all,time)                self-discharge (loss) of storage as % of storage level in each timestep
+    storage_initial(node,tec,mode,level,commodity,year_all,time)                       initial content of storage
+    storage_self_discharge(node,tec,mode,level,commodity,year_all,time)                self-discharge (loss) of storage as % of storage level in each timestep
     time_order(lvl_temporal,time)                                                 sequence of subannual timesteps
 ;
 

--- a/message_ix/model/MESSAGE/sets_maps_def.gms
+++ b/message_ix/model/MESSAGE/sets_maps_def.gms
@@ -342,7 +342,7 @@ Alias(type_tec,type_tec_total);
 *    * - map_time(time,time2)
 *      - Mapping of time periods across hierarchy levels (time2 is in time)
 *    * - map_time_period(year_all,lvl_temporal,time,time2)
-*      - Mapping of the sequence of sub-annual timesteps (used in :ref:`storage <gams-storage>`)
+*      - Mapping of the sequence of sub-annual timeslices (used in :ref:`storage <gams-storage>`)
 *    * - map_resource(node,commodity,grade,year_all)
 *      - Mapping of resources and grades to node over time
 *    * - map_ren_grade(node,commodity,grade,year_all)
@@ -361,7 +361,7 @@ Alias(type_tec,type_tec_total);
 *      - Mapping of technology to temporal dissagregation (time)
 *    * - map_tec_mode(node,tec,year_all,mode)
 *      - Mapping of technology to modes
-*    * - map_tec_storage(node,tec,tec2,level,commodity)
+*    * - map_tec_storage(node,tec,mode,tec2,mode2,level,commodity,lvl_temporal)
 *      - Mapping of charge-discharge technologies ``tec`` to their storage container ``tec2``, stored ``commodity`` and ``level``.
 *    * - map_time_commodity_storage(node,tec,level,commodity,mode,year_all,time)
 *      - Mapping of storage containers to their input commodity-level (not commodity-level of stored media)
@@ -385,7 +385,7 @@ Sets
     map_tec_mode(node,tec,year_all,mode)            mapping of technology to modes
     map_tec_act(node,tec,year_all,mode,time)        mapping of technology to modes AND temporal dissagregation
     map_tec_addon(tec,type_addon)                   mapping of types of add-on technologies to the underlying parent technology
-    map_tec_storage(node,tec,tec2,level,commodity)  mapping of charge-discharging technologies to their respective storage container tec and level-commodity
+    map_tec_storage(node,tec,mode,tec2,mode2,level,commodity,lvl_temporal)  mapping of charge-discharging technologies to their respective storage container tec and level-commodity
 
     map_spatial_hierarchy(lvl_spatial,node,node)    mapping of spatial resolution to nodes (last index is 'parent')
     map_temporal_hierarchy(lvl_temporal,time,time)  mapping of temporal resolution to time (last index is 'parent')

--- a/message_ix/model/MESSAGE/sets_maps_def.gms
+++ b/message_ix/model/MESSAGE/sets_maps_def.gms
@@ -370,7 +370,7 @@ Alias(type_tec,type_tec_total);
 Sets
     map_node(node,location)                            mapping of nodes across hierarchy levels (location is in node)
     map_time(time,time2)                               mapping of time periods across hierarchy levels (time2 is in time)
-    map_time_period(year_all,lvl_temporal,time,time2)  mapping of the sequence of sub-annual timesteps
+    map_time_period(year_all,lvl_temporal,time,time2)  mapping of the sequence of sub-annual time slices
 
     map_resource(node,commodity,grade,year_all)  mapping of resources and grades to node over time
     map_ren_grade(node,commodity,grade,year_all) mapping of renewables and grades to node over time

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -421,7 +421,7 @@ class MESSAGE(GAMSModel):
                 scenario.add_set(set_name, expected)
 
         # Enforcing new indexes for existing set and parameters
-        # TODO: this should ideally done by introducing a new method called
+        # TODO: this should be ideally done by introducing a new method called
         # `reinitiate_items()` that would reinitialize some items with new index sets
         sets = ["map_tec_storage"]
         pars = ["storage_self_discharge", "storage_initial"]
@@ -442,7 +442,6 @@ class MESSAGE(GAMSModel):
                         idx_names=MESSAGE_ITEMS[set_name]["idx_names"],
                     )
                 else:
-                    print(set(df.columns))
                     if tuple(df.columns) == MESSAGE_ITEMS[set_name]["idx_names"]:
                         continue
                     else:
@@ -450,6 +449,7 @@ class MESSAGE(GAMSModel):
                             f"{set_name} requires an updated index sets:",
                             f" {MESSAGE_ITEMS[set_name]['idx_sets']}",
                         )
+
         for par_name in pars:
             try:
                 scenario.init_par(

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -258,7 +258,7 @@ MESSAGE_ITEMS = {
     ),
     "tax": item("par", "nl type_tec ya"),
     "technical_lifetime": item("par", "nl t yv"),
-    # Order of sub-annual time steps
+    # Order of sub-annual time slices
     "time_order": dict(ix_type="par", idx_sets=["lvl_temporal", "time"]),
     "var_cost": item("par", "nl t yv ya m h"),
     #

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -134,7 +134,13 @@ MESSAGE_ITEMS = {
     ),
     "map_tec_addon": dict(ix_type="set", idx_sets=["technology", "type_addon"]),
     # Mapping of storage reservoir to charger/discharger
-    "map_tec_storage": item("set", "n t storage_tec l c"),
+    "map_tec_storage": dict(
+        ix_type="set",
+        idx_sets=["node", "technology", "mode", "technology",
+                  "mode", "level", "commodity", "lvl_temporal"],
+        idx_names=["node", "technology", "mode", "storage_tec",
+                   "storage_mode", "level", "commodity", "lvl_temporal"]
+        ),
     "map_temporal_hierarchy": dict(
         ix_type="set",
         idx_sets=["lvl_temporal", "time", "time"],
@@ -245,9 +251,12 @@ MESSAGE_ITEMS = {
     "soft_new_capacity_lo": item("par", "nl t yv"),
     "soft_new_capacity_up": item("par", "nl t yv"),
     # Initial amount of storage
-    "storage_initial": item("par", "n t l c y h"),
+    "storage_initial": item("par", "n t m l c y h"),
     # Storage losses as a percentage of installed capacity
-    "storage_self_discharge": item("par", "n t l c y h"),
+    "storage_self_discharge": item("par", "n t m l c y h"),
+	'STORAGE': item("var", "n t m l c y h"),
+	'STORAGE_CHARGE': item("var", "n t m l c y h"),
+    
     "subsidy": item("par", "nl type_tec ya"),
     "tax_emission": dict(
         ix_type="par", idx_sets=["node", "type_emission", "type_tec", "type_year"]

--- a/message_ix/tests/test_feature_storage.py
+++ b/message_ix/tests/test_feature_storage.py
@@ -18,6 +18,7 @@ from ixmp.testing import assert_logs
 from message_ix import Scenario
 from message_ix.models import MESSAGE
 from message_ix.testing import make_dantzig
+from message_ix.util import expand_dims
 
 
 # A function for generating a simple MESSAGEix model with two technologies
@@ -283,6 +284,8 @@ def test_structure(caplog, test_mp):
         MESSAGE.initialize(scen)
 
     assert "mode" in scen.idx_sets(name)
+    # …and enforce() completes without raising an exception
+    MESSAGE.enforce(scen)
 
     # Now with data in storage_initial, a warning is raised
     prepare(scen, with_data=True)
@@ -300,3 +303,10 @@ def test_structure(caplog, test_mp):
     # …and the scenario would not solve
     with pytest.raises(ValueError, match="'storage_initial' has data with dimensions"):
         MESSAGE.enforce(scen)
+
+    # expand_dims() results in the correct dimensionality and complete data
+    expand_dims(scen, name, mode="production")
+    assert "mode" in scen.idx_sets(name)
+
+    # …and enforce() completes without raising an exception
+    MESSAGE.enforce(scen)

--- a/message_ix/tests/test_feature_storage.py
+++ b/message_ix/tests/test_feature_storage.py
@@ -75,7 +75,10 @@ def add_storage_data(scen, time_order):
 
     # Adding mapping for storage and charger/discharger technologies
     for tec in ["pump", "turbine"]:
-        scen.add_set("map_tec_storage", ["node", tec, "M1", "dam", "M1", "storage", "water", "season"])
+        scen.add_set(
+            "map_tec_storage",
+            ["node", tec, "M1", "dam", "M1", "storage", "water", "season"],
+        )
 
     # Adding time sequence
     for h in time_order.keys():
@@ -166,8 +169,11 @@ def storage_setup(test_mp, time_duration, comment):
     df["value"] = 1.2
     scen.add_par("input", df)
     scen.commit("storage needs no separate input")
-    scen.solve(case="with_storage_and_input" + comment, quiet=True,
-               var_list=["STORAGE", "STORAGE_CHARGE"])
+    scen.solve(
+        case="with_storage_and_input" + comment,
+        quiet=True,
+        var_list=["STORAGE", "STORAGE_CHARGE"],
+    )
     cost_with_stor = scen.var("OBJ")["lvl"]
     act_with_stor = scen.var("ACT", {"technology": "gas_ppl"})["lvl"].sum()
 

--- a/message_ix/tests/test_feature_storage.py
+++ b/message_ix/tests/test_feature_storage.py
@@ -23,13 +23,13 @@ def model_setup(scen, years):
     scen.add_set("year", years)
     scen.add_set("type_year", years)
     scen.add_set("technology", ["wind_ppl", "gas_ppl"])
-    scen.add_set("mode", "mode")
+    scen.add_set("mode", "M1")
     output_specs = ["node", "electr", "level", "year", "year"]
     # Two technologies, one cheaper than the other
     var_cost = {"wind_ppl": 0, "gas_ppl": 2}
     for year, (tec, cost) in product(years, var_cost.items()):
         scen.add_par("demand", ["node", "electr", "level", year, "year"], 1, "GWa")
-        tec_specs = ["node", tec, year, year, "mode"]
+        tec_specs = ["node", tec, year, year, "M1"]
         scen.add_par("output", tec_specs + output_specs, 1, "GWa")
         scen.add_par("var_cost", tec_specs + ["year"], cost, "USD/GWa")
 
@@ -75,7 +75,7 @@ def add_storage_data(scen, time_order):
 
     # Adding mapping for storage and charger/discharger technologies
     for tec in ["pump", "turbine"]:
-        scen.add_set("map_tec_storage", ["node", tec, "dam", "storage", "water"])
+        scen.add_set("map_tec_storage", ["node", tec, "M1", "dam", "M1", "storage", "water", "season"])
 
     # Adding time sequence
     for h in time_order.keys():
@@ -97,19 +97,19 @@ def add_storage_data(scen, time_order):
     var_cost = {"dam": 0, "pump": 0.2, "turbine": 0.3}
     stor_tecs = ["dam", "pump", "turbine"]
     for year, h, tec in product(set(scen.set("year")), time_order.keys(), stor_tecs):
-        tec_sp = ["node", tec, year, year, "mode"]
+        tec_sp = ["node", tec, year, year, "M1"]
         scen.add_par("output", tec_sp + output_spec[tec] + [h, h], 1, "GWa")
         scen.add_par("input", tec_sp + input_spec[tec] + [h, h], 1, "GWa")
         scen.add_par("var_cost", tec_sp + [h], var_cost[tec], "USD/GWa")
 
     # Adding storage self-discharge (as %) and initial content
     for year, h in product(set(scen.set("year")), time_order.keys()):
-        storage_spec = ["node", "dam", "storage", "water", year, h]
+        storage_spec = ["node", "dam", "M1", "storage", "water", year, h]
         scen.add_par("storage_self_discharge", storage_spec, 0.05, "%")
 
         # Adding initial content of storage (optional)
-        storage_spec = ["node", "dam", "storage", "water", year, "a"]
-        scen.add_par("storage_initial", storage_spec, 0.08, "GWa")
+        storage_spec = ["node", "dam", "M1", "storage", "water", year, "a"]
+        scen.add_par("storage_initial", storage_spec, 0.5, "%")
 
 
 # Main function for building a model with storage and testing the functionality
@@ -135,7 +135,7 @@ def storage_setup(test_mp, time_duration, comment):
     scen.check_out()
     for h in time_duration.keys():
         scen.add_par(
-            "bound_activity_up", ["node", "wind_ppl", 2020, "mode", h], 0.25, "GWa"
+            "bound_activity_up", ["node", "wind_ppl", 2020, "M1", h], 0.25, "GWa"
         )
     scen.commit("activity bounded")
     scen.solve(case="no_storage_bounded" + comment, quiet=True)
@@ -166,7 +166,8 @@ def storage_setup(test_mp, time_duration, comment):
     df["value"] = 1.2
     scen.add_par("input", df)
     scen.commit("storage needs no separate input")
-    scen.solve(case="with_storage_and_input" + comment, quiet=True)
+    scen.solve(case="with_storage_and_input" + comment, quiet=True,
+               var_list=["STORAGE", "STORAGE_CHARGE"])
     cost_with_stor = scen.var("OBJ")["lvl"]
     act_with_stor = scen.var("ACT", {"technology": "gas_ppl"})["lvl"].sum()
 
@@ -180,11 +181,10 @@ def storage_setup(test_mp, time_duration, comment):
     # Activity of expensive technology should be lower with storage
     assert act_with_stor < act_no_stor
 
-    # 3. Activity of discharger <= activity of charger + initial content
+    # 3. Activity of discharger <= activity of charger
     act_pump = scen.var("ACT", {"technology": "pump"})["lvl"]
     act_turb = scen.var("ACT", {"technology": "turbine"})["lvl"]
-    initial_content = float(scen.par("storage_initial")["value"])
-    assert act_turb.sum() <= act_pump.sum() + initial_content
+    assert act_turb.sum() <= act_pump.sum()
 
     # 4. Activity of input provider to storage = act of storage * storage input
     for ts in time_duration.keys():
@@ -205,22 +205,21 @@ def storage_setup(test_mp, time_duration, comment):
     assert max_turb <= max_stor * (1 - loss)
 
     # Sixth, testing equations of storage (when added to ixmp variables)
-    if scen.has_var("STORAGE"):
-        # 1. Equality: storage content in the beginning and end is related
-        storage_first = scen.var("STORAGE", {"time": "a"})["lvl"]
-        storage_last = scen.var("STORAGE", {"time": "d"})["lvl"]
-        relation = scen.par("relation_storage", {"time_first": "d", "time_last": "a"})[
-            "value"
-        ][0]
-        assert storage_last >= storage_first * relation
+    if scen.has_var("STORAGE") and not scen.var("STORAGE").empty:
+        # 1. Equality: storage content at the end is equal to the beginning
+        # (i.e., the difference is what is pumped in the first time slice)
+        storage_first = float(scen.var("STORAGE", {"time": "a"})["lvl"])
+        storage_last = float(scen.var("STORAGE", {"time": "d"})["lvl"])
+        pump_first = float(scen.var("ACT", {"technology": "pump", "time": "a"})["lvl"])
+        assert storage_last == storage_first - pump_first
 
         # 2. Storage content should never exceed storage activity
         assert max(scen.var("STORAGE")["lvl"]) <= max_stor
 
         # 3. Commodity balance: charge - discharge - losses = 0
-        change = scen.var("STORAGE_CHARGE").set_index(["year_act", "time"])["lvl"]
+        change = scen.var("STORAGE_CHARGE").set_index(["year", "time"])["lvl"]
         loss = scen.par("storage_self_discharge").set_index(["year", "time"])["value"]
-        assert sum(change[change > 0] * (1 - loss)) == -sum(change[change < 0])
+        assert (change[change > 0] * (1 - loss)).sum() >= -(change[change < 0]).sum()
 
         # 4. Energy balance: storage change + losses = storage content
         storage = scen.var("STORAGE").set_index(["year", "time"])["lvl"]

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -51,7 +51,7 @@ def test_reporter_from_scenario(message_test_mp):
     rep = Reporter.from_scenario(scen)
 
     # Number of quantities available in a rudimentary MESSAGEix Scenario
-    assert len(rep.graph["all"]) == 123
+    assert len(rep.graph["all"]) == 125
 
     # Quantities have short dimension names
     assert "demand:n-c-l-y-h" in rep
@@ -69,11 +69,11 @@ def test_reporter_from_scenario(message_test_mp):
     assert_qty_equal(obs, demand, check_attrs=False)
 
     # ixmp.Reporter pre-populated with only model quantities and aggregates
-    assert len(rep_ix.graph) == 5225
+    assert len(rep_ix.graph) == 5609
 
     # message_ix.Reporter pre-populated with additional, derived quantities
     # This is the same value as in test_tutorials.py
-    assert len(rep.graph) == 12690
+    assert len(rep.graph) == 13074
 
     # Derived quantities have expected dimensions
     vom_key = rep.full_key("vom")

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -56,7 +56,7 @@ tutorials: List[Tuple] = [
     (("westeros", "westeros_addon_technologies"), [], {}),
     (("westeros", "westeros_historical_new_capacity"), [], {}),
     # NB this is the same value as in test_reporter()
-    (("westeros", "westeros_report"), [("len-rep-graph", 12690)], {}),
+    (("westeros", "westeros_report"), [("len-rep-graph", 13074)], {}),
     ((AT, "austria"), [("solve-objective-value", 206321.90625)], {}),
     (
         (AT, "austria_single_policy"),

--- a/message_ix/util/__init__.py
+++ b/message_ix/util/__init__.py
@@ -6,8 +6,9 @@ from collections.abc import Mapping
 import pandas as pd
 from pandas.api.types import is_scalar
 
+from message_ix.core import Scenario
 from message_ix.macro import MACRO_ITEMS
-from message_ix.models import MESSAGE_ITEMS
+from message_ix.models import MESSAGE, MESSAGE_ITEMS
 
 
 def make_df(name, **data):
@@ -102,6 +103,8 @@ def make_df(name, **data):
         if `name` is not the name of a MESSAGE or MACRO parameter; if arrays in `data`
         have uneven lengths.
     """
+    # NB could be expanded to handle "mapping sets"
+
     if isinstance(name, (Mapping, pd.Series, pd.DataFrame)):
         return _deprecated_make_df(name, **data)
 
@@ -189,3 +192,43 @@ def _deprecated_make_df(base, **kwargs):
         base = base.to_dict()
     base.update(**kwargs)
     return pd.DataFrame(base)
+
+
+def expand_dims(scenario: Scenario, name, **data):
+    """Expand dimensions of parameter `name` on `scenario`, filling with `data`.
+
+    This function is for use when an existing parameter `name` has dimensions that are a
+    subset of those that would be created by :func:`make_df`, i.e. those given by
+    :data:`.MESSAGE_ITEMS`.
+
+    This can occur when the underlying structure of MESSAGE and the model core is
+    enhanced by adding dimensions to existing parameters. Existing scenario data in
+    users' databases can not then be automatically updated.
+
+    :func:`expand_dims` helps users to update this data manually. It:
+
+    1. Retrieves the existing parameter data for `name`.
+    2. Passes this existing data, plus any `data` given as keyword arguments, to
+       :func:`make_df`. The result must be a data frame with no empty values; in other
+       words, `data` must include all the dimensions to be added to `name`.
+    3. Re-initializes the parameter `name` on `scenario`, with the dimensions given by
+       :data:`.MESSAGE_ITEMS`.
+    4. Adds the expanded data.
+
+    The modifications (steps 3 and 4) are wrapped using :meth:`.transact`.
+    """
+    # NB could be improved by allowing `data` to include callables; these would be
+    #    pd.DataFrame.apply(…)'d to each row in order to compute values for the new
+    #    dimension(s).
+
+    # Create the expanded data
+    new_data = make_df(name, **scenario.par(name), **data)
+    assert not new_data.isna().any(axis=None), "Expanded data are incomplete"
+
+    with scenario.transact(f"expand_dims({name}, …)"):
+        # Remove the parameter entirely, and re-initialize
+        scenario.remove_par(name)
+        MESSAGE.initialize_items(scenario, {name: MESSAGE_ITEMS[name]})
+
+        # Add the expanded data
+        scenario.add_par(name, new_data)


### PR DESCRIPTION
This PR addresses #632 by adding `mode` to the mapping set of storage technologies (`map_tec_storage`) and also to storage equations.
More details:
This change means re-initializing the existing set of `map_tec_storage` with new index sets. Based on the discussion in #631, this re-initializing happens automatically by modifications in the file `models.py`, only if the mapping set is empty. If the set is not empty, an exception is raised, telling the user that they need to update this set.
Moreover, this PR improves the documentation of storage section to reflect the above changes and more than that, adding required details for each equation.

## How to review

- create a branch from the submitted PR; load an existing scenario (from Westeros, national or global models); clone a new scenario without carrying the solution (using the argument `keep_solution=False`); solve the cloned scenario again. The cloned scenario should solve without an error, if there is no content in the set `map_tec_storage` in that scenario. Otherwise, there should be an error asking you to update this set.
- run  `test_feature_storage.py` from this PR on the main branch; it should fail.
- read the documentation of the storage section and migration notes, and make sure it's clear and complete.

## PR checklist

- [X] Continuous integration checks all ✅
- [x] Test is enhanced (`test_feature_storage.py`) to reflect the new changes.
- [x] Expanded the documentation.
- [x] Update release and migration notes.
