### PR TITLE
Expand `levelized_cost` to include `relation_cost`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -19,6 +19,9 @@ All changes
 - Correct calculation of `COST_NODAL_NET` for standalone MESSAGE (:pull:`648`)
 - Account for difference in period-length in equations `NEW_CAPACITY_CONSTRAINT_LO` and `NEW_CAPACITY_CONSTRAINT_UP` (:pull:`654`)
 - Ensure `levelized_cost` are also calculated for technologies with only variable costs (:pull:`653`)
+- Ensure `levelized_cost` are also calculated for technologies with only variable costs (:pull:`653`)
+- Adjust :meth:`.Scenario.add_macro` calculations for pandas 1.5.0 (:pull:`656`).
+- Correct calculation of `COST_NODAL_NET` for standalone MESSAGE (:pull:`648`)
 - Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
 
 .. _v3.6.0:

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,7 +12,7 @@ Migration notes
 
 All changes
 -----------
-
+- Expand `levelized_cost` to include `relation_cost` (:pull:`667`).
 - Adjust default `lpmethod` from "Dual Simplex" (2) to "Barrier" (4); do NOT remove `cplex.opt` file(s) after solving workflow completes (:pull:`657`).
 - Adjust :meth:`.Scenario.add_macro` calculations for pandas 1.5.0 (:pull:`656`).
 - Ensure `levelized_cost` are also calculated for technologies with only variable costs (:pull:`653`).

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -18,6 +18,7 @@ All changes
 - Ensure `levelized_cost` are also calculated for technologies with only variable costs (:pull:`653`).
 - Correct calculation of `COST_NODAL_NET` for standalone MESSAGE (:pull:`648`)
 - Account for difference in period-length in equations `NEW_CAPACITY_CONSTRAINT_LO` and `NEW_CAPACITY_CONSTRAINT_UP` (:pull:`654`)
+- Ensure `levelized_cost` are also calculated for technologies with only variable costs (:pull:`653`)
 - Add additional oscillation detection mechanism for macro iterations (:pull:`645`)
 
 .. _v3.6.0:


### PR DESCRIPTION
This PR resolves issue #667 by adding `relation_cost` to the calculation of `levelized_cost`. It also improves the inline documentation to ensure consistency in index sets.

## How to review

This is a draft at the time being. There will be tests for this when `levelized_cost` can be read back from GDX.

## PR checklist

- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.

