### PR TITLE
Correct levelized_cost calculation

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,6 +7,7 @@ All changes
 - Adjust :meth:`.Scenario.add_macro` calculations for pandas 1.5.0 (:pull:`656`).
 - Add additional oscillation detection mechanism for MACRO iterations (:pull:`645`).
 - Correct calculation of `COST_NODAL_NET` for standalone MESSAGE (:pull:`648`)
+- Ensure `levelized_cost` are also calculated for technologies with only variable costs (:pull:`653`)
 - Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
 
 .. _v3.6.0:

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,10 +4,9 @@ Next release
 All changes
 -----------
 
-- Adjust :meth:`.Scenario.add_macro` calculations for pandas 1.5.0 (:pull:`656`).
-- Add additional oscillation detection mechanism for MACRO iterations (:pull:`645`).
-- Correct calculation of `COST_NODAL_NET` for standalone MESSAGE (:pull:`648`)
 - Ensure `levelized_cost` are also calculated for technologies with only variable costs (:pull:`653`)
+- Adjust :meth:`.Scenario.add_macro` calculations for pandas 1.5.0 (:pull:`656`).
+- Correct calculation of `COST_NODAL_NET` for standalone MESSAGE (:pull:`648`)
 - Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
 
 .. _v3.6.0:

--- a/doc/macro.rst
+++ b/doc/macro.rst
@@ -43,12 +43,12 @@ For an example of such input data files, see the files :file:`message_ix/tests/d
 General configuration sheet
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``config``: This configuration sheet specifies MACRO-related nodes and years, and maps MACRO sectors to MESSAGE commodities and levels.
-   The sheet has five columns, each of which is a list of labels/codes for a corresponding :ref:`ixmp set <ixmp:data-model-data>`:
-
-   - "node", "year": these can each have any length, depending on the number of regions and years to be included in the MACRO calibration process.
-   - "sector", "commodity", "level": these 3 columns must have equal lengths.
-     They describe a one-to-one mapping between MACRO sectors (entries in the "sector" column) and MESSAGE commodities and levels (paired entries in the "commodity" and "level" columns).
+  - ``config``: This configuration sheet specifies MACRO-related nodes and years, and maps MACRO sectors to MESSAGE commodities and levels.
+    The sheet has five columns, each of which is a list of labels/codes for a corresponding :ref:`ixmp set <ixmp:data-model-data>`:
+    
+    - "node", "year": these can each have any length, depending on the number of regions and years to be included in the MACRO calibration process.
+    - "sector", "commodity", "level": these 3 columns must have equal lengths.
+      They describe a one-to-one mapping between MACRO sectors (entries in the "sector" column) and MESSAGE commodities and levels (paired entries in the "commodity" and "level" columns).
 
 MACRO parameter sheets
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -218,6 +218,7 @@ Parameter
 *
 * .. [#levelizedcost] The parameter ``levelized_cost`` is computed in the GAMS pre-processing under the assumption of
 *    full capacity utilization until the end of the technical lifetime.
+*    As these are calculated in the preprocessing, the reported ``levelized_cost`` in the output GDX-file exclude fuel costs.
 *
 * .. [#construction] The construction time only has an effect on the investment costs; in |MESSAGEix|,
 *    each unit of new-built capacity is available instantaneously at the beginning of the model period.

--- a/message_ix/model/MESSAGE/scaling_investment_costs.gms
+++ b/message_ix/model/MESSAGE/scaling_investment_costs.gms
@@ -28,12 +28,14 @@ beyond_horizon_lifetime(node,inv_tec,vintage)$( beyond_horizon_lifetime(node,inv
 * where :math:`|y| = technical\_lifetime_{n,t,y}`. This formulation implicitly assumes constant fixed
 * and variable costs over time.
 *
-* **Warning:** All soft relaxations of the dynamic activity constraint are
+* **Warning:** 
+* Levelized capital costs do not include fuel-related costs.
+* All soft relaxations of the dynamic activity constraint are
 * disabled if the levelized costs are negative!
 ***
 
-levelized_cost(node,tec,year,time)$( map_tec_time(node,tec,year,time) AND inv_tec(tec) ) =
-    inv_cost(node,tec,year)
+levelized_cost(node,tec,year,time)$( map_tec_time(node,tec,year,time)) =
+    (inv_cost(node,tec,year)
         * (
 * compute discounted annualized investment costs if interest rate > 0
             ( interestrate(year)
@@ -47,7 +49,7 @@ levelized_cost(node,tec,year,time)$( map_tec_time(node,tec,year,time) AND inv_te
     + ( fix_cost(node,tec,year,year) /
           sum(time2$( map_tec_time(node,tec,year,time2) ),
              duration_time(time2) * capacity_factor(node,tec,year,year,time2) )
-        )$( fix_cost(node,tec,year,year) )
+        )$( fix_cost(node,tec,year,year) ))$(inv_tec(tec))
     + sum(mode$( map_tec_act(node,tec,year,mode,time) ), var_cost(node,tec,year,year,mode,time) )
 ;
 

--- a/message_ix/model/MESSAGE/scaling_investment_costs.gms
+++ b/message_ix/model/MESSAGE/scaling_investment_costs.gms
@@ -13,8 +13,8 @@ beyond_horizon_lifetime(node,inv_tec,vintage)$( map_tec(node,inv_tec,vintage) ) 
 beyond_horizon_lifetime(node,inv_tec,vintage)$( beyond_horizon_lifetime(node,inv_tec,vintage) < 0 ) = 0 ;
 
 ***
-* Levelized capital costs
-* -----------------------
+* Levelized costs excluding fuel costs
+* ------------------------------------
 * For the 'soft' relaxations of the dynamic constraints and the associated penalty factor in the objective function,
 * we need to compute the parameter :math:`levelized\_cost_{n,t,y}`.
 *


### PR DESCRIPTION
As explained in issue #652, this PR aims to adjust the calculation of levelized_costs, so that these are not only calculated when investment costs are parametrized for a technology, but also when variable costs *only* have been defined.

## How to review

- Read the diff and note that the CI checks all pass.
A Specific test cannot be written because it is not possible to retrieve the parameter "levelized_cost" from the scenario object.

## PR checklist


- [x] Continuous integration checks all ✅
~- [ ] Add or expand tests; coverage checks both ✅~
- [x] Add, expand, or update documentation.
- [x] Update release notes.