### PR TITLE
Add additional oscillation indicator

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,8 @@
 .. All changes
 .. -----------
 
+- Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
+
 .. _v3.6.0:
 
 v3.6.0 (2022-08-17)

--- a/doc/macro.rst
+++ b/doc/macro.rst
@@ -58,6 +58,10 @@ The algorithm detects 'oscillation', which occurs when MESSAGE and MACRO each re
 
 If the difference between these points is greater than `convergence_criterion`, the algorithm might jump between these two points infinitely.
 Instead, the algorithm detects oscillation by comparing model solutions on each iteration to previous values recorded in the iteration log.
+Specifically, the algorithm checks for three patterns across the iterations.
+1. Does the sign of the `max_adjustment` parameter change?
+2. Are the maximum-positive and maximum-negative adjustments equal to each other?
+3. Do the solutions jump between two objective functions?
 
 If the algorithm picks up on the oscillation between iterations, then after MACRO has solved and before solving MESSAGE, a log message is printed as follows::
 

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -98,7 +98,7 @@ Scalar
     scaling            scaling factor to adjust step size when iteration oscillates / 1 /
     max_it             maximum number of iterations                                 / %MAX_ITERATION% /
     ctr                iteration counter                                            / 0 /
-    obj_func_chng      change of objective function compared iteration-1           / 0 /
+    obj_func_chng      change of objective function compared to iteration-1         / 0 /
     obj_func_chng_pre  change of objective function of iteration-1 compared to iteration-2 / 0 /
     obj_func_pre       objective function from iteration-1                          / 0 /
     osc_check          tracks which oscillation check is used                       / 0 /

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -289,7 +289,6 @@ elseif abs( max_adjustment_pos + max_adjustment_neg ) < 1e-4 ,
     scaling = scaling * sqrt(2) ;
     osc_check = 2 ;
     osc_check_final = 1 ;
-*    scaling = scaling + 1;
     put_utility 'log' /"+++ Indication of instability, increase the scaling parameter (", scaling:0:0, ") +++" ;
 * Oscillation check 3: Do the solutions jump between two objective functions?
 elseif ORD(iteration) > 2 AND abs(obj_func_chng_pre + obj_func_chng) < 1e-4 ,
