### PR TITLE
Adjust "ureg" test fixture for pint 0.20

### DIFF
--- a/message_ix/tests/conftest.py
+++ b/message_ix/tests/conftest.py
@@ -54,7 +54,7 @@ def ureg():
     for unit in "USD", "case":
         try:
             registry.define(f"{unit} = [{unit}]")
-        except pint.DefinitionSyntaxError:
+        except (pint.RedefinitionError, pint.DefinitionSyntaxError):
             # Already defined
             pass
 


### PR DESCRIPTION
The release of pint 0.20 triggered test failures. Some of these were fixed upstream (IAMconsortium/units#40, khaeru/genno#74); this PR takes care of those in `message_ix` itself.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, test suite changes only.
- ~Update release notes.~