### PR TITLE
Work around CI failure due to plotnine

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Cache Anaconda installer, conda packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           $CONDA/pkgs

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,17 +37,18 @@ jobs:
       # with:
       #   python-version: "3.10"
 
+    - name: Upgrade pip, wheel
+      id: pip
+      run: |
+        python -m pip install --upgrade pip wheel
+        # Locate pip cache directory
+        echo "::set-output name=cache-dir::$(pip cache dir)"
+
     - name: Cache Python packages
       uses: actions/cache@v3
       with:
-        path: |
-          ~/.cache/pip
-          ~/Library/Caches/pip
-          ~/appdata/local/pip/cache
+        path: ${{ steps.pip.outputs.cache-dir }}
         key: lint-${{ runner.os }}
-
-    - name: Upgrade pip, wheel
-      run: python -m pip install --upgrade pip wheel
 
     - name: Check "black" code style
       working-directory: message_ix

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Check out ixmp
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: iiasa/ixmp
         # For PRs that depend on an ixmp PR branch, uncomment the following 2
@@ -27,18 +27,18 @@ jobs:
         path: ixmp
 
     - name: Check out message_ix
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: message_ix
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       # This should match the "Latest version testable on GitHub Actions"
       # in pytest.yaml
       # with:
       #   python-version: "3.10"
 
     - name: Cache Python packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pip

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -43,14 +43,19 @@ jobs:
       # with:
       #   python-version: "3.10"
 
+    - name: Upgrade pip, wheel, setuptools-scm
+      id: pip
+      run: |
+        python -m pip install --upgrade pip wheel setuptools-scm
+        # Locate pip cache directory
+        echo "::set-output name=cache-dir::$(pip cache dir)"
+
     - name: Cache GAMS installer and Python packages
       uses: actions/cache@v3
       with:
         path: |
           gams
-          ~/.cache/pip
-          ~/Library/Caches/pip
-          ~/appdata/local/pip/cache
+          ${{ steps.pip.outputs.cache-dir }}
         key: gams${{ env.GAMS_VERSION }}
 
     - uses: iiasa/actions/setup-gams@main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,14 +20,14 @@ jobs:
 
     steps:
     - name: Check out ixmp
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: iiasa/ixmp
         path: ixmp
         fetch-depth: ${{ env.depth }}
 
     - name: Check out message_ix
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: message_ix
         fetch-depth: ${{ env.depth }}
@@ -37,14 +37,14 @@ jobs:
         (cd ixmp; git fetch --tags --depth=${{ env.depth }})
         (cd message_ix; git fetch --tags --depth=${{ env.depth }})
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       # This should match the "Latest version testable on GitHub Actions"
       # in pytest.yaml
       # with:
       #   python-version: "3.10"
 
     - name: Cache GAMS installer and Python packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           gams

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       # This should match the "Latest version testable on GitHub Actions"
       # in pytest.yaml
       # with:
       #   python-version: "3.10"
 
     - name: Cache Python packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pip

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,15 +24,18 @@ jobs:
       # with:
       #   python-version: "3.10"
 
+    - name: Upgrade pip, wheel, setuptools-scm
+      id: pip
+      run: |
+        python -m pip install --upgrade pip wheel setuptools-scm twine
+        # Locate pip cache directory
+        echo "::set-output name=cache-dir::$(pip cache dir)"
+
     - name: Cache Python packages
       uses: actions/cache@v3
       with:
-        path: |
-          ~/.cache/pip
+        path: ${{ steps.pip.outputs.cache-dir }}
         key: publish-${{ runner.os }}
-
-    - name: Upgrade pip, wheel, setuptools-scm
-      run: python -m pip install --upgrade pip wheel setuptools-scm twine
 
     - name: Build package
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -42,12 +42,12 @@ jobs:
 
     steps:
     - name: Cancel previous runs that have not completed
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.10.0
       with:
         access_token: ${{ github.token }}
 
     - name: Check out ixmp
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: iiasa/ixmp
         # For PRs that depend on an ixmp PR branch, uncomment the following 2
@@ -58,7 +58,7 @@ jobs:
         fetch-depth: ${{ env.depth }}
 
     - name: Check out message_ix
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: message_ix
         fetch-depth: ${{ env.depth }}
@@ -69,7 +69,7 @@ jobs:
         (cd message_ix; git fetch --tags --depth=${{ env.depth }})
       shell: bash
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -82,7 +82,7 @@ jobs:
       id: setup-r
 
     - name: Cache GAMS installer, Python packages, and R packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           gams
@@ -144,6 +144,6 @@ jobs:
       run: make --directory=doc html
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         directory: message_ix

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -73,6 +73,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Upgrade pip, wheel, setuptools-scm
+      id: pip
+      run: |
+        python -m pip install --upgrade pip wheel setuptools-scm
+        # Locate pip cache directory
+        echo "::set-output name=cache-dir::$(pip cache dir)"
+
     - name: Set RETICULATE_PYTHON
       # Use the environment variable set by the setup-python action, above.
       run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
@@ -86,9 +93,7 @@ jobs:
       with:
         path: |
           gams
-          ~/.cache/pip
-          ~/Library/Caches/pip
-          ~/appdata/local/pip/cache
+          ${{ steps.pip.outputs.cache-dir }}
           ${{ env.R_LIBS_USER }}
         key: ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-py${{ matrix.python-version }}-R${{ steps.setup-r.outputs.installed-r-version }}
         restore-keys: |
@@ -102,9 +107,6 @@ jobs:
         license: ${{ secrets.GAMS_LICENSE }}
 
     - uses: ts-graphviz/setup-graphviz@v1
-
-    - name: Upgrade pip, wheel, setuptools-scm
-      run: python -m pip install --upgrade pip wheel setuptools-scm
 
     - name: Install ixmp and dependencies
       working-directory: ixmp

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -112,7 +112,10 @@ jobs:
 
     - name: Install Python package and dependencies
       working-directory: message_ix
-      run: pip install .[tests]
+      run: |
+        pip install .[tests]
+        # TEMPORARY work around has2k1/plotnine#619, khaeru/genno#71
+        pip install "matplotlib<3.6.0"
 
     - name: Install R dependencies and tutorial requirements
       run: |

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,8 +1,8 @@
-.. Next release
-.. ============
+Next release
+============
 
-.. All changes
-.. -----------
+All changes
+-----------
 
 - Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,12 +95,13 @@ module = [
   "pyam",
   "pytest",
   "setuptools",
-  # Indirectly via ixmp; this should be a subset of the list in ixmp's setup.cfg
+  # Indirectly via ixmp; this should be a subset of the list in ixmp's pyproject.toml
   "dask",
   "jpype",
   "nbclient",
   "nbformat",
   "memory_profiler",
+  "pint._vendor",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
This works around CI failures observed here due to has2k1/plotnine#619, which affects message_ix via khaeru/genno#71. For the moment, matplotlib v3.6.0 cannot be used with genno and thus with message_ix.reporting.

Also:
- Upgrade versions of actions used in CI workflows.
- Standardize the method for querying pip's cache.
- Clean up incomplete edits to release notes in #645.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update release notes.~