@@ -308,6 +307,15 @@ osc_check = 0;
 obj_func_pre = OBJ.l
 if ( ORD(Iteration) > 1,
     obj_func_chng_pre = obj_func_chng;
+) ;
+
+* In the case that the model solves with unscaled infeasibilities, the cplex options file `cplex.op2`
+* will be used which forces the use of `Dual Crossover` when solving with Barrier. This will avoid
+* solving further with unscaled infeasibilities.
+if( MESSAGE_LP.modelstat = 5,
+   put_utility 'log' /'+++ Detected issues solving with unscaled infeasibilities. Enforcing Dual crossover +++ ' ;
+   MESSAGE_LP.optFile = 2;
+   report_iteration(iteration, 'unscaled infeasibilities') = 1 ;
 ) ;
 
 * store the maximum adjustment in this iteration for the oscillation-prevention query in the next iteration

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -249,7 +249,7 @@ max_adjustment_neg = smin((node_macro,sector,year)$( NOT macro_base_period(year)
 max_adjustment = max_adjustment_pos ;
 max_adjustment$( max_adjustment_neg < - max_adjustment_pos ) = max_adjustment_neg ;
 
-* Add entry to log-file: which of the checks have been used
+* Add entries to log-file
 report_iteration(iteration, 'max adjustment pos') = max_adjustment_pos ;
 report_iteration(iteration, 'max adjustment neg') = -max_adjustment_neg ;
 report_iteration(iteration, 'absolute max adjustment max/min') = abs(max_adjustment) ;
@@ -264,30 +264,34 @@ if ( abs(max_adjustment) < %CONVERGENCE_CRITERION%,
         put_utility 'log' /"+++ Convergence criteria satisfied after ", ORD(iteration):0:0, " iterations +++ " ;
     ) ;
     if ( osc_check_final = 1,
-        put_utility 'log' /"+++ Convergence achieved via oscillation check mechanims; check iteration log for further details +++ " ;
+        put_utility 'log' /"+++ Convergence achieved via oscillation check mechanism; check iteration log for further details +++ " ;
     else
         put_utility 'log' /"+++ Natural convergence achieved +++ " ;
     ) ;
     break ;
 ) ;
-* Check_change in objective function.
+
+* Calculate change in objective function for use in oscillation check 3
 if ( ORD(iteration) > 1,
     obj_func_chng = 1 - (OBJ.l / obj_func_pre);
 ) ;
 
-* check whether oscillation occurs during the iteration - if the sign of the adjusment switches, reduce maximum adjustment
+* Perform oscillation checks:
+* Oscillation check 1: Does the sign of the `max_adjustment` parameter change?
 if ( ORD(iteration) > 1 AND sign(max_adjustment_pre) = -sign(max_adjustment)
         AND abs(max_adjustment_pre) > abs(max_adjustment) * 0.9,
     scaling = scaling * sqrt(2) ;
     osc_check = 1 ;
     osc_check_final = 1;
     put_utility 'log' /"+++ Indication of oscillation, increase the scaling parameter (", scaling:0:0, ") +++" ;
+* Oscillation check 2: Are the maximum-positive and maximum-negative adjustments equal to each other?
 elseif abs( max_adjustment_pos + max_adjustment_neg ) < 1e-4 ,
     scaling = scaling * sqrt(2) ;
     osc_check = 2 ;
     osc_check_final = 1 ;
 *    scaling = scaling + 1;
     put_utility 'log' /"+++ Indication of instability, increase the scaling parameter (", scaling:0:0, ") +++" ;
+* Oscillation check 3: Do the solutions jump between two objective functions?
 elseif ORD(iteration) > 2 AND abs(obj_func_chng_pre + obj_func_chng) < 1e-4 ,
     scaling = scaling * sqrt(2) ;
     osc_check = 3 ;
@@ -295,12 +299,12 @@ elseif ORD(iteration) > 2 AND abs(obj_func_chng_pre + obj_func_chng) < 1e-4 ,
     put_utility 'log' /"+++ Indication of oscillating objective function, increase the scaling parameter (", scaling:0:0, ") +++" ;
 ) ;
 
-* Add entry to log-file: which of the checks have been used
+* Add entry to log-file about which of the checks have been used.
 report_iteration(iteration, 'oscillation check') = osc_check ;
-* Reset check for next iteration
+* Reset check for next iteration.
 osc_check = 0;
 
-* shift current values to *_pre* for use in the next iteration.
+* Store current calculated change in objective function to *_pre* for use in the next iteration.
 obj_func_pre = OBJ.l
 if ( ORD(Iteration) > 1,
     obj_func_chng_pre = obj_func_chng;

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -98,8 +98,8 @@ Scalar
     scaling            scaling factor to adjust step size when iteration oscillates / 1 /
     max_it             maximum number of iterations                                 / %MAX_ITERATION% /
     ctr                iteration counter                                            / 0 /
-    obj_func_chng      change of obejective function compared iteration-1           / 0 /
-    obj_func_chng_pre  change of obejective function of iteration-1 compared to iteration-2 / 0 /
+    obj_func_chng      change of objective function compared iteration-1           / 0 /
+    obj_func_chng_pre  change of objective function of iteration-1 compared to iteration-2 / 0 /
     obj_func_pre       objective function from iteration-1                          / 0 /
     osc_check          tracks which oscillation check is used                       / 0 /
     osc_check_final    tracks if any oscillation check has been triggered           / 0 /

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -97,10 +97,12 @@ Scalar
     convergence_status status of convergence (1 if successful)                      / 0 /
     scaling            scaling factor to adjust step size when iteration oscillates / 1 /
     max_it             maximum number of iterations                                 / %MAX_ITERATION% /
-    ctr                iteration counter                                            /0 /
+    ctr                iteration counter                                            / 0 /
     obj_func_chng      change of obejective function compared iteration-1           / 0 /
     obj_func_chng_pre  change of obejective function of iteration-1 compared to iteration-2 / 0 /
     obj_func_pre       objective function from iteration-1                          / 0 /
+    osc_check          tracks which oscillation check is used                       / 0 /
+    osc_check_final    tracks if any oscillation check has been triggered           / 0 /
 ;
 
 
@@ -247,6 +249,7 @@ max_adjustment_neg = smin((node_macro,sector,year)$( NOT macro_base_period(year)
 max_adjustment = max_adjustment_pos ;
 max_adjustment$( max_adjustment_neg < - max_adjustment_pos ) = max_adjustment_neg ;
 
+* Add entry to log-file: which of the checks have been used
 report_iteration(iteration, 'max adjustment pos') = max_adjustment_pos ;
 report_iteration(iteration, 'max adjustment neg') = -max_adjustment_neg ;
 report_iteration(iteration, 'absolute max adjustment max/min') = abs(max_adjustment) ;
@@ -260,6 +263,11 @@ if ( abs(max_adjustment) < %CONVERGENCE_CRITERION%,
     else
         put_utility 'log' /"+++ Convergence criteria satisfied after ", ORD(iteration):0:0, " iterations +++ " ;
     ) ;
+    if ( osc_check_final = 1,
+        put_utility 'log' /"+++ Convergence achieved via oscillation check mechanims; check iteration log for further details +++ " ;
+    else
+        put_utility 'log' /"+++ Natural convergence achieved +++ " ;
+    ) ;
     break ;
 ) ;
 * Check_change in objective function.
@@ -271,15 +279,26 @@ if ( ORD(iteration) > 1,
 if ( ORD(iteration) > 1 AND sign(max_adjustment_pre) = -sign(max_adjustment)
         AND abs(max_adjustment_pre) > abs(max_adjustment) * 0.9,
     scaling = scaling * sqrt(2) ;
+    osc_check = 1 ;
+    osc_check_final = 1;
     put_utility 'log' /"+++ Indication of oscillation, increase the scaling parameter (", scaling:0:0, ") +++" ;
 elseif abs( max_adjustment_pos + max_adjustment_neg ) < 1e-4 ,
     scaling = scaling * sqrt(2) ;
+    osc_check = 2 ;
+    osc_check_final = 1 ;
 *    scaling = scaling + 1;
     put_utility 'log' /"+++ Indication of instability, increase the scaling parameter (", scaling:0:0, ") +++" ;
 elseif ORD(iteration) > 2 AND abs(obj_func_chng_pre + obj_func_chng) < 1e-4 ,
     scaling = scaling * sqrt(2) ;
+    osc_check = 3 ;
+    osc_check_final = 1;
     put_utility 'log' /"+++ Indication of oscillating objective function, increase the scaling parameter (", scaling:0:0, ") +++" ;
 ) ;
+
+* Add entry to log-file: which of the checks have been used
+report_iteration(iteration, 'oscillation check') = osc_check ;
+* Reset check for next iteration
+osc_check = 0;
 
 * shift current values to *_pre* for use in the next iteration.
 obj_func_pre = OBJ.l

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -97,7 +97,10 @@ Scalar
     convergence_status status of convergence (1 if successful)                      / 0 /
     scaling            scaling factor to adjust step size when iteration oscillates / 1 /
     max_it             maximum number of iterations                                 / %MAX_ITERATION% /
-    ctr                iteration counter                                            /0/
+    ctr                iteration counter                                            /0 /
+    obj_func_chng      change of obejective function compared iteration-1           / 0 /
+    obj_func_chng_pre  change of obejective function of iteration-1 compared to iteration-2 / 0 /
+    obj_func_pre       objective function from iteration-1                          / 0 /
 ;
 
 
@@ -259,6 +262,10 @@ if ( abs(max_adjustment) < %CONVERGENCE_CRITERION%,
     ) ;
     break ;
 ) ;
+* Check_change in objective function.
+if ( ORD(iteration) > 1,
+    obj_func_chng = 1 - (OBJ.l / obj_func_pre);
+) ;
 
 * check whether oscillation occurs during the iteration - if the sign of the adjusment switches, reduce maximum adjustment
 if ( ORD(iteration) > 1 AND sign(max_adjustment_pre) = -sign(max_adjustment)
@@ -269,6 +276,15 @@ elseif abs( max_adjustment_pos + max_adjustment_neg ) < 1e-4 ,
     scaling = scaling * sqrt(2) ;
 *    scaling = scaling + 1;
     put_utility 'log' /"+++ Indication of instability, increase the scaling parameter (", scaling:0:0, ") +++" ;
+elseif ORD(iteration) > 2 AND abs(obj_func_chng_pre + obj_func_chng) < 1e-4 ,
+    scaling = scaling * sqrt(2) ;
+    put_utility 'log' /"+++ Indication of oscillating objective function, increase the scaling parameter (", scaling:0:0, ") +++" ;
+) ;
+
+* shift current values to *_pre* for use in the next iteration.
+obj_func_pre = OBJ.l
+if ( ORD(Iteration) > 1,
+    obj_func_chng_pre = obj_func_chng;
 ) ;
 
 * store the maximum adjustment in this iteration for the oscillation-prevention query in the next iteration

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -373,6 +373,11 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
         optfile.write_text("\n".join(lines))
         log.info(f"Use CPLEX options {self.cplex_opts}")
 
+        self.cplex_opts.update({"barcrossalg": 2})
+        optfile2 = Path(self.model_dir).joinpath("cplex.op2")
+        lines2 = ("{} = {}".format(*kv) for kv in self.cplex_opts.items())
+        optfile2.write_text("\n".join(lines2))
+
         try:
             result = super().run(scenario)
         finally:
@@ -382,6 +387,8 @@ class GAMSModel(ixmp.model.gams.GAMSModel):
             # py37 compat: check for existence instead of using unlink(missing_ok=True)
             if optfile.exists():
                 optfile.unlink()
+            if optfile2.exists():
+                optfile2.unlink()
 
         return result
 


### PR DESCRIPTION
This PR adds an additional check to detect the oscillation between the various iterations when running MESSAGE-MACRO.
The additional check looks to see if the objective function bounces between two points.

Some of the findings and solutions to handling unscaled infeasibilities discussed in issue #337 have also been updated.

## How to review

Review code updates to "MESSAGE-MACRO_run.gms".
Review updated documentation to the section "calibrate-and-tune-message-macro" found in "marco.rst".

## PR checklist

- [x] Continuous integration checks all ✅
~- [ ] Add or expand tests; coverage checks both ✅~ N/A as this cannot be tested
- [x] Add, expand, or update documentation.
- [x] Update release notes.
