### PR TITLE
Adjust `.macro.Calculate._bconst` for pandas 1.5.0

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,7 +4,8 @@ Next release
 All changes
 -----------
 
-- Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
+- Adjust :meth:`.Scenario.add_macro` calculations for pandas 1.5.0 (:pull:`656`).
+- Add additional oscillation detection mechanism for MACRO iterations (:pull:`645`).
 
 .. _v3.6.0:
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -91,6 +91,7 @@ Model classes
    GAMSModel
    DEFAULT_CPLEX_OPTIONS
    MESSAGE_ITEMS
+   MACRO_ITEMS
 
 .. autodata:: DEFAULT_CPLEX_OPTIONS
 
@@ -194,13 +195,9 @@ Model classes
    :exclude-members: defaults
    :show-inheritance:
 
-   .. autoattribute:: name
-
 .. autoclass:: MACRO
    :members:
    :show-inheritance:
-
-   .. autoattribute:: name
 
 .. autoclass:: MESSAGE_MACRO
    :members:
@@ -221,8 +218,6 @@ Model classes
 
    .. seealso:: :meth:`.Scenario.add_macro`
 
-   .. autoattribute:: name
-
 .. autodata:: MESSAGE_ITEMS
    :annotation: = dict(…)
 
@@ -235,8 +230,6 @@ Model classes
 
 .. autodata:: MACRO_ITEMS
    :annotation: = dict(…)
-
-   All of the items in the MACRO mathematical formulation.
 
    .. seealso:: :data:`.MESSAGE_ITEMS`
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,7 +17,7 @@ from pkg_resources import get_distribution
 # -- Project information -----------------------------------------------------
 
 project = "MESSAGEix"
-copyright = "2021, IIASA Energy, Climate, and Environment (ECE) Program"
+copyright = "2018–2022, IIASA Energy, Climate, and Environment (ECE) Program"
 author = "MESSAGEix Developers"
 
 # The major project version, used as the replacement for |version|.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -106,9 +106,9 @@ latex_engine = "lualatex"
 gh_ref = "main" if ".dev" in version else f"v{version}"
 
 extlinks = {
-    "issue": ("https://github.com/iiasa/message_ix/issue/%s", "#"),
-    "pull": ("https://github.com/iiasa/message_ix/pull/%s", "PR #"),
-    "tut": (f"https://github.com/iiasa/message_ix/blob/{gh_ref}/tutorial/%s", ""),
+    "issue": ("https://github.com/iiasa/message_ix/issue/%s", "#%s"),
+    "pull": ("https://github.com/iiasa/message_ix/pull/%s", "PR #%s"),
+    "tut": (f"https://github.com/iiasa/message_ix/blob/{gh_ref}/tutorial/%s", None),
 }
 
 

--- a/doc/contrib/tutorial.rst
+++ b/doc/contrib/tutorial.rst
@@ -49,7 +49,7 @@ Generally, a tutorial should have the following elements or sections.
 
 - Modeling results and visualizations:
 
-  - Model outputs and post-processing calculations in tutorials should demonstrate usage of the :doc:`message_ix.reporting module <reporting>`.
+  - Model outputs and post-processing calculations in tutorials should demonstrate usage of the :doc:`message_ix.reporting module </reporting>`.
   - Plots to depict results should use `pyam <https://github.com/IAMconsortium/pyam/>`_.
   - Include a brief discussion of insights from the results, in line with the learning objectives.
 

--- a/doc/contrib/version.rst
+++ b/doc/contrib/version.rst
@@ -6,7 +6,7 @@ Versions and releases
 - We use `semantic versioning <https://semver.org>`_.
 
   To paraphrase: a **major** version increment (e.g. from 3.5 to 4.0) means there are *backwards-incompatible* changes to the API or functionality (e.g. code written for version 3.5 may no longer work with 4.0).
-  Major releases always include migration notes in :doc:`whatsnew` to alert users to such changes and suggest how to adjust their code.
+  Major releases always include migration notes in :doc:`/whatsnew` to alert users to such changes and suggest how to adjust their code.
   A **minor** version increment may fix bugs or add new features, but does not change existing functionality.
   Code written for e.g. version 3.5 will continue to work with 3.6.
 

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -444,7 +444,7 @@ class Scenario(ixmp.Scenario):
 
         4. If `ya_args` are given and `tl_only` is :obj:`True` (the default): :math:`y`
            is in the subset of :math:`Y` for which
-           :math:`\text{technical_lifetime}_{n,t,y}` is defined.[1]_
+           :math:`\text{technical_lifetime}_{n,t,y}` is defined. [1]_
         5. (Deprecated) If `in_horizon` is :obj:`True`: :math:`y \geq y_0`, the
            :attr:`.firstmodelyear`.
 

--- a/message_ix/macro.py
+++ b/message_ix/macro.py
@@ -43,7 +43,8 @@ UNITS = dict(
     price_MESSAGE="price_ref",
 )
 
-# ixmp items (sets, parameters, variables, and equations) in MACRO.
+#: All of the ixmp items (sets, parameters, variables, and equations) in the MACRO
+#: mathematical formulation.
 MACRO_ITEMS = dict(
     sector=dict(ix_type="set"),
     mapping_macro_sector=dict(ix_type="set", idx_sets=["sector", "commodity", "level"]),

--- a/message_ix/macro.py
+++ b/message_ix/macro.py
@@ -371,14 +371,12 @@ class Calculate:
 
     @lru_cache()
     def _gdp0(self):
-        """
-        Derive GDP reference values from "gdp_calibrate" for MACRO calibration.
+        """Derive GDP reference values from "gdp_calibrate" for MACRO calibration.
 
         Returns
         -------
-        pandas Series
+        pandas.Series
             Calculated "gdp0" parameter.
-
         """
         gdp = self.data["gdp_calibrate"]
         gdp0 = gdp.iloc[gdp.index.isin([self.init_year], level="year")]
@@ -526,23 +524,26 @@ class Calculate:
 
     @lru_cache()
     def _bconst(self):
-        """
-        Calculate production function coefficient of different energy sectors ("bcosnt")
-        for MACRO calibration (specified as "prfconst" in GAMS formulation).
+        """Calculate production function coefficient ("bconst").
+
+        This quantity is specified as "prfconst" in the GAMS formulation.
 
         Returns
         -------
-        pandas Series
+        pandas.Series
             Data as initial value for parameter "prfconst".
-
         """
         price_ref = self.data["price_ref"]
         demand_ref = self.data["demand_ref"]
         rho = self._rho()
         gdp0 = self._gdp0()
-        # TODO: automatically get the units here!!
-        bconst = price_ref / 1e3 * (gdp0 / demand_ref) ** (rho - 1)
-        self.data["bconst"] = bconst
+
+        # TODO automatically get the units here
+        # NB(PNK) pandas 1.4.4 automatically drops "year" in the division; pandas 1.5.0
+        # does not. Drop here pre-emptively.
+        tmp = ((gdp0 / demand_ref) ** (rho - 1)).droplevel("year")
+        self.data["bconst"] = price_ref / 1e3 * tmp
+
         return self.data["bconst"]
 
     @lru_cache()
@@ -567,7 +568,7 @@ class Calculate:
         # TODO: automatically get the units here!!
         aconst = ((gdp0 / 1e3) ** rho - partmp) / (k0 / 1e3) ** (rho * kpvs)
         # want the series to only have index of node
-        self.data["aconst"] = aconst.reset_index(level="year", drop=True)
+        self.data["aconst"] = aconst.droplevel("year")
         return self.data["aconst"]
 
 

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -12,6 +12,7 @@
 
 ***
 * .. _section_parameter_general:
+* .. _duration_time_rel:
 *
 * General parameters of the |MESSAGEix| implementation
 * ----------------------------------------------------

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -11,7 +11,7 @@ from .macro import MACRO_ITEMS
 
 log = logging.getLogger(__name__)
 
-#: Solver options used by :meth:`message_ix.Scenario.solve`.
+#: Solver options used by :meth:`.Scenario.solve`.
 DEFAULT_CPLEX_OPTIONS = {
     "advind": 0,
     "lpmethod": 2,
@@ -74,7 +74,7 @@ def item(ix_type, expr):
 
 
 # NB order by ix_type (set, par, var, equ), then alphabetically.
-#: List of ixmp items for MESSAGE.
+#: ixmp items (sets, parameters, variables, and equations) for MESSAGE.
 MESSAGE_ITEMS = {
     # Index sets
     "commodity": dict(ix_type="set"),


### PR DESCRIPTION
With pandas 1.5.0, the test `message_ix/tests/test_macro.py::test_multiregion_derive_data` began to fail, e.g. [here](https://github.com/iiasa/message_ix/actions/runs/3087665121/jobs/4993267658#step:16:185).

This PR adjusts the function to work with both pandas 1.4.4 and 1.5.0.

## How to review

- Look at the change to the method mentioned in the PR title.
- Run `pytest -k macro` using both pandas 1.5.0 and pandas < 1.5.0.
- Confirm the tests pass under both conditions.
- Note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~
- [x] Update release notes.