### PR TITLE
Adjust default reporting key to "message::default", following genno

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,10 +12,16 @@ Migration notes
 
      df = scen.vintage_and_active_years().query(f"{scen.y0} <= year_vtg")
 
+- The :ref:`default reports <default-reports>` (tables in IAMC format) available in a :class:`~message_ix.reporting.Reporter` have changed keys to e.g. ``message::default`` with **two** colons.
+  Code using e.g. ``message:default`` (one colon) should be updated to use the current keys.
+
+  This matches fixed behaviour upstream in :mod:`genno` version 1.12 to avoid unintended confusion with keys like ``A:i``: ``i`` (after the first colon) is the name for the sole dimension of a 1-dimensional quantity, whereas ``default`` in ``message::default`` is a tag.
+
 
 All changes
 -----------
 
+- Adjust keys for IAMC-format reporting nodes (:pull:`628`, :pull:`641`)
 - New reporting computation :func:`.as_message_df` (:pull:`628`).
 - Extend functionality of :meth:`.vintage_and_active_years`; add aliases :meth:`.yv_ya`, :meth:`.ya`, and :attr:`.y0` (:pull:`572`, :pull:`623`).
 - Add scripts and HOWTO for documentation videos (:pull:`396`).

--- a/doc/reporting.rst
+++ b/doc/reporting.rst
@@ -182,6 +182,8 @@ Other added keys include:
   Each of these is also available in a Reporter: for example ``rep.get("n")`` returns a list with the elements of the |MESSAGEix| set named "node".
   These keys can be used as input
 
+.. _default-reports:
+
 - Computations to convert internal :func:`Quantity` data format to the IAMC data format, i.e. as :class:`pyam.IamDataFrame` objects.
   These include:
 

--- a/message_ix/reporting/__init__.py
+++ b/message_ix/reporting/__init__.py
@@ -203,7 +203,7 @@ def get_tasks() -> Sequence[Tuple[Tuple, Mapping]]:
         put("concat", group, *pyam_keys, strict=True)
 
     # Add all standard reporting to the default message node
-    put("concat", "message:default", *REPORTS.keys(), strict=True)
+    put("concat", "message::default", *REPORTS.keys(), strict=True)
 
     return to_add
 

--- a/message_ix/tests/test_reporting.py
+++ b/message_ix/tests/test_reporting.py
@@ -113,7 +113,7 @@ def test_reporter_from_westeros(test_mp):
 
     # message default target can be calculated
     # TODO if df is empty, year is cast to float
-    obs = rep.get("message:default")
+    obs = rep.get("message::default")
 
     # all expected reporting exists
     assert len(obs.data) == 69

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -22,8 +22,8 @@ mark1 = pytest.mark.xfail(
 )
 
 mark2 = pytest.mark.xfail(
-    condition=sys.platform == "win32" and sys.version_info.minor == 10,
-    reason="Fails occasionally on GitHub Actions runners for Windows / Python 3.10",
+    condition=sys.platform == "win32",
+    reason="Fails occasionally on GitHub Actions runners for Windows",
 )
 
 # Argument values to parametrize test_tutorial


### PR DESCRIPTION
This change was missed in #628, which adjusted the keys of other reports.

## How to review

- Read the diff and note that CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~
- [x] Update release notes.