### PR TITLE
Extend user-defined relations to include the index of `time`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -103,6 +103,35 @@ Migration notes
       # Re-use the existing data in `scen`, adding the `mode` dimension
       expand_dims(scen, "storage_initial", mode="an existing mode")
 
+- The index sets of user-defined relations are extended to include sub-annual time slices, i.e., index of `time`.
+  This includes sets (``is_relation_upper`` and ``is_relation_lower``) and parameters (``relation_activity``, ``relation_upper``, ``relation_lower``, and ``relation_cost``).
+  If these items are already populated with data in a Scenario, this data will be incompatible with the MESSAGE GAMS implementation in this release; a :class:`UserWarning` will be emitted when the :class:`.Scenario` is instantiated, and :meth:`~.message_ix.Scenario.solve` will raise a :class:`ValueError`.
+  (If these items are empty, their dimensions will be updated automatically, and new Scenarios are unaffected.)
+
+  Data for these items must be updated as follows:
+
+  ==========================  ============================================
+  Existing parameter or set   Dimension to add
+  ==========================  ============================================
+  ``relation_activity``         ``time``
+  ``relation_upper``            ``time``
+  ``relation_lower``            ``time``
+  ``relation_cost``             ``time``
+  ``is_relation_lower``         ``time``
+  ``is_relation_upper``         ``time``
+  ==========================  ============================================
+
+  For extending the dimensionality of these items, :func:`.expand_dims` can help:
+
+  .. code-block:: python
+
+      from message_ix import Scenario
+      from message_ix.util import expand_dims
+
+      scen, platform = Scenario.from_url("…")
+
+      # Re-use the existing data in `scen`, adding the `time` dimension of "year"
+      expand_dims(scen, "relation_activity", time="year")
 
 All changes
 -----------

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -137,6 +137,7 @@ All changes
 -----------
 
 - Add a tutorial for Westeros multi-node and different trade possibilities (:pull:`683`).
+- Extend user-defined relations to include the index of time (:pull:`680`).
 - Add additional oscillation detection mechanism for macro iterations (:pull:`645`, :pull:`676`)
 - Adjust default `lpmethod` from "Dual Simplex" (2) to "Barrier" (4); do NOT remove `cplex.opt` file(s) after solving workflow completes (:pull:`657`).
 - Adjust :meth:`.Scenario.add_macro` calculations for pandas 1.5.0 (:pull:`656`).

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -80,7 +80,7 @@ fixed_extraction, fixed_stock, fixed_new_capacity, fixed_capacity, fixed_activit
 * storage parameters
 storage_initial, storage_self_discharge, time_order
 * time-related relation parameters and mappings
-is_relation_upper_time, is_relation_lower_time, relation_activity_time, relation_upper_time, relation_lower_time
+is_relation_upper_time, is_relation_lower_time, relation_activity_time, relation_upper_time, relation_lower_time, relation_cost_time
 ;
 
 

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -117,12 +117,12 @@ duration_time_rel(time,time2)$( map_time(time,time2) ) = duration_time(time2) / 
 * making duration_time_rel equal to 1, i.e., a consistent unit for ACT in sub-annual time slices, for parent 'time' not specified in set 'time_relative'
 duration_time_rel(time,time2)$( Not time_relative(time) ) = 1 ;
 
-* add the mapping of new timeslice-related parameters to existing mappings
-* Note: such mapping sets are generated in backend, and this one should be added to them or be done in python.
+* add the mapping of new time slice-related parameters to existing mappings
+* Note: such mapping sets are typically generated at the Java backend, and this one should be added to the existing ones or to a new solution implemented in python.
 map_tec_relation(node,relation,tec,year_all,mode,time)$(sum( (node2,year_all2),
     relation_activity_time(relation,node2,year_all,node,tec,year_all2,mode,time) ) ) = yes;
 
-* update mapping sets based on new relations defined at the sub-annual timeslice level
+* update mapping sets based on new relations defined at the sub-annual time slice level
 map_tec(node,tec,year_all)$(sum( (relation,mode,time), map_tec_relation(node,relation,tec,year_all,mode,time) ) ) = yes;
 map_tec_mode(node,tec,year_all,mode)$(sum( (relation,time), map_tec_relation(node,relation,tec,year_all,mode,time) ) ) = yes;
 map_tec_time(node,tec,year_all,time)$(sum( (relation,mode), map_tec_relation(node,relation,tec,year_all,mode,time) ) ) = yes;
