### PR TITLE
Improve depiction of Latex text in docs

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -21,16 +21,16 @@ There are a number of guides out there, e.g. on docutils_.
 Building the docs on your local machine
 ---------------------------------------
 
-From the command line, run::
+From the command line, run in `doc/`::
 
     make html
 
 You can then view the site by::
 
     cd build
-    python -m SimpleHTTPServer
+    python -m http.server
 
-and pointing your browser at http://localhost:8000/html/
+and pointing your browser at http://0.0.0.0:8000/_build/html/
 
 
 Read the Docs

--- a/doc/contrib/release.rst
+++ b/doc/contrib/release.rst
@@ -18,7 +18,7 @@ Preliminaries
     and
     `message-ix-feedstock <https://github.com/conda-forge/message-ix-feedstock>`__
     repositories.
-    This means your Github account is listed in each of them in the :file:`recipe/meta.yaml`, under the key ``recipe-maintainers:``.
+    This means your Github account is listed in each of them in the :file:`recipe/meta.yaml`, under the key ``recipe-maintainers:``. For an easy way of achieving that, see `the conda-forge docs <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__.
 
 - In the below:
 

--- a/doc/contrib/release.rst
+++ b/doc/contrib/release.rst
@@ -18,7 +18,7 @@ Preliminaries
     and
     `message-ix-feedstock <https://github.com/conda-forge/message-ix-feedstock>`__
     repositories.
-    This means your Github account is listed in the :file:`recipe/meta.yaml`, under the key ``recipe-maintainers:``.
+    This means your Github account is listed in each of them in the :file:`recipe/meta.yaml`, under the key ``recipe-maintainers:``.
 
 - In the below:
 
@@ -45,7 +45,7 @@ For instance, an item marked as deprecated in v2.1 can be removed as of v3.0; an
 
    .. note:: This can be done at any point, and should be done before the release prep begins.
       For instance, a feature marked as deprecated in v2.0 *should* be removed before 3.0 is released.
-      But *may* also be removed from the ``master`` branch *immediately after* 2.0.0 is released.
+      But *may* also be removed from the ``main`` branch *immediately after* 2.0.0 is released.
       This is preferred, because it forces tutorials, user code, etc. to stay ahead of deprecations.
 
 3. (message_ix only) Edit :file:`setup.cfg`, updating the ``install_requires`` line for ixmp as necessary.
@@ -72,12 +72,12 @@ Releasing
 
    - Comment the heading "Next release", and insert below it:
 
-     - A commented "All changes" sub-heading (``---``).
-     - A ReST anchor with the version number.
+     - A commented "All changes" sub-heading (``---``)
+     - A ReST anchor with the version number
      - Another heading (``===``) below it, with the version number and date
 
-   - Add a short text description summarizing the release.
-   - If necessary, add a subsection "Migration notes" explaining to users how to adjust to changes in the release.
+   - Add a short text description summarizing the release
+   - If necessary, add a subsection "Migration notes" explaining to users how to adjust to changes in the release
 
    For example, the top of the file should look like:
 
@@ -121,7 +121,7 @@ Releasing
    Build the docs locally to ensure any ReST markup in these additions renders correctly.
 
 3. Make a commit with a message like “Mark v<version> in release notes”.
-4. Tag the release candidate version, i.e. with a ``rcN`` suffix, and push::
+4. Tag the release candidate version, i.e. with a ``rcN`` suffix where ``N`` is a natural number, and push::
 
    $ git tag vX.Y.ZrcN
    $ git push --tags <upstream> release/X.Y.Z

--- a/doc/efficiency.rst
+++ b/doc/efficiency.rst
@@ -16,7 +16,7 @@ As an additional benefit, we do not need to define an explicit efficiency parame
 or "main" input and output fuels.  
 
 The recommended approach is illustrated below for multiple examples. 
-The decision variables :math:`CAP\_NEW`, :math:`CAP` and :math:`ACT` as well as all bounds 
+The decision variables :math:`\text{CAP\_NEW}`, :math:`\text{CAP}` and :math:`\text{ACT}` as well as all bounds 
 are always understood to be in the same units. All cost parameters also have to be provided 
 in monetary units per these units - there is no "automatic rescaling" done either within the ixmp API
 or in the GAMS implementation pre- or postprocessing.
