### PR TITLE
Specify Python version for "nightly" CI workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,6 +11,7 @@ on:
   - cron: "0 5 * * *"
 
 env:
+  GAMS_VERSION: 25.1.1
   # See description in lint.yml
   depth: 100
 
@@ -38,10 +39,10 @@ jobs:
         (cd message_ix; git fetch --tags --depth=${{ env.depth }})
 
     - uses: actions/setup-python@v4
-      # This should match the "Latest version testable on GitHub Actions"
-      # in pytest.yaml
-      # with:
-      #   python-version: "3.10"
+      with:
+        # If the "Latest version testable on GitHub Actions" in pytest.yaml
+        # is not the latest 3.x stable version, adjust here to match:
+        python-version: "3.x"
 
     - name: Upgrade pip, wheel, setuptools-scm
       id: pip
@@ -56,11 +57,11 @@ jobs:
         path: |
           gams
           ${{ steps.pip.outputs.cache-dir }}
-        key: gams${{ env.GAMS_VERSION }}
+        key: ubuntu-latest-gams${{ env.GAMS_VERSION }}
 
     - uses: iiasa/actions/setup-gams@main
       with:
-        version: 25.1.1
+        version: ${{ env.GAMS_VERSION }}
         license: ${{ secrets.GAMS_LICENSE }}
 
     - name: Install Python packages and dependencies

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -27,6 +27,7 @@ jobs:
         - "3.8"
         - "3.9"
         - "3.10"  # Latest release / latest supported by message_ix
+        # - "3.x"  #
 
         # For freshy released or development versions of Python, compiled
         # binary wheels are not available for some dependencies, e.g. llvmlite,


### PR DESCRIPTION
After #649, the "nightly" workflow fails, likely due to actions/setup-python@v4 no longer automatically defaulting to the latest version. Fix.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, CI changes only
- ~Update release notes.~