### PR TITLE
Update versions of conda and miniconda in workflow conda.yaml

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest]
         conda:
-        - {installer: anaconda, version: 2021.05}
-        - {installer: miniconda, version: py39_4.10.3}
+        - {installer: anaconda, version: 2023.03-1}
+        - {installer: miniconda, version: latest}
         extra-deps: ["", "JPype1=1.2.1"]
       fail-fast: false
 


### PR DESCRIPTION
The conda-forge workflow is currently failing on some windows systems, which might simply be due to using 2021 versions of anaconda and miniconda.

## How to review

- After the workflow file is updated, trigger the workflow and check that it works for all systems

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
