### PR TITLE
Exclude Python 3.11 from CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,19 +36,11 @@ jobs:
         # If the "Latest version testable on GitHub Actions" in pytest.yaml
         # is not the latest 3.x stable version, adjust here to match:
         python-version: "3.10"
+        cache: pip
+        cache-dependency-path: "**/setup.cfg"
 
     - name: Upgrade pip, wheel
-      id: pip
-      run: |
-        python -m pip install --upgrade pip wheel
-        # Locate pip cache directory
-        echo "pip-cache-dir=$(pip cache dir)" >> $GITHUB_ENV
-
-    - name: Cache Python packages
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.pip-cache-dir }}
-        key: lint-${{ runner.os }}
+      run: python -m pip install --upgrade pip wheel
 
     - name: Check "black" code style
       working-directory: message_ix

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,10 +32,10 @@ jobs:
         path: message_ix
 
     - uses: actions/setup-python@v4
-      # This should match the "Latest version testable on GitHub Actions"
-      # in pytest.yaml
-      # with:
-      #   python-version: "3.10"
+      with:
+        # If the "Latest version testable on GitHub Actions" in pytest.yaml
+        # is not the latest 3.x stable version, adjust here to match:
+        python-version: "3.10"
 
     - name: Upgrade pip, wheel
       id: pip
@@ -43,7 +43,6 @@ jobs:
         python -m pip install --upgrade pip wheel
         # Locate pip cache directory
         echo "pip-cache-dir=$(pip cache dir)" >> $GITHUB_ENV
-
 
     - name: Cache Python packages
       uses: actions/cache@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -42,7 +42,7 @@ jobs:
       with:
         # If the "Latest version testable on GitHub Actions" in pytest.yaml
         # is not the latest 3.x stable version, adjust here to match:
-        python-version: "3.x"
+        python-version: "3.10"
 
     - name: Upgrade pip, wheel, setuptools-scm
       id: pip

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -43,20 +43,16 @@ jobs:
         # If the "Latest version testable on GitHub Actions" in pytest.yaml
         # is not the latest 3.x stable version, adjust here to match:
         python-version: "3.10"
+        cache: pip
+        cache-dependency-path: "**/setup.cfg"
 
-    - name: Upgrade pip, wheel, setuptools-scm
-      id: pip
-      run: |
-        python -m pip install --upgrade pip wheel setuptools-scm
-        # Locate pip cache directory
-        echo "pip-cache-dir=$(pip cache dir)" >> $GITHUB_ENV
+    - name: Upgrade pip, setuptools-scm, wheel
+      run: python -m pip install --upgrade pip setuptools-scm wheel
 
     - name: Cache GAMS installer and Python packages
       uses: actions/cache@v3
       with:
-        path: |
-          gams
-          ${{ env.pip-cache-dir }}
+        path: gams
         key: ubuntu-latest-gams${{ env.GAMS_VERSION }}
 
     - uses: iiasa/actions/setup-gams@main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,10 +19,10 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: actions/setup-python@v4
-      # This should match the "Latest version testable on GitHub Actions"
-      # in pytest.yaml
-      # with:
-      #   python-version: "3.10"
+      with:
+        # If the "Latest version testable on GitHub Actions" in pytest.yaml
+        # is not the latest 3.x stable version, adjust here to match:
+        python-version: "3.10"
 
     - name: Upgrade pip, wheel, setuptools-scm
       id: pip

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,19 +23,11 @@ jobs:
         # If the "Latest version testable on GitHub Actions" in pytest.yaml
         # is not the latest 3.x stable version, adjust here to match:
         python-version: "3.10"
+        cache: pip
+        cache-dependency-path: "**/setup.cfg"
 
-    - name: Upgrade pip, wheel, setuptools-scm
-      id: pip
-      run: |
-        python -m pip install --upgrade pip wheel setuptools-scm twine
-        # Locate pip cache directory
-        echo "pip-cache-dir=$(pip cache dir)" >> $GITHUB_ENV
-
-    - name: Cache Python packages
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.pip-cache-dir }}
-        key: publish-${{ runner.os }}
+    - name: Upgrade pip, setuptools-scm, twine, wheel
+      run: python -m pip install --upgrade pip setuptools-scm twine wheel
 
     - name: Build package
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -26,15 +26,16 @@ jobs:
         - "3.7"  # Earliest version supported by message_ix
         - "3.8"
         - "3.9"
-        - "3.10"  # Latest release / latest supported by message_ix
-        # - "3.x"  #
+        - "3.10"  # Latest version testable on GitHub Actions
 
-        # For freshy released or development versions of Python, compiled
-        # binary wheels are not available for some dependencies, e.g. llvmlite,
-        # numba, numpy, and/or pandas. Compiling these on the job runner
-        # requires a more elaborate build environment, currently out of scope
-        # for the message_ix project.
-        # - "3.10.0-alpha.1"  # Development version
+        # Below this comment are newly released or development versions of
+        # Python. For these versions, binary wheels are not available for some
+        # dependencies, e.g. llvmlite, numba, numpy, and/or pandas. Compiling
+        # these on the job runner requires a more elaborate build environment,
+        # currently out of scope for the message_ix project.
+
+        # - "3.11"  # Latest release. Pending numba/numba#8304
+        # - "3.12.0-alpha.1"  # Development version
 
       fail-fast: false
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -74,13 +74,11 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: "**/setup.cfg"
 
     - name: Upgrade pip, wheel, setuptools-scm
-      id: pip
-      run: |
-        python -m pip install --upgrade pip wheel setuptools-scm
-        # Locate pip cache directory
-        echo "pip-cache-dir=$(pip cache dir)" >> $GITHUB_ENV
+      run: python -m pip install --upgrade pip wheel setuptools-scm
 
     - name: Set RETICULATE_PYTHON
       # Use the environment variable set by the setup-python action, above.
@@ -97,11 +95,9 @@ jobs:
       with:
         path: |
           gams
-          ${{ env.pip-cache-dir }}
           ${{ env.R_LIBS_USER }}
-        key: ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-py${{ matrix.python-version }}-R${{ steps.setup-r.outputs.installed-r-version }}
+        key: ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-R${{ steps.setup-r.outputs.installed-r-version }}
         restore-keys: |
-          ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-py${{ matrix.python-version }}-
           ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}-
           ${{ matrix.os }}-
 


### PR DESCRIPTION
Until numba/numba#8304 is closed by a release that supports Python 3.11, Python 3.10 is the latest we can test/support. This resolves failures of the "nightly" CI workflow, e.g. [here](https://github.com/iiasa/message_ix/actions/runs/3391374683).

Also:
- Use the built-in feature of the first-party actions/setup-python to cache pip packages. The manual usage of actions/cache and related state variables is no longer needed for these.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A; CI changes only
- ~Update release notes.~