@@ -196,19 +196,19 @@ map_time_period(year_all,lvl_temporal,time,time2)$( time_order(lvl_temporal,time
 * mapping of sequence of the last sub-annual time slice to the first to create a close the order of time slices
 map_time_period(year_all,lvl_temporal,time,time2)$( time_order(lvl_temporal,time) AND
      time_order(lvl_temporal,time) = SMAX(time3,time_order(lvl_temporal,time3) ) AND time_order(lvl_temporal,time2) = 1 ) = yes;
-* mapping of relations that should be accounted at 'year' even with sub-annual timeslices
+* mapping of relations that should be accounted at 'year' even with sub-annual time slices
 map_relation_year(relation,node,year_all,time)$(
     SUM( (node2,year_all2,tec,mode), relation_activity_time(relation,node,year_all,node2,tec,year_all2,mode,time)
     ) AND ( duration_time(time) = 1 )  ) = yes;
 
-* including those with only activity at timeslice, but relation at 'year' level
+* including those with only activity at time slice, but relation at 'year' level
 map_relation_year(relation,node,year_all,'year')$( is_relation_upper_time(relation,node,year_all,'year') OR
     is_relation_lower_time(relation,node,year_all,'year')  ) = yes;
 
 * mapping set of relations at 'year' level
 relation_year(relation)$( SUM( (node,year_all,time), map_relation_year(relation,node,year_all,time) ) ) = yes;
 
-* mapping of relations that should be accounted at subannual timeslices
+* mapping of relations that should be accounted at the subannual time slice level
 map_relation_time(relation,node,year_all,time)$(
     SUM( (node2,year_all2,tec,mode), relation_activity_time(relation,node,year_all,node2,tec,year_all2,mode,time)
     ) AND NOT relation_year(relation) ) = yes;

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -79,6 +79,8 @@ is_fixed_extraction, is_fixed_stock, is_fixed_new_capacity, is_fixed_capacity, i
 fixed_extraction, fixed_stock, fixed_new_capacity, fixed_capacity, fixed_activity, fixed_land
 * storage parameters
 storage_initial, storage_self_discharge, time_order
+* time-related relation parameters and mappings
+is_relation_upper_time, is_relation_lower_time, relation_activity_time, relation_upper_time, relation_lower_time
 ;
 
 
@@ -114,6 +116,16 @@ $INCLUDE includes/period_parameter_assignment.gms
 duration_time_rel(time,time2)$( map_time(time,time2) ) = duration_time(time2) / duration_time(time) ;
 * making duration_time_rel equal to 1, i.e., a consistent unit for ACT in sub-annual time slices, for parent 'time' not specified in set 'time_relative'
 duration_time_rel(time,time2)$( Not time_relative(time) ) = 1 ;
+
+* add the mapping of new timeslice-related parameters to existing mappings
+* Note: such mapping sets are generated in backend, and this one should be added to them or be done in python.
+map_tec_relation(node,relation,tec,year_all,mode,time)$(sum( (node2,year_all2),
+    relation_activity_time(relation,node2,year_all,node,tec,year_all2,mode,time) ) ) = yes;
+
+* update mapping sets based on new relations defined at the sub-annual timeslice level
+map_tec(node,tec,year_all)$(sum( (relation,mode,time), map_tec_relation(node,relation,tec,year_all,mode,time) ) ) = yes;
+map_tec_mode(node,tec,year_all,mode)$(sum( (relation,time), map_tec_relation(node,relation,tec,year_all,mode,time) ) ) = yes;
+map_tec_time(node,tec,year_all,time)$(sum( (relation,mode), map_tec_relation(node,relation,tec,year_all,mode,time) ) ) = yes;
 
 * assign an additional mapping set for technologies to nodes, modes and subannual time slices (for shorter reference)
 map_tec_act(node,tec,year_all,mode,time)$( map_tec_time(node,tec,year_all,time) AND
@@ -184,6 +196,22 @@ map_time_period(year_all,lvl_temporal,time,time2)$( time_order(lvl_temporal,time
 * mapping of sequence of the last sub-annual time slice to the first to create a close the order of time slices
 map_time_period(year_all,lvl_temporal,time,time2)$( time_order(lvl_temporal,time) AND
      time_order(lvl_temporal,time) = SMAX(time3,time_order(lvl_temporal,time3) ) AND time_order(lvl_temporal,time2) = 1 ) = yes;
+* mapping of relations that should be accounted at 'year' even with sub-annual timeslices
+map_relation_year(relation,node,year_all,time)$(
+    SUM( (node2,year_all2,tec,mode), relation_activity_time(relation,node,year_all,node2,tec,year_all2,mode,time)
+    ) AND ( duration_time(time) = 1 )  ) = yes;
+
+* including those with only activity at timeslice, but relation at 'year' level
+map_relation_year(relation,node,year_all,'year')$( is_relation_upper_time(relation,node,year_all,'year') OR
+    is_relation_lower_time(relation,node,year_all,'year')  ) = yes;
+
+* mapping set of relations at 'year' level
+relation_year(relation)$( SUM( (node,year_all,time), map_relation_year(relation,node,year_all,time) ) ) = yes;
+
+* mapping of relations that should be accounted at subannual timeslices
+map_relation_time(relation,node,year_all,time)$(
+    SUM( (node2,year_all2,tec,mode), relation_activity_time(relation,node,year_all,node2,tec,year_all2,mode,time)
+    ) AND NOT relation_year(relation) ) = yes;
 *----------------------------------------------------------------------------------------------------------------------*
 * sanity checks on the data set                                                                                        *
 *----------------------------------------------------------------------------------------------------------------------*

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -28,32 +28,33 @@
 *
 * Decision variables
 * ^^^^^^^^^^^^^^^^^^
-* =============================================================== ====================================================================================
-* Variable                                                        Explanatory text
-* =============================================================== ====================================================================================
-* :math:`\text{OBJ} \in \mathbb{R}`                               Objective value of the optimization program
-* :math:`\text{EXT}_{n,c,g,y} \in \mathbb{R}_+`                   Extraction of non-renewable/exhaustible resources from reserves
-* :math:`\text{STOCK}_{n,c,l,y} \in \mathbb{R}_+`                 Quantity in stock (storage) at start of period :math:`y`
-* :math:`\text{STOCK_CHG}_{n,c,l,y,h} \in \mathbb{R}`             Input or output quantity into intertemporal commodity stock (storage)
-* :math:`\text{COST_NODAL}_{n,y} \in \mathbb{R}`                  System costs at the node level over time
-* :math:`\text{REN}_{n,t,c,g,y,h} \in \mathbb{R}_+`               Activity of renewable technologies per grade
-* :math:`\text{CAP_NEW}_{n,t,y} \in \mathbb{R}_+`                 Newly installed capacity (yearly average over period duration)
-* :math:`\text{CAP}_{n,t,y^V,y} \in \mathbb{R}_+`                 Maintained capacity in year :math:`y` of vintage :math:`y^V`
-* :math:`\text{CAP_FIRM}_{n,t,c,l,y,q} \in \mathbb{R}_+`          Capacity counting towards firm (dispatchable)
-* :math:`\text{ACT}_{n,t,y^V,y,m,h} \in \mathbb{R}`               Activity of a technology (by vintage, mode, subannual time)
-* :math:`\text{ACT_RATING}_{n,t,y^V,y,c,l,h,q} \in \mathbb{R}_+`  Auxiliary variable for activity attributed to a particular rating bin [#ACT_RATING]_
-* :math:`\text{CAP_NEW_UP}_{n,t,y} \in \mathbb{R}_+`              Relaxation of upper dynamic constraint on new capacity
-* :math:`\text{CAP_NEW_LO}_{n,t,y} \in \mathbb{R}_+`              Relaxation of lower dynamic constraint on new capacity
-* :math:`\text{ACT_UP}_{n,t,y,h} \in \mathbb{R}_+`                Relaxation of upper dynamic constraint on activity [#ACT_BD]_
-* :math:`\text{ACT_LO}_{n,t,y,h} \in \mathbb{R}_+`                Relaxation of lower dynamic constraint on activity [#ACT_BD]_
-* :math:`\text{LAND}_{n,s,y} \in [0,1]`                           Relative share of land-use scenario (for land-use model emulator)
-* :math:`\text{EMISS}_{n,e,\widehat{t},y} \in \mathbb{R}`         Auxiliary variable for aggregate emissions by technology type
-* :math:`\text{REL}_{r,n,y} \in \mathbb{R}`                       Auxiliary variable for left-hand side of relations (linear constraints)
-* :math:`\text{COMMODITY_USE}_{n,c,l,y} \in \mathbb{R}`           Auxiliary variable for amount of commodity used at specific level
-* :math:`\text{COMMODITY_BALANCE}_{n,c,l,y,h} \in \mathbb{R}`     Auxiliary variable for right-hand side of :ref:`commodity_balance`
-* :math:`\text{STORAGE}_{n,t,m,l,c,y,h} \in \mathbb{R}`           State of charge or content of storage at each sub-annual time slice
-* :math:`\text{STORAGE_CHARGE}_{n,t,m,l,c,y,h} \in \mathbb{R}`    Charging of storage in each sub-annual time slice (negative for discharging)
-* =============================================================== ====================================================================================
+* ======================================================== ====================================================================================
+* Variable                                                 Explanatory text
+* ======================================================== ====================================================================================
+* :math:`OBJ \in \mathbb{R}`                               Objective value of the optimization program
+* :math:`EXT_{n,c,g,y} \in \mathbb{R}_+`                   Extraction of non-renewable/exhaustible resources from reserves
+* :math:`STOCK_{n,c,l,y} \in \mathbb{R}_+`                 Quantity in stock (storage) at start of period :math:`y`
+* :math:`STOCK\_CHG_{n,c,l,y,h} \in \mathbb{R}`            Input or output quantity into intertemporal commodity stock (storage)
+* :math:`COST\_NODAL_{n,y} \in \mathbb{R}`                 System costs at the node level over time
+* :math:`REN_{n,t,c,g,y,h} \in \mathbb{R}_+`               Activity of renewable technologies per grade
+* :math:`CAP\_NEW_{n,t,y} \in \mathbb{R}_+`                Newly installed capacity (yearly average over period duration)
+* :math:`CAP_{n,t,y^V,y} \in \mathbb{R}_+`                 Maintained capacity in year :math:`y` of vintage :math:`y^V`
+* :math:`CAP\_FIRM_{n,t,c,l,y,q} \in \mathbb{R}_+`         Capacity counting towards firm (dispatchable)
+* :math:`ACT_{n,t,y^V,y,m,h} \in \mathbb{R}`               Activity of a technology (by vintage, mode, subannual time)
+* :math:`ACT\_RATING_{n,t,y^V,y,c,l,h,q} \in \mathbb{R}_+` Auxiliary variable for activity attributed to a particular rating bin [#ACT_RATING]_
+* :math:`CAP\_NEW\_UP_{n,t,y} \in \mathbb{R}_+`            Relaxation of upper dynamic constraint on new capacity
+* :math:`CAP\_NEW\_LO_{n,t,y} \in \mathbb{R}_+`            Relaxation of lower dynamic constraint on new capacity
+* :math:`ACT\_UP_{n,t,y,h} \in \mathbb{R}_+`               Relaxation of upper dynamic constraint on activity [#ACT_BD]_
+* :math:`ACT\_LO_{n,t,y,h} \in \mathbb{R}_+`               Relaxation of lower dynamic constraint on activity [#ACT_BD]_
+* :math:`LAND_{n,s,y} \in [0,1]`                           Relative share of land-use scenario (for land-use model emulator)
+* :math:`EMISS_{n,e,\widehat{t},y} \in \mathbb{R}`         Auxiliary variable for aggregate emissions by technology type
+* :math:`REL_{r,n,y} \in \mathbb{R}`                       Auxiliary variable for left-hand side of relations (linear constraints)
+* :math:`REL\_TIME_{r,n,y,h} \in \mathbb{R}`               Auxiliary variable for left-hand side of relations (linear constraints) at each subannual timeslice
+* :math:`COMMODITY\_USE_{n,c,l,y} \in \mathbb{R}`          Auxiliary variable for amount of commodity used at specific level
+* :math:`COMMODITY\_BALANCE_{n,c,l,y,h} \in \mathbb{R}`    Auxiliary variable for right-hand side of :ref:`commodity_balance`
+* :math:`STORAGE_{n,t,m,l,c,y,h} \in \mathbb{R}`             State of charge or content of storage at each sub-annual time slice
+* :math:`STORAGE\_CHARGE_{n,t,m,l,c,y,h} \in \mathbb{R}`     Charging of storage in each sub-annual time slice (negative for discharging)
+* ======================================================== ====================================================================================
 *
 * The index :math:`y^V` is the year of construction (vintage) wherever it is necessary to
 * clearly distinguish between year of construction and the year of operation.
@@ -122,6 +123,8 @@ Variables
     EMISS(node,emission,type_tec,year_all)       aggregate emissions by technology type and land-use model emulator
 * auxiliary variable for left-hand side of relations (linear constraints)
     REL(relation,node,year_all)                  auxiliary variable for left-hand side of user-defined relations
+* time-related auxiliary variable for left-hand side of relations (linear constraints)
+    REL_TIME(relation,node,year_all,time)                  auxiliary variable for left-hand side of user-defined relations
 * change in the content of storage device
     STORAGE_CHARGE(node,tec,mode,level,commodity,year_all,time)    charging of storage in each time slice (negative for discharge)
 ;
@@ -226,6 +229,8 @@ Positive variables
     SLACK_LAND_TYPE_LO(node,year_all,land_type)       slack variable for dynamic land type constraint relaxation (downwards)
     SLACK_RELATION_BOUND_UP(relation,node,year_all)   slack variable for upper bound of generic relation
     SLACK_RELATION_BOUND_LO(relation,node,year_all)   slack variable for lower bound of generic relation
+    SLACK_RELATION_BOUND_UP_TIME(relation,node,year_all,time)   slack variable for upper bound of generic relation with subannual timestep
+    SLACK_RELATION_BOUND_LO_TIME(relation,node,year_all,time)   slack variable for lower bound of generic relation with subannual timestep
 ;
 
 *----------------------------------------------------------------------------------------------------------------------*
@@ -293,6 +298,10 @@ Equations
     STORAGE_BALANCE                 balance of the state of charge of storage
     STORAGE_BALANCE_INIT            balance of the state of charge of storage at sub-annual time slices with initial storage content
     STORAGE_INPUT                   connecting an input commodity to maintain the activity of storage container (not stored commodity)
+    RELATION_EQUIVALENCE_TIME       time dependent auxiliary equation to simplify the implementation of relations
+    RELATION_EQUIVALENCE_YEAR       time dependent auxiliary equation to simplify the implementation of relations at year level
+    RELATION_CONSTRAINT_UP_TIME     time dependentupper bound of relations (linear constraints)
+    RELATION_CONSTRAINT_LO_TIME     time dependent lower bound of relations (linear constraints)
 ;
 *----------------------------------------------------------------------------------------------------------------------*
 * equation statements                                                                                                  *
@@ -416,6 +425,10 @@ COST_ACCOUNTING_NODAL(node, year)..
 * cost terms associated with linear relations
     + SUM(relation$( relation_cost(relation,node,year) ),
         relation_cost(relation,node,year) * REL(relation,node,year) )
+* cost terms associated with linear relations on sub-annual timeslice level
+    + SUM((relation,time)$( relation_cost(relation,node,year) AND
+          (map_relation_time(relation,node,year,time) OR map_relation_year(relation,node,year,time) ) ),
+        relation_cost(relation,node,year) * REL_TIME(relation,node,year,time ) )
 * implementation of slack variables for constraints to aid in debugging
     + SUM((commodity,level,time)$( map_commodity(node,commodity,level,year,time) ), ( 0
 %SLACK_COMMODITY_EQUIVALENCE%   + SLACK_COMMODITY_EQUIVALENCE_UP(node,commodity,level,year,time)
@@ -448,6 +461,10 @@ COST_ACCOUNTING_NODAL(node, year)..
     + SUM((relation), 0
 %SLACK_RELATION_BOUND_UP% + 1e6 * SLACK_RELATION_BOUND_UP(relation,node,year)$( is_relation_upper(relation,node,year) )
 %SLACK_RELATION_BOUND_LO% + 1e6 * SLACK_RELATION_BOUND_LO(relation,node,year)$( is_relation_lower(relation,node,year) )
+        )
+    + SUM((relation,time), 0
+%SLACK_RELATION_BOUND_UP_TIME% + 1e6 * SLACK_RELATION_BOUND_UP_TIME(relation,node,year,time)
+%SLACK_RELATION_BOUND_LO_TIME% + 1e6 * SLACK_RELATION_BOUND_LO_TIME(relation,node,year,time)
         )
 ;
 
@@ -2146,6 +2163,91 @@ RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,yea
     REL(relation,node,year)
 %SLACK_RELATION_BOUND_LO% + SLACK_RELATION_BOUND_LO(relation,node,year)
     =G= relation_lower(relation,node,year) ;
+
+* Section of generic relations (linear constraints) with sub-annual timeslices
+* -------------------------------------------------
+*
+* This feature is intended for development and testing only for addressing sub-annual timeslices!
+*
+* Auxiliary variable for left-hand side
+* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+*
+* .. _equation_relation_equivalence_time:
+*
+* Equation RELATION_EQUIVALENCE_TIME
+* """""""""""""""""""""""""""""
+*   .. math::
+*      REL\_TIME_{r,n,y,h} = \sum_{t} \Bigg(
+*          & \ relation\_new\_capacity_{r,n,y,t} \cdot CAP\_NEW_{n,t,y} \\[4 pt]
+*          & + relation\_total\_capacity_{r,n,y,t} \cdot \sum_{y^V \leq y} \ CAP_{n,t,y^V,y} \\
+*          & + \sum_{n^L,y',m} \ relation\_activity\_time_{r,n,y,n^L,t,y',m,h} \\
+*          & \quad \quad \cdot \Big( \sum_{y^V \leq y'} ACT_{n^L,t,y^V,y',m,h}
+*                              + historical\_activity_{n^L,t,y',m,h} \Big) \Bigg)
+*
+* The parameter :math:`historical\_new\_capacity_{r,n,y}` is not included here, because relations can only be active
+* in periods included in the model horizon and there is no "writing" of capacity relation factors across periods.
+***
+RELATION_EQUIVALENCE_TIME(relation,node,year,time)$( map_relation_time(relation,node,year,time) )..
+    REL_TIME(relation,node,year,time)
+        =E=
+        SUM(tec,
+        ( relation_new_capacity(relation,node,year,tec) * CAP_NEW(node,tec,year)
+          + relation_total_capacity(relation,node,year,tec)
+            * SUM(vintage$( map_tec_lifetime(node,tec,vintage,year) ), CAP(node,tec,vintage,year) )
+          )$( inv_tec(tec) )
+        + SUM( (location,year_all2,mode)$( map_relation_time(relation,location,year_all2,time) ),
+            relation_activity_time(relation,node,year,location,tec,year_all2,mode,time)
+            * ( SUM(vintage$( map_tec_lifetime(location,tec,vintage,year_all2) ),
+                  ACT(location,tec,vintage,year_all2,mode,time) )
+                  + historical_activity(location,tec,year_all2,mode,time) )
+          )
+      ) ;
+
+* Linear relations of sub-annual timeslice that is accounted at 'year' level
+RELATION_EQUIVALENCE_YEAR(relation,node,year)$( sum (time, map_relation_year(relation,node,year,time) ) )..
+    REL_TIME(relation,node,year,'year')
+        =E=
+        SUM(tec,
+        ( relation_new_capacity(relation,node,year,tec) * CAP_NEW(node,tec,year)
+          + relation_total_capacity(relation,node,year,tec)
+            * SUM(vintage$( map_tec_lifetime(node,tec,vintage,year) ), CAP(node,tec,vintage,year) )
+          )$( inv_tec(tec) )
+        + SUM( (location,year_all2,mode,time) ,
+            relation_activity_time(relation,node,year,location,tec,year_all2,mode,time)
+            * ( SUM(vintage$( map_tec_lifetime(location,tec,vintage,year_all2) ),
+                  ACT(location,tec,vintage,year_all2,mode,time) )
+                  + historical_activity(location,tec,year_all2,mode,time) )
+          )
+      ) ;
+
+***
+* Upper and lower bounds on user-defined relations with sub-annual timeslices
+* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+*
+* .. _equation_relation_constraint_up_time:
+*
+* Equation RELATION_CONSTRAINT_UP_TIME
+* """"""""""""""""""""""""""""""""""""
+*   .. math::
+*      REL\_TIME_{r,n,y,h} \leq relation\_upper\_time_{r,n,y,h}
+***
+RELATION_CONSTRAINT_UP_TIME(relation,node,year,time)$( is_relation_upper_time(relation,node,year,time) )..
+    REL_TIME(relation,node,year,time)
+%SLACK_RELATION_BOUND_UP_TIME% - SLACK_RELATION_BOUND_UP_TIME(relation,node,year,time)
+    =L= relation_upper_time(relation,node,year,time) ;
+
+***
+* .. _equation_relation_constraint_lo_time:
+*
+* Equation RELATION_CONSTRAINT_LO_TIME
+* """"""""""""""""""""""""""""""""""""
+*   .. math::
+*      REL\_TIME_{r,n,y,h} \geq relation\_lower\_time_{r,n,y,h}
+***
+RELATION_CONSTRAINT_LO_TIME(relation,node,year,time)$( is_relation_lower_time(relation,node,year,time) )..
+    REL_TIME(relation,node,year,time)
+%SLACK_RELATION_BOUND_LO_TIME% + SLACK_RELATION_BOUND_LO_TIME(relation,node,year,time)
+    =G= relation_lower_time(relation,node,year,time) ;
 
 *----------------------------------------------------------------------------------------------------------------------*
 ***

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -428,7 +428,7 @@ COST_ACCOUNTING_NODAL(node, year)..
 * cost terms associated with linear relations at the sub-annual time slice level
     + SUM((relation,time)$( relation_cost(relation,node,year) AND
           (map_relation_time(relation,node,year,time) OR map_relation_year(relation,node,year,time) ) ),
-        relation_cost(relation,node,year) * REL_TIME(relation,node,year,time ) )
+        relation_cost_time(relation,node,year,time) * REL_TIME(relation,node,year,time ) )
 * implementation of slack variables for constraints to aid in debugging
     + SUM((commodity,level,time)$( map_commodity(node,commodity,level,year,time) ), ( 0
 %SLACK_COMMODITY_EQUIVALENCE%   + SLACK_COMMODITY_EQUIVALENCE_UP(node,commodity,level,year,time)

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -49,7 +49,7 @@
 * :math:`LAND_{n,s,y} \in [0,1]`                           Relative share of land-use scenario (for land-use model emulator)
 * :math:`EMISS_{n,e,\widehat{t},y} \in \mathbb{R}`         Auxiliary variable for aggregate emissions by technology type
 * :math:`REL_{r,n,y} \in \mathbb{R}`                       Auxiliary variable for left-hand side of relations (linear constraints)
-* :math:`REL\_TIME_{r,n,y,h} \in \mathbb{R}`               Auxiliary variable for left-hand side of relations (linear constraints) at each subannual timeslice
+* :math:`REL\_TIME_{r,n,y,h} \in \mathbb{R}`               Auxiliary variable for left-hand side of relations (linear constraints) at each subannual time slice
 * :math:`COMMODITY\_USE_{n,c,l,y} \in \mathbb{R}`          Auxiliary variable for amount of commodity used at specific level
 * :math:`COMMODITY\_BALANCE_{n,c,l,y,h} \in \mathbb{R}`    Auxiliary variable for right-hand side of :ref:`commodity_balance`
 * :math:`STORAGE_{n,t,m,l,c,y,h} \in \mathbb{R}`             State of charge or content of storage at each sub-annual time slice
@@ -229,8 +229,8 @@ Positive variables
     SLACK_LAND_TYPE_LO(node,year_all,land_type)       slack variable for dynamic land type constraint relaxation (downwards)
     SLACK_RELATION_BOUND_UP(relation,node,year_all)   slack variable for upper bound of generic relation
     SLACK_RELATION_BOUND_LO(relation,node,year_all)   slack variable for lower bound of generic relation
-    SLACK_RELATION_BOUND_UP_TIME(relation,node,year_all,time)   slack variable for upper bound of generic relation with subannual timestep
-    SLACK_RELATION_BOUND_LO_TIME(relation,node,year_all,time)   slack variable for lower bound of generic relation with subannual timestep
+    SLACK_RELATION_BOUND_UP_TIME(relation,node,year_all,time)   slack variable for upper bound of generic relation with subannual time slice
+    SLACK_RELATION_BOUND_LO_TIME(relation,node,year_all,time)   slack variable for lower bound of generic relation with subannual time slice
 ;
 
 *----------------------------------------------------------------------------------------------------------------------*
@@ -425,7 +425,7 @@ COST_ACCOUNTING_NODAL(node, year)..
 * cost terms associated with linear relations
     + SUM(relation$( relation_cost(relation,node,year) ),
         relation_cost(relation,node,year) * REL(relation,node,year) )
-* cost terms associated with linear relations on sub-annual timeslice level
+* cost terms associated with linear relations at the sub-annual time slice level
     + SUM((relation,time)$( relation_cost(relation,node,year) AND
           (map_relation_time(relation,node,year,time) OR map_relation_year(relation,node,year,time) ) ),
         relation_cost(relation,node,year) * REL_TIME(relation,node,year,time ) )
@@ -2164,10 +2164,10 @@ RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,yea
 %SLACK_RELATION_BOUND_LO% + SLACK_RELATION_BOUND_LO(relation,node,year)
     =G= relation_lower(relation,node,year) ;
 
-* Section of generic relations (linear constraints) with sub-annual timeslices
+* Section of generic relations (linear constraints) with sub-annual time slices
 * -------------------------------------------------
 *
-* This feature is intended for development and testing only for addressing sub-annual timeslices!
+* This feature is intended for development and testing only for addressing sub-annual time slices!
 *
 * Auxiliary variable for left-hand side
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2203,7 +2203,7 @@ RELATION_EQUIVALENCE_TIME(relation,node,year,time)$( map_relation_time(relation,
           )
       ) ;
 
-* Linear relations of sub-annual timeslice that is accounted at 'year' level
+* Linear relations of the sub-annual time slice that is accounted at the 'year' level
 RELATION_EQUIVALENCE_YEAR(relation,node,year)$( sum (time, map_relation_year(relation,node,year,time) ) )..
     REL_TIME(relation,node,year,'year')
         =E=
@@ -2221,7 +2221,7 @@ RELATION_EQUIVALENCE_YEAR(relation,node,year)$( sum (time, map_relation_year(rel
       ) ;
 
 ***
-* Upper and lower bounds on user-defined relations with sub-annual timeslices
+* Upper and lower bounds on user-defined relations with sub-annual time slices
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *
 * .. _equation_relation_constraint_up_time:

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -2367,7 +2367,7 @@ STORAGE_BALANCE_INIT(node,storage_tec,mode,level,commodity,year,time,time2)$ (
         AND map_time_period(year,lvl_temporal,time,time2) )
     AND storage_initial(node,storage_tec,mode,level,commodity,year,time2) )..
 * Showing the state of charge of storage at a time slice prior to a time slice that has initial storage content
-    STORAGE(node,storage_tec,mode,level,commodity,year,time) =G=
+    STORAGE(node,storage_tec,mode,level,commodity,year,time) =L=
 * Initial content of storage in the examined time slice as a percentage multiplier in available capacity of storage
         storage_initial(node,storage_tec,mode,level,commodity,year,time2)
         * SUM(vintage$( map_tec_lifetime(node,storage_tec,vintage,year) ), capacity_factor(node,storage_tec,vintage,year,time2)

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -145,7 +145,7 @@ Variables
 * =========================================================================== ======================================================================================================
 *
 * .. warning::
-*    Please be aware that transitioning from one period length to another for consecutive periods may result in false values of :math:`\text{PRICE_EMISSION}`. 
+*    Please be aware that transitioning from one period length to another for consecutive periods may result in false values of :math:`\text{PRICE_EMISSION}`.
 *    Please see `this issue <https://github.com/iiasa/message_ix/issues/723>`_ for further information. We are currently working on a fix.
 ***
 
@@ -426,7 +426,7 @@ COST_ACCOUNTING_NODAL(node, year)..
     + SUM(relation$( relation_cost(relation,node,year) ),
         relation_cost(relation,node,year) * REL(relation,node,year) )
 * cost terms associated with linear relations at the sub-annual time slice level
-    + SUM((relation,time)$( relation_cost(relation,node,year) AND
+    + SUM((relation,time)$( relation_cost_time(relation,node,year,time) AND
           (map_relation_time(relation,node,year,time) OR map_relation_year(relation,node,year,time) ) ),
         relation_cost_time(relation,node,year,time) * REL_TIME(relation,node,year,time ) )
 * implementation of slack variables for constraints to aid in debugging

--- a/message_ix/model/MESSAGE/model_setup.gms
+++ b/message_ix/model/MESSAGE/model_setup.gms
@@ -57,6 +57,9 @@ $IF NOT SET SLACK_LAND_TYPE_LO       $SETGLOBAL SLACK_LAND_TYPE_LO "*"
 $IF NOT SET SLACK_RELATION_BOUND_UP  $SETGLOBAL SLACK_RELATION_BOUND_UP "*"
 $IF NOT SET SLACK_RELATION_BOUND_LO  $SETGLOBAL SLACK_RELATION_BOUND_LO "*"
 
+$IF NOT SET SLACK_RELATION_BOUND_UP_TIME  $SETGLOBAL SLACK_RELATION_BOUND_UP_TIME  "*"
+$IF NOT SET SLACK_RELATION_BOUND_LO_TIME  $SETGLOBAL SLACK_RELATION_BOUND_LO_TIME  "*"
+
 *----------------------------------------------------------------------------------------------------------------------*
 * initialize sets, mappings, parameters, load data, do pre-processing                                                  *
 *----------------------------------------------------------------------------------------------------------------------*

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -415,7 +415,7 @@ Parameters
 *
 * The |MESSAGEix| formulation includes "storage" solutions to model sub-annual, inter-temporal storage of commodities in each period.
 * This feature can be used to model electricity storage (pumped hydro, batteries, compressed air energy storage, etc.), thermal energy storage,
-* demand side management, and in general any technology for storing commodities (gas, hydrogen, water, etc.) over sub-annual timesteps.
+* demand side management, and in general any technology for storing commodities (gas, hydrogen, water, etc.) over sub-annual time slices.
 * The user defines the chronological order of sub-annual time slices by assigning a number to them in parameter ``time_order``.
 * This order is used by storage equations to shift the stored commodity in a correct timeline, e.g., from Jan through to Dec, and not vice versa.
 * The last sub-annual time slice is linked to the first one to close the loop of the year. Parameter ``storage_initial`` is to set an initial amount
@@ -781,7 +781,7 @@ Parameters
     relation_activity(relation,node,year_all,node,tec,year_all,mode) activity factor (multiplier) of generic relation
     relation_upper_time(relation,node,year_all,time)    time-related upper bound of generic relation
     relation_lower_time(relation,node,year_all,time)    time-related lower bound of generic relation
-    relation_activity_time(relation,node,year_all,node,tec,year_all,mode,time) time-related activity factor (multiplier) of generic relation	
+    relation_activity_time(relation,node,year_all,node,tec,year_all,mode,time) time-related activity factor (multiplier) of generic relation
 ;
 
 *----------------------------------------------------------------------------------------------------------------------*

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -779,6 +779,9 @@ Parameters
     relation_new_capacity(relation,node,year_all,tec)   new capacity factor (multiplier) of generic relation
     relation_total_capacity(relation,node,year_all,tec) total capacity factor (multiplier) of generic relation
     relation_activity(relation,node,year_all,node,tec,year_all,mode) activity factor (multiplier) of generic relation
+    relation_upper_time(relation,node,year_all,time)    time-related upper bound of generic relation
+    relation_lower_time(relation,node,year_all,time)    time-related lower bound of generic relation
+    relation_activity_time(relation,node,year_all,node,tec,year_all,mode,time) time-related activity factor (multiplier) of generic relation	
 ;
 
 *----------------------------------------------------------------------------------------------------------------------*

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -781,6 +781,7 @@ Parameters
     relation_activity(relation,node,year_all,node,tec,year_all,mode) activity factor (multiplier) of generic relation
     relation_upper_time(relation,node,year_all,time)    time-related upper bound of generic relation
     relation_lower_time(relation,node,year_all,time)    time-related lower bound of generic relation
+    relation_cost_time(relation,node,year_all,time)     cost of investment and activities included in generic relation with sub-annual time slices
     relation_activity_time(relation,node,year_all,node,tec,year_all,mode,time) time-related activity factor (multiplier) of generic relation
 ;
 

--- a/message_ix/model/MESSAGE/sets_maps_def.gms
+++ b/message_ix/model/MESSAGE/sets_maps_def.gms
@@ -308,7 +308,7 @@ Sets
     type_tec_land(type_tec)                 dynamic set whether emissions from land use are included in type_tec
     balance_equality(commodity,level)       mapping of commodities-level where the supply-demand balance must be maintained with equality
     time_relative(time)                     flag for treating unit of ACT in sub-annual time slices relative to parent 'time' (activating parameter 'duration_time_rel')
-	relation_year(relation)                 set of relations accounted at 'year' level
+    relation_year(relation)                 set of relations accounted at the 'year' level
 ;
 
 Alias(type_tec,type_tec_share);
@@ -343,7 +343,7 @@ Alias(type_tec,type_tec_total);
 *    * - map_time(time,time2)
 *      - Mapping of time periods across hierarchy levels (time2 is in time)
 *    * - map_time_period(year_all,lvl_temporal,time,time2)
-*      - Mapping of the sequence of sub-annual timeslices (used in :ref:`storage <gams-storage>`)
+*      - Mapping of the sequence of sub-annual time slices (used in :ref:`storage <gams-storage>`)
 *    * - map_resource(node,commodity,grade,year_all)
 *      - Mapping of resources and grades to node over time
 *    * - map_ren_grade(node,commodity,grade,year_all)
@@ -399,9 +399,9 @@ Sets
 
     map_land(node,land_scenario,year_all)            mapping of land-use model emulator scenarios to nodes and years
     map_relation(relation,node,year_all)             mapping of generic (user-defined) relations to nodes and years
-    map_relation_time(relation,node,year_all,time)             mapping of relations that should be accounted at subannual timestep level
-    map_relation_year(relation,node,year_all,time)             mapping of relations that should be accounted at year level
-    
+    map_relation_time(relation,node,year_all,time)             mapping of relations that should be accounted at the subannual time slice level
+    map_relation_year(relation,node,year_all,time)             mapping of relations that should be accounted at the year level
+
 
 * Storage
     map_time_commodity_storage(node,tec,level,commodity,mode,year_all,time)  mapping of storage containers to their input commodity-level (not commodity-level of stored media)

--- a/message_ix/model/MESSAGE/sets_maps_def.gms
+++ b/message_ix/model/MESSAGE/sets_maps_def.gms
@@ -308,6 +308,7 @@ Sets
     type_tec_land(type_tec)                 dynamic set whether emissions from land use are included in type_tec
     balance_equality(commodity,level)       mapping of commodities-level where the supply-demand balance must be maintained with equality
     time_relative(time)                     flag for treating unit of ACT in sub-annual time slices relative to parent 'time' (activating parameter 'duration_time_rel')
+	relation_year(relation)                 set of relations accounted at 'year' level
 ;
 
 Alias(type_tec,type_tec_share);
@@ -386,6 +387,7 @@ Sets
     map_tec_act(node,tec,year_all,mode,time)        mapping of technology to modes AND temporal dissagregation
     map_tec_addon(tec,type_addon)                   mapping of types of add-on technologies to the underlying parent technology
     map_tec_storage(node,tec,mode,tec2,mode2,level,commodity,lvl_temporal)  mapping of charge-discharging technologies to their respective storage container tec and level-commodity
+	map_tec_relation(node,relation,tec,year_all,mode,time)     mapping of technologies to relations and periods
 
     map_spatial_hierarchy(lvl_spatial,node,node)    mapping of spatial resolution to nodes (last index is 'parent')
     map_temporal_hierarchy(lvl_temporal,time,time)  mapping of temporal resolution to time (last index is 'parent')
@@ -397,6 +399,9 @@ Sets
 
     map_land(node,land_scenario,year_all)            mapping of land-use model emulator scenarios to nodes and years
     map_relation(relation,node,year_all)             mapping of generic (user-defined) relations to nodes and years
+    map_relation_time(relation,node,year_all,time)             mapping of relations that should be accounted at subannual timestep level
+    map_relation_year(relation,node,year_all,time)             mapping of relations that should be accounted at year level
+    
 
 * Storage
     map_time_commodity_storage(node,tec,level,commodity,mode,year_all,time)  mapping of storage containers to their input commodity-level (not commodity-level of stored media)
@@ -455,6 +460,8 @@ Sets
 
     is_relation_upper(relation,node,year_all)     flag whether upper bounds exists for generic relation
     is_relation_lower(relation,node,year_all)     flag whether lower bounds exists for generic relation
+    is_relation_upper_time(relation,node,year_all,time)     flag whether upper bounds exists for generic relation with time index
+    is_relation_lower_time(relation,node,year_all,time)     flag whether lower bounds exists for generic relation with time index
 ;
 
 *----------------------------------------------------------------------------------------------------------------------*

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -81,6 +81,7 @@ class Item:
     #: The same set name may be repeated if it indexes multiple dimensions.
     coords: Tuple[str, ...] = field(default_factory=tuple)
 
+	"relation_activity_time": item("par", "relation nr yr nl t ya m h"),
     #: Dimensions of the item.
     dims: Tuple[str, ...] = field(default_factory=tuple)
 
@@ -285,7 +286,7 @@ class MESSAGE(GAMSModel):
         # handled in JDBCBackend. For the moment, this code does not backstop that
         # behaviour.
         # TODO Extend to handle all masks, e.g. for new backends.
-        for par_name in ("capacity_factor",):
+        for par_name in ("capacity_factor", "relation_lower_time", "relation_upper_time"):
             # Name of the corresponding set
             set_name = f"is_{par_name}"
 

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -845,23 +845,25 @@ equ(
 )
 equ(
     "RELATION_EQUIVALENCE_TIME",
-    "", "time dependent auxiliary equation to simplify the implementation of relations",
-    )
+    "",
+    "time dependent auxiliary equation to simplify the implementation of relations",
+)
 equ(
     "RELATION_EQUIVALENCE_YEAR",
     "",
     "time dependent auxiliary equation to simplify the implementation of relations at"
     " the year level",
-    )
+)
 equ(
     "RELATION_CONSTRAINT_UP_TIME",
     "",
     "time dependentupper bound of relations (linear constraints)",
-    )
+)
 equ(
     "RELATION_CONSTRAINT_LO_TIME",
     "",
-    "time dependent lower bound of relations (linear constraints)")
+    "time dependent lower bound of relations (linear constraints)",
+)
 equ(
     "RENEWABLES_CAPACITY_REQUIREMENT",
     "",

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -81,7 +81,6 @@ class Item:
     #: The same set name may be repeated if it indexes multiple dimensions.
     coords: Tuple[str, ...] = field(default_factory=tuple)
 
-	"relation_activity_time": item("par", "relation nr yr nl t ya m h"),
     #: Dimensions of the item.
     dims: Tuple[str, ...] = field(default_factory=tuple)
 
@@ -286,7 +285,11 @@ class MESSAGE(GAMSModel):
         # handled in JDBCBackend. For the moment, this code does not backstop that
         # behaviour.
         # TODO Extend to handle all masks, e.g. for new backends.
-        for par_name in ("capacity_factor", "relation_lower_time", "relation_upper_time"):
+        for par_name in (
+            "capacity_factor",
+            "relation_lower_time",
+            "relation_upper_time",
+        ):
             # Name of the corresponding set
             set_name = f"is_{par_name}"
 

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -374,6 +374,8 @@ _set("cat_relation", "type_relation r")
 _set("cat_tec", "type_tec t")
 _set("cat_year", "type_year y")
 _set("is_capacity_factor", "nl t yv ya h")
+_set("is_relation_lower_time", "r nr yr h")
+_set("is_relation_upper_time", "r nr yr h")
 _set("level_renewable", "l")
 _set("level_resource", "l")
 _set("level_stocks", "l")
@@ -469,11 +471,15 @@ par("ref_extraction", "n c g y")
 par("ref_new_capacity", "nl t yv")
 par("ref_relation", "r nr yr")
 par("relation_activity", "r nr yr nl t ya m")
+par("relation_activity_time", "r nr yr nl t ya m h")
 par("relation_cost", "r nr yr")
+par("relation_cost_time", "r nr yr h")
 par("relation_lower", "r nr yr")
+par("relation_lower_time", "r nr yr h")
 par("relation_new_capacity", "r nr yr t")
 par("relation_total_capacity", "r nr yr t")
 par("relation_upper", "r nr yr")
+par("relation_upper_time", "r nr yr h")
 par("reliability_factor", "n t ya c l h q")
 par("renewable_capacity_factor", "n c g l y")
 par("renewable_potential", "n c g l y")
@@ -567,6 +573,11 @@ var(
     "REL",
     "r nr yr",
     "Auxiliary variable for left-hand side of user-defined relations",
+)
+var(
+    "REL_TIME",
+    "r nr yr",
+    "Time-dependent auxiliary variable for left-hand side of user-defined relations",
 )
 var(
     "REN",
@@ -832,6 +843,25 @@ equ(
     "",
     "Auxiliary equation to simplify the implementation of relations",
 )
+equ(
+    "RELATION_EQUIVALENCE_TIME",
+    "", "time dependent auxiliary equation to simplify the implementation of relations",
+    )
+equ(
+    "RELATION_EQUIVALENCE_YEAR",
+    "",
+    "time dependent auxiliary equation to simplify the implementation of relations at"
+    " the year level",
+    )
+equ(
+    "RELATION_CONSTRAINT_UP_TIME",
+    "",
+    "time dependentupper bound of relations (linear constraints)",
+    )
+equ(
+    "RELATION_CONSTRAINT_LO_TIME",
+    "",
+    "time dependent lower bound of relations (linear constraints)")
 equ(
     "RENEWABLES_CAPACITY_REQUIREMENT",
     "",

--- a/message_ix/tests/test_report.py
+++ b/message_ix/tests/test_report.py
@@ -52,7 +52,7 @@ def test_reporter_from_scenario(message_test_mp):
     rep = Reporter.from_scenario(scen)
 
     # Number of quantities available in a rudimentary MESSAGEix Scenario
-    assert 268 == len(rep.graph["all"])
+    assert 281 == len(rep.graph["all"])
 
     # Quantities have short dimension names
     assert "demand:n-c-l-y-h" in rep, sorted(rep.graph)
@@ -70,11 +70,11 @@ def test_reporter_from_scenario(message_test_mp):
     assert_qty_equal(obs, demand, check_attrs=False)
 
     # ixmp.Reporter pre-populated with only model quantities and aggregates
-    assert 6462 == len(rep_ix.graph)
+    assert 6784 == len(rep_ix.graph)
 
     # message_ix.Reporter pre-populated with additional, derived quantities
     # This is the same value as in test_tutorials.py
-    assert 13724 == len(rep.graph)
+    assert 14046 == len(rep.graph)
 
     # Derived quantities have expected dimensions
     vom_key = rep.full_key("vom")

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -87,7 +87,7 @@ TUTORIALS: List[Tuple] = [
     _t("w0", f"{W}_historical_new_capacity"),
     _t("w0", f"{W}_multinode_energy_trade"),
     # NB this is the same value as in test_reporter()
-    _t(None, f"{W}_report", check=[("len-rep-graph", 13724)]),
+    _t(None, f"{W}_report", check=[("len-rep-graph", 14046)]),
     _t("at0", "austria", check=[("solve-objective-value", 206321.90625)]),
     _t("at0", "austria_single_policy", check=[("solve-objective-value", 205310.34375)]),
     _t("at0", "austria_multiple_policies"),


### PR DESCRIPTION
This PR re-introduces user-defined relations (sets, parameters, equations, variables) with the inclusion of sub-annual `time` index.
**_Background_**: The user-defined relations in the GAMS formulation do not represent index of `time`, which can be an issue when working on models with sub-annual time slices (see #191). For example, it is not possible to represent time slices in parameter `relation_activity`, which relates to the activity of technologies and must be defined at the sub-annual time level. The addition of `time` to existing sets and parameters means re-initializing these items, which will create backward incompatibility. Via #631 a workaround was suggested, which was implemented in [PR#633](https://github.com/iiasa/message_ix/pull/633). The improvements proposed in this PR could use the same workaround as #633, however, a few sets here, namely, `is_relation_upper` and `is_relation_lower` are populated in the Java Backend side, which may make re-initializing these sets impossible or complex on the `message_ix` side, i.e., in `models.py`.

**_Solution_**: Until a robust solution will be in place for re-initializing sets and parameters that are at the moment being populated at the Java side in `message_ix`, this PR proposes an interim solution as follows:
- creating mirror sets and parameters for adding the missing index: For example, parameter `relation_activity_time` is introduced as the mirror of existing `relation_activity`, and similarly `relation_cost_time`, `relation_lower_time` and `relation_upper_time` are added.
- creating mapping (or masking) sets on the fly in `models.py`. This includes `is_relation_lower_time` and `is_relation_upper_time` instead of existing `is_relation_lower` and `is_relation_upper`, respectively, which are produced on the Java backend.
- adding duplicate blocks of equations (`RELATION_EQUIVALENCE_TIME`, `RELATION_CONSTRAINT_UP_TIME`, and `RELATION_CONSTRAINT_LO_TIME`) for enhancing the mathematical formulation.

This PR remains as draft for the time being. Merging this PR in the main branch shouldn't create any problems for running existing scenarios. However, having duplicate items (set, parameter, variable and equations) proposed in this PR may not be an optimal solution from a design perspective.

## How to review

1. Check out this branch and run your existing scenarios, and they should work without a flaw.
2. Load model/scenario "MESSAGEix-CAS/relations_with_time_index" from "ene_ixmp" database and solve it using the code in this PR. This scenario does include the new items proposed in this PR. There shouldn't be any error when loading and solving that.

## PR checklist
- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
