### PR TITLE
Correct calculation of NEW_CAPACITY_CONSTRAINTs

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,7 +7,7 @@ All changes
 - Adjust :meth:`.Scenario.add_macro` calculations for pandas 1.5.0 (:pull:`656`).
 - Add additional oscillation detection mechanism for MACRO iterations (:pull:`645`).
 - Correct calculation of `COST_NODAL_NET` for standalone MESSAGE (:pull:`648`)
-- Account for difference in period-length when calculating `NEW_CAPACITY_CONSTRAINT_LO` and `NEW_CAPACITY_CONSTRAINT_UP` (:pull:`654`)
+- Account for difference in period-length in equations `NEW_CAPACITY_CONSTRAINT_LO` and `NEW_CAPACITY_CONSTRAINT_UP` (:pull:`654`)
 - Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
 
 .. _v3.6.0:

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -7,6 +7,7 @@ All changes
 - Adjust :meth:`.Scenario.add_macro` calculations for pandas 1.5.0 (:pull:`656`).
 - Add additional oscillation detection mechanism for MACRO iterations (:pull:`645`).
 - Correct calculation of `COST_NODAL_NET` for standalone MESSAGE (:pull:`648`)
+- Account for difference in period-length when calculating `NEW_CAPACITY_CONSTRAINT_LO` and `NEW_CAPACITY_CONSTRAINT_UP` (:pull:`654`)
 - Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
 
 .. _v3.6.0:

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -1547,7 +1547,7 @@ SHARE_CONSTRAINT_COMMODITY_LO(shares,node_share,year,time)$( share_commodity_lo(
 *
 * Here, :math:`|y|` is the number of years in period :math:`y`, i.e., :math:`duration\_period_{y}`.
 ***
-NEW_CAPACITY_CONSTRAINT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
+NEW_CAPACITY_CONSTRAI/NT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
         AND is_dynamic_new_capacity_up(node,inv_tec,year) )..
 * actual new capacity
     CAP_NEW(node,inv_tec,year) =L=
@@ -1576,6 +1576,9 @@ NEW_CAPACITY_CONSTRAINT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 * GAMS implementation comment:
 * The sums in the constraint have to be over `year_all2` (not `year2`) to also get the dynamic effect from historical
 * new capacity. If one would sum over `year2`, periods prior to the first model year would be ignored.
+* Furthermore, as `CAP_NEW` is derived from the value in a previous period, any change in the duration of two consecutive
+* model periods needs to be accounted for. This is done by using the ratio of two consecutive model periods as a
+* multiplication factor.
 
 ***
 * .. _equation_new_capacity_soft_constraint_up:
@@ -1643,6 +1646,13 @@ NEW_CAPACITY_CONSTRAINT_LO(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 * optional relaxation for calibration and debugging
 %SLACK_CAP_NEW_DYNAMIC_LO% - SLACK_CAP_NEW_DYNAMIC_LO(node,inv_tec,year)
 ;
+
+* GAMS implementation comment:
+* The sums in the constraint have to be over `year_all2` (not `year2`) to also get the dynamic effect from historical
+* new capacity. If one would sum over `year2`, periods prior to the first model year would be ignored.
+* Furthermore, as `CAP_NEW` is derived from the value in a previous period, any change in the duration of two consecutive
+* model periods needs to be accounted for. This is done by using the ratio of two consecutive model periods as a
+* multiplication factor.
 
 ***
 * .. _equation_new_capacity_soft_constraint_lo:

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -1551,7 +1551,7 @@ NEW_CAPACITY_CONSTRAINT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 * actual new capacity
     CAP_NEW(node,inv_tec,year) =L=
 * initial new capacity (compounded over the duration of the period)
-        initial_new_capacity_up(node,inv_tec,year) * (
+        (initial_new_capacity_up(node,inv_tec,year) * (
             ( ( POWER( 1 + growth_new_capacity_up(node,inv_tec,year) , duration_period(year) ) - 1 )
                 / growth_new_capacity_up(node,inv_tec,year) )$( growth_new_capacity_up(node,inv_tec,year) )
               + ( duration_period(year) )$( NOT growth_new_capacity_up(node,inv_tec,year) )
@@ -1565,7 +1565,9 @@ NEW_CAPACITY_CONSTRAINT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 * 'soft' relaxation of dynamic constraints
         + ( CAP_NEW_UP(node,inv_tec,year)
             * ( POWER( 1 + soft_new_capacity_up(node,inv_tec,year) , duration_period(year) ) - 1 )
-           )$( soft_new_capacity_up(node,inv_tec,year) )
+           )$( soft_new_capacity_up(node,inv_tec,year) ))
+       * SUM(year_all2$( seq_period(year_all2,year) ),
+            ( duration_period(year_all2) / duration_period(year) ))
 * optional relaxation for calibration and debugging
 %SLACK_CAP_NEW_DYNAMIC_UP% + SLACK_CAP_NEW_DYNAMIC_UP(node,inv_tec,year)
 ;
@@ -1619,7 +1621,7 @@ NEW_CAPACITY_CONSTRAINT_LO(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 * actual new capacity
     CAP_NEW(node,inv_tec,year) =G=
 * initial new capacity (compounded over the duration of the period)
-        - initial_new_capacity_lo(node,inv_tec,year) * (
+        (- initial_new_capacity_lo(node,inv_tec,year) * (
             ( ( POWER( 1 + growth_new_capacity_lo(node,inv_tec,year) , duration_period(year) ) - 1 )
                 / growth_new_capacity_lo(node,inv_tec,year) )$( growth_new_capacity_lo(node,inv_tec,year) )
               + ( duration_period(year) )$( NOT growth_new_capacity_lo(node,inv_tec,year) )
@@ -1633,7 +1635,9 @@ NEW_CAPACITY_CONSTRAINT_LO(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 * 'soft' relaxation of dynamic constraints
         - ( CAP_NEW_LO(node,inv_tec,year)
             * ( POWER( 1 + soft_new_capacity_lo(node,inv_tec,year) , duration_period(year) ) - 1 )
-           )$( soft_new_capacity_lo(node,inv_tec,year) )
+           )$( soft_new_capacity_lo(node,inv_tec,year) ))
+       * SUM(year_all2$( seq_period(year_all2,year) ),
+            ( duration_period(year_all2) / duration_period(year) ))
 * optional relaxation for calibration and debugging
 %SLACK_CAP_NEW_DYNAMIC_LO% - SLACK_CAP_NEW_DYNAMIC_LO(node,inv_tec,year)
 ;

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -1536,12 +1536,13 @@ SHARE_CONSTRAINT_COMMODITY_LO(shares,node_share,year,time)$( share_commodity_lo(
 *
 *  .. math::
 *     CAP\_NEW_{n,t,y}
-*         \leq & ~ initial\_new\_capacity\_up_{n,t,y}
+*         \leq & \Bigg(~ initial\_new\_capacity\_up_{n,t,y}
 *             \cdot \frac{ \Big( 1 + growth\_new\_capacity\_up_{n,t,y} \Big)^{|y|} - 1 }
 *                        { growth\_new\_capacity\_up_{n,t,y} } \\
 *              & + \Big( CAP\_NEW_{n,t,y-1} + historical\_new\_capacity_{n,t,y-1} \Big) \\
 *              & \hspace{2 cm} \cdot \Big( 1 + growth\_new\_capacity\_up_{n,t,y} \Big)^{|y|} \\
-*              & + CAP\_NEW\_UP_{n,t,y} \cdot \Bigg( \Big( 1 + soft\_new\_capacity\_up_{n,t,y}\Big)^{|y|} - 1 \Bigg) \\
+*              & + CAP\_NEW\_UP_{n,t,y} \cdot \Bigg( \Big( 1 + soft\_new\_capacity\_up_{n,t,y}\Big)^{|y|} - 1 \Bigg)\Bigg) \\
+*              & * \frac{|y-1|}{|y|} \\
 *         & \quad \forall \ t \ \in \ T^{INV}
 *
 * Here, :math:`|y|` is the number of years in period :math:`y`, i.e., :math:`duration\_period_{y}`.
@@ -1607,12 +1608,13 @@ NEW_CAPACITY_SOFT_CONSTRAINT_UP(node,inv_tec,year)$( soft_new_capacity_up(node,i
 *
 *  .. math::
 *     CAP\_NEW_{n,t,y}
-*         \geq & - initial\_new\_capacity\_lo_{n,t,y}
+*         \geq & \Bigg(- initial\_new\_capacity\_lo_{n,t,y}
 *             \cdot \frac{ \Big( 1 + growth\_new\_capacity\_lo_{n,t,y} \Big)^{|y|} }
 *                        { growth\_new\_capacity\_lo_{n,t,y} } \\
 *              & + \Big( CAP\_NEW_{n,t,y-1} + historical\_new\_capacity_{n,t,y-1} \Big) \\
 *              & \hspace{2 cm} \cdot \Big( 1 + growth\_new\_capacity\_lo_{n,t,y} \Big)^{|y|} \\
-*              & - CAP\_NEW\_LO_{n,t,y} \cdot \Bigg( \Big( 1 + soft\_new\_capacity\_lo_{n,t,y}\Big)^{|y|} - 1 \Bigg) \\
+*              & - CAP\_NEW\_LO_{n,t,y} \cdot \Bigg( \Big( 1 + soft\_new\_capacity\_lo_{n,t,y}\Big)^{|y|} - 1 \Bigg)\Bigg) \\
+*              & * \frac{|y-1|}{|y|} \\
 *         & \quad \forall \ t \ \in \ T^{INV}
 *
 ***

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -1547,7 +1547,7 @@ SHARE_CONSTRAINT_COMMODITY_LO(shares,node_share,year,time)$( share_commodity_lo(
 *
 * Here, :math:`|y|` is the number of years in period :math:`y`, i.e., :math:`duration\_period_{y}`.
 ***
-NEW_CAPACITY_CONSTRAI/NT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
+NEW_CAPACITY_CONSTRAINT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
         AND is_dynamic_new_capacity_up(node,inv_tec,year) )..
 * actual new capacity
     CAP_NEW(node,inv_tec,year) =L=

--- a/message_ix/tests/test_equation_NEW_CAPACITY_CONTRAINT.py
+++ b/message_ix/tests/test_equation_NEW_CAPACITY_CONTRAINT.py
@@ -19,6 +19,11 @@ def test_NEW_CAPACITY_UP(test_mp, model_horizon):
     the parameter "CAP_NEW" is correctly calculated.
     We check this for the transition from 10 to 5-year timesteps, and from
     5 to 10-year timesteps.
+    The values against which the test results are being compared are based
+    on the assumption that due to the carbon price, the capacity installation
+    of `wind_ppl` is maximized.
+    Hence the values are derived by applying the parameters of `wind_ppl`
+    directly to the `NEW_CAPACITY_BOUND_UP` equation."
     """
     tax_emission = pd.DataFrame(
         {

--- a/message_ix/tests/test_equation_NEW_CAPACITY_CONTRAINT.py
+++ b/message_ix/tests/test_equation_NEW_CAPACITY_CONTRAINT.py
@@ -1,0 +1,81 @@
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from message_ix.testing import make_westeros
+
+
+@pytest.mark.parametrize(
+    "model_horizon",
+    [
+        [[700, 710, 715, 720], [3.746712, 4.149163, 8.731826, 9.182337]],
+        [[695, 700, 710, 720], [3.560014, 3.746712, 2.074581, 2.302091]],
+    ],
+)
+def test_NEW_CAPACITY_UP(test_mp, model_horizon):
+    """This test ensures that the correct value for "CAP_NEW" is calculated.
+
+    This test checks that when the period length changes within the model,
+    the parameter "CAP_NEW" is correctly calculated.
+    We check this for the transition from 10 to 5-year timesteps, and from
+    5 to 10-year timesteps.
+    """
+    tax_emission = pd.DataFrame(
+        {
+            "node": "Westeros",
+            "type_emission": "GHG",
+            "type_tec": "all",
+            "type_year": model_horizon[0],
+            "value": 30,
+            "unit": "???",
+        }
+    )
+
+    # Create a westeros baseline scenario including emissions
+    s = make_westeros(test_mp, emissions=True, model_horizon=model_horizon[0])
+
+    # Make changes
+    with s.transact("prepare for test"):
+
+        # Add tax_emission
+        s.add_par("tax_emission", tax_emission)
+
+        # Remove `coal_ppl` related growth constraint to avoid infeasibility
+        # when applying the capacity constraint
+        rem_df = s.par("growth_activity_up", filters={"technology": "coal_ppl"})
+        s.remove_par("growth_activity_up", rem_df)
+
+        # Add `initial_new_capacity_up` for `wind_ppl`
+        df = pd.DataFrame(
+            {
+                "node_loc": "Westeros",
+                "technology": "wind_ppl",
+                "year_vtg": model_horizon[0],
+                "value": 0.001,
+                "unit": "GW",
+            }
+        )
+        s.add_par("initial_new_capacity_up", df)
+
+        # Add `growth_new_capacity_up` for `wind_ppl`
+        df.value = 0.01
+        s.add_par("growth_new_capacity_up", df)
+
+    # Solve scenario
+    s.solve()
+
+    # Retrieve results
+    obs = s.var("CAP_NEW", filters={"technology": "wind_ppl"}).set_index("node_loc")
+
+    # Expected results
+    exp = pd.DataFrame(
+        {
+            "node_loc": "Westeros",
+            "technology": "wind_ppl",
+            "year_vtg": model_horizon[0],
+            "lvl": model_horizon[1],
+            "mrg": 0.0,
+        }
+    ).set_index("node_loc")
+
+    assert_frame_equal(exp, obs, check_dtype=False)


### PR DESCRIPTION
This PR addresses an issue which occurs when calculating the upper and lower constraints for new capacity (`NEW_CAPACITY_CONSTRAINT_LO` and `NEW_CAPACITY_CONSTRAINT_UP`).
The issue resulting from the current formulation will vary the magnitude of the bound when the `duration_period` of the time-period for the bound is being calculated, differs to the previous time-period.
An adjustment of the bound is made to take into consideration the change in the `duration_period`.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.