@@ -25,15 +25,15 @@ Example 1 - Power plants
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Technical specifications of power plants are commonly stated in terms of electricity generated (output). 
-Therefore, the decision variables should be understood as outputs, with the parameter :math:`output = 1` 
-and parameter :math:`input = \frac{1}{efficiency}`. This may seem counter-intuitive at first, but the clear 
+Therefore, the decision variables should be understood as outputs, with the parameter :math:`\text{output} = 1` 
+and parameter :math:`\text{input} = \frac{1}{\text{efficiency}}`. This may seem counter-intuitive at first, but the clear 
 advantage is that all technical parameters can be immediately related to values found in the literature.
 
 Example 2 - Refineries
 ~~~~~~~~~~~~~~~~~~~~~~
 
 For crude oil refineries, it is more common to scale costs and emissions 
-in terms of crude oil input quantities. Hence, the parameter :math:`input = 1` 
+in terms of crude oil input quantities. Hence, the parameter :math:`\text{input} = 1` 
 and the output parameters (usually for multiple different oil products) 
 should be set accordingly.
 
@@ -42,8 +42,8 @@ The decision variables and bounds are then implicitly understood as input-based.
 An alternative would be to parametrize a refinery based on outputs, but 
 considering that there are multiple outputs (in fixed proportions), 
 the sum of output parameters over all products should be set to 1,
-i.e., :math:`\sum_{c} output_{c} = 1`. The input of crude oil should then 
-include the losses during the refining process,  :math:`input > 1`.
+i.e., :math:`\sum_{c} \text{output}_{c} = 1`. The input of crude oil should then 
+include the losses during the refining process,  :math:`\text{input} > 1`.
  
 Example 3 - Combined power- and heat plants
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -56,11 +56,11 @@ the capacity and activity variables should be understood as electricity generate
 Assuming that such a plant usually has (at least) two modes of operation, these 
 modes could be parametrized as follows:
 
-:math:`input = \frac{1}{efficiency}`
+:math:`\text{input} = \frac{1}{\text{efficiency}}`
 
-:math:`output_{'M1','electricity'} = 1` and :math:`output_{'M1','heat'} = 0.2`
+:math:`\text{output}_{\text{M1},\text{electricity}} = 1` and :math:`\text{output}_{\text{M1},\text{heat}} = 0.2`
 
-:math:`output_{'M2','electricity'} = 0.5` and :math:`output_{'M2','heat'} = 3`.
+:math:`\text{output}_{\text{M2},\text{electricity}} = 0.5` and :math:`\text{output}_{\text{M2}, \text{heat}} = 3`.
 
 Note that the activity level in mode 'M2' has an odd interpretation - the amount 
 of electricity generated if electricity generation were maximized. The sum of outputs 

--- a/doc/efficiency.rst
+++ b/doc/efficiency.rst
@@ -16,7 +16,7 @@ As an additional benefit, we do not need to define an explicit efficiency parame
 or "main" input and output fuels.  
 
 The recommended approach is illustrated below for multiple examples. 
-The decision variables :math:`\text{CAP\_NEW}`, :math:`\text{CAP}` and :math:`\text{ACT}` as well as all bounds 
+The decision variables :math:`\text{CAP_NEW}`, :math:`\text{CAP}` and :math:`\text{ACT}` as well as all bounds 
 are always understood to be in the same units. All cost parameters also have to be provided 
 in monetary units per these units - there is no "automatic rescaling" done either within the ixmp API
 or in the GAMS implementation pre- or postprocessing.

--- a/doc/time.rst
+++ b/doc/time.rst
@@ -82,9 +82,9 @@ Example 5
    Using the same setup as Example 2:
 
    - Discounting for the element ``1010`` involves discounting for years ``1001``, ``1002``, ... , ``1010``.
