### PR TITLE
Add capability to regenerate observed objective function values

### DIFF
--- a/message_ix/tests/data/README.md
+++ b/message_ix/tests/data/README.md
@@ -1,0 +1,16 @@
+# Nightly Tests
+
+Nightly tests are run based on the `scenario.yaml` file, which contains the scenario specifics and expected objective values.
+
+# Generating observed values
+
+If a change has been made either upstream or to related code (e.g., the GAMS formulation), expected objective values
+may also change. You can regenerate those values with
+
+```
+$ python generate_nightly_test_values.py
+```
+
+Running this assumes you are within the IIASA network and able to connect to the `ixmp_dev` database.
+
+It creates a new YAML file called `scenario_obs.yaml` with a value 'obs' containing the observed objective function value for each scenario. If there is an error, the error message is provided instead.

--- a/message_ix/tests/data/generate_nightly_test_values.py
+++ b/message_ix/tests/data/generate_nightly_test_values.py
@@ -1,0 +1,23 @@
+import yaml
+import ixmp
+import message_ix
+
+with open("./scenarios.yaml", mode="r") as f:
+    d = yaml.safe_load(f)
+
+mp = ixmp.Platform("ixmp_dev")
+
+for name, data in d.items():
+    try:
+        s = message_ix.Scenario(mp, data["model"], data["scenario"])
+        scen = s.clone(
+            scenario=data["scenario"] + "observing_current_obj_value",
+            keep_solution=False,
+        )
+        scen.solve(model=data["solve"], solve_options=data["solve_options"])
+        data["obs"] = scen.var("OBJ")["lvl"]
+    except Exception as e:
+        data["obs"] = "Failed with message: " + str(e)
+
+with open("./scenarios_obs.yaml", mode="w") as f:
+    yaml.safe_dump(d, f)

--- a/message_ix/tests/data/generate_nightly_test_values.py
+++ b/message_ix/tests/data/generate_nightly_test_values.py
@@ -9,7 +9,7 @@ with open("./scenarios.yaml", mode="r") as f:
 mp = ixmp.Platform("ixmp_dev")
 
 for name, data in d.items():
-    print('Testing', data["model"], data["scenario"])
+    print("Testing", data["model"], data["scenario"])
     try:
         s = message_ix.Scenario(mp, data["model"], data["scenario"])
         scen = s.clone(

--- a/message_ix/tests/data/generate_nightly_test_values.py
+++ b/message_ix/tests/data/generate_nightly_test_values.py
@@ -1,6 +1,6 @@
-import yaml
 import ixmp
 import message_ix
+import yaml
 
 with open("./scenarios.yaml", mode="r") as f:
     d = yaml.safe_load(f)

--- a/message_ix/tests/data/generate_nightly_test_values.py
+++ b/message_ix/tests/data/generate_nightly_test_values.py
@@ -1,7 +1,9 @@
-import ixmp
-import message_ix
 import traceback
+
+import ixmp
 import yaml
+
+import message_ix
 
 with open("./scenarios.yaml", mode="r") as f:
     d = yaml.safe_load(f)

--- a/message_ix/tests/data/generate_nightly_test_values.py
+++ b/message_ix/tests/data/generate_nightly_test_values.py
@@ -1,5 +1,6 @@
 import ixmp
 import message_ix
+import traceback
 import yaml
 
 with open("./scenarios.yaml", mode="r") as f:
@@ -8,6 +9,7 @@ with open("./scenarios.yaml", mode="r") as f:
 mp = ixmp.Platform("ixmp_dev")
 
 for name, data in d.items():
+    print('Testing', data["model"], data["scenario"])
     try:
         s = message_ix.Scenario(mp, data["model"], data["scenario"])
         scen = s.clone(
@@ -18,6 +20,7 @@ for name, data in d.items():
         data["obs"] = scen.var("OBJ")["lvl"]
     except Exception as e:
         data["obs"] = "Failed with message: " + str(e)
+        print(traceback.format_exc())
 
 with open("./scenarios_obs.yaml", mode="w") as f:
     yaml.safe_dump(d, f)

--- a/message_ix/tests/data/scenarios.yaml
+++ b/message_ix/tests/data/scenarios.yaml
@@ -19,5 +19,5 @@ CD_Links_SSP2_v2_1000:
     lpmethod: 4
   cases:
   - obs: scen.var('OBJ')['lvl']
-    exp: '3358441.5'
+    exp: '3359089.5'
     test: partial(np.isclose, rtol=3e-6)  # not sure why 1e-6 doesn't work

--- a/message_ix/tests/data/scenarios.yaml
+++ b/message_ix/tests/data/scenarios.yaml
@@ -8,7 +8,7 @@ CD_Links_SSP2_baseline:
     lpmethod: 4
   cases: # Each entry in this list is eval()'d in Python, so must be a string
   - obs: scen.var('OBJ')['lvl']
-    exp: '3870157.5'
+    exp: '3869529.75'
     test: partial(np.isclose, rtol=3e-6)  # not sure why 1e-6 doesn't work
 
 CD_Links_SSP2_v2_1000:
@@ -19,5 +19,5 @@ CD_Links_SSP2_v2_1000:
     lpmethod: 4
   cases:
   - obs: scen.var('OBJ')['lvl']
-    exp: '3359089.5'
+    exp: '3359089.0'
     test: partial(np.isclose, rtol=3e-6)  # not sure why 1e-6 doesn't work


### PR DESCRIPTION
<!--

Delete each of these instruction comments as you complete it.

Title: use a short, declarative statement similar to a commit message,
e.g. “Change [thing X] to [fix solve bug|enable feature Y]”

-->

This PR adds a utility to generate nightly test observed values + documentation.

<!-- Optional: write a longer description to help a reviewer understand the PR in ~3 minutes. -->

## How to review

- read docs
- try local execution

<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- Build the documentation and look at a certain page.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
  <!--
  The following items are all *required* if the PR results in changes to user-
  facing behaviour, e.g. new features or fixes to existing behaviour. They are
  *optional* if the changes are solely to documentation, CI configuration, etc.

  In ambiguous cases, strike them out and add a short explanation, e.g.

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
~- [ ] Add or expand tests; coverage checks both ✅~
- [x] Add, expand, or update documentation.
~- [ ] Update release notes.~
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