-   - Using the standard PV formula, we have that, for the year ``1001`` the discount factor would be :math:`(1 + \text{interest\_rate})^(1000 - 1001)`, for the year  ``1002`` the discount factor would be :math:`(1 + \text{interest\_rate})^(1000 - 1002)`, and so on.
-   - Therefore, the period discount factor for the element ``1010`` is :math:`\text{df}_{1010} = (1 + \text{interest\_rate})^(1000 - 1001) + (1 + \text{interest\_rate})^(1000 - 1002) + ... + (1 + \text{interest\_rate})^(1000 - 1010)`
-   - Analogously, the period discount factor for the element ``1020`` is :math:`\text{df}_{1020} = (1 + \text{interest\_rate})^(1000 - 1011) + (1 + \text{interest\_rate})^(1000 - 1012) + ... + (1 + \text{interest\_rate})^(1000 - 1020)`
+   - Using the standard PV formula, we have that, for the year ``1001`` the discount factor would be :math:`(1 + \text{interest_rate})^{1000 - 1001}`, for the year  ``1002`` the discount factor would be :math:`(1 + \text{interest_rate})^{1000 - 1002}`, and so on.
+   - Therefore, the period discount factor for the element ``1010`` is :math:`\text{df}_{1010} = (1 + \text{interest_rate})^{1000 - 1001} + ... + (1 + \text{interest_rate})^{1000 - 1010}`
+   - Analogously, the period discount factor for the element ``1020`` is :math:`\text{df}_{1020} = (1 + \text{interest_rate})^{1000 - 1011} + ... + (1 + \text{interest_rate})^{1000 - 1020}`
    - So, if we have a cost of ``K_1010`` for the element ``1010``, its discounted value would be ``df_1010 * K_1010``, which means, all the years in  element ``1010`` have a representative cost of ``K_1010`` that is discounted up to the initial ``year`` of the setup, namely, the year ``1000``.
 
 In practice, since the representative year of a period is always its final year, the actual calculation of the period discount factor within the model is performed backwards, i.e., starting from the final year of the period until the initial year.

--- a/doc/time.rst
+++ b/doc/time.rst
@@ -82,9 +82,9 @@ Example 5
    Using the same setup as Example 2:
 
    - Discounting for the element ``1010`` involves discounting for years ``1001``, ``1002``, ... , ``1010``.
-   - Using the standard PV formula, we have that, for the year ``1001`` the discount factor would be :math:`(1 + interest_rate)^(1000 - 1001)`, for the year  ``1002`` the discount factor would be :math:`(1 + interest_rate)^(1000 - 1002)`, and so on.
-   - Therefore, the period discount factor for the element ``1010`` is :math:`df_1010 = (1 + interest_rate)^(1000 - 1001) + (1 + interest_rate)^(1000 - 1002) + ... + (1 + interest_rate)^(1000 - 1010)`
-   - Analogously, the period discount factor for the element ``1020`` is :math:`df_1020 = (1 + interest_rate)^(1000 - 1011) + (1 + interest_rate)^(1000 - 1012) + ... + (1 + interest_rate)^(1000 - 1020)`
+   - Using the standard PV formula, we have that, for the year ``1001`` the discount factor would be :math:`(1 + \text{interest\_rate})^(1000 - 1001)`, for the year  ``1002`` the discount factor would be :math:`(1 + \text{interest\_rate})^(1000 - 1002)`, and so on.
+   - Therefore, the period discount factor for the element ``1010`` is :math:`\text{df}_{1010} = (1 + \text{interest\_rate})^(1000 - 1001) + (1 + \text{interest\_rate})^(1000 - 1002) + ... + (1 + \text{interest\_rate})^(1000 - 1010)`
+   - Analogously, the period discount factor for the element ``1020`` is :math:`\text{df}_{1020} = (1 + \text{interest\_rate})^(1000 - 1011) + (1 + \text{interest\_rate})^(1000 - 1012) + ... + (1 + \text{interest\_rate})^(1000 - 1020)`
    - So, if we have a cost of ``K_1010`` for the element ``1010``, its discounted value would be ``df_1010 * K_1010``, which means, all the years in  element ``1010`` have a representative cost of ``K_1010`` that is discounted up to the initial ``year`` of the setup, namely, the year ``1000``.
 
 In practice, since the representative year of a period is always its final year, the actual calculation of the period discount factor within the model is performed backwards, i.e., starting from the final year of the period until the initial year.


### PR DESCRIPTION
<!--

Delete each of these instruction comments as you complete it.

Title: use a short, declarative statement similar to a commit message,
e.g. “Change [thing X] to [fix solve bug|enable feature Y]”

-->

This PR simply writes `\text{xyz}` in Latex math mode in the docs where before it used to be `xyz`. This should improve [the time page](https://docs.messageix.org/en/stable/time.html) and [the efficiency page](https://docs.messageix.org/en/stable/efficiency.html).

## How to review

- Build the documentation and look at the changed pages

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅

