### PR TITLE
Address tests that are flaky on GHA

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -31,7 +31,8 @@ jobs:
         - "3.7"  # Earliest version supported by message_ix
         - "3.8"
         - "3.9"
-        - "3.10"  # Latest version testable on GitHub Actions
+        - "3.10"
+        - "3.11"  # Latest version supported by message_ix
 
         # Below this comment are newly released or development versions of
         # Python. For these versions, binary wheels are not available for some
@@ -39,7 +40,6 @@ jobs:
         # these on the job runner requires a more elaborate build environment,
         # currently out of scope for the message_ix project.
 
-        # - "3.11"  # Latest release. Pending numba/numba#8304
         # - "3.12.0-alpha.1"  # Development version
 
       fail-fast: false

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -489,7 +489,7 @@ def test_excel_read_write(message_test_mp, tmp_path):
     pdt.assert_frame_equal(exp, obs)
 
     assert scen2.has_par("new_par")
-    assert float(scen2.par("new_par")["value"]) == 2
+    assert 2 == scen2.par("new_par").at[0, "value"]
 
     scen2.solve(quiet=True)
     assert np.isclose(scen2.var("OBJ")["lvl"], scen1.var("OBJ")["lvl"])

--- a/message_ix/tests/test_feature_bound_activity_shares.py
+++ b/message_ix/tests/test_feature_bound_activity_shares.py
@@ -64,7 +64,7 @@ def test_add_bound_activity_up_all_modes(message_test_mp):
     scen.solve(quiet=True, solve_options=dict(lpmethod=2))
 
     # data for act bound
-    print(calculate_activity(scen))
+    # print(calculate_activity(scen))
     exp = 0.95 * calculate_activity(scen).sum()
     data = pd.DataFrame(
         {

--- a/message_ix/tests/test_feature_bound_emission.py
+++ b/message_ix/tests/test_feature_bound_emission.py
@@ -37,7 +37,7 @@ def add_bound_emission(scen, bound, year="cumulative"):
 
 def assert_function(scen, year):
     var_em = scen.var("EMISS", {"node": "node"}).set_index(["year"])["lvl"]
-    bound_em = float(scen.par("bound_emission", {"type_year": year})["value"])
+    bound_em = scen.par("bound_emission", {"type_year": year}).at[0, "value"]
 
     if year == "cumulative":
         duration = scen.par("duration_period").set_index("year")["value"]

--- a/message_ix/tests/test_feature_capacity_factor.py
+++ b/message_ix/tests/test_feature_capacity_factor.py
@@ -21,7 +21,7 @@ def check_solution(scen: Scenario) -> None:
     # 2) CAP is correctly calculated based on "ACT", CF, and "operation_factor"
     for i in act.index:
         # Correct CF based on duration of each time slice
-        duration = float(scen.par("duration_time", {"time": i[1]})["value"])
+        duration = scen.par("duration_time", {"time": i[1]}).at[0, "value"]
         if i[1] != "year":
             cf.loc[i, "duration-corrected"] = cf.loc[i, "value"] * duration
             if cf.loc[i, "value"] == 0 or duration == 0:

--- a/message_ix/tests/test_feature_duration_time.py
+++ b/message_ix/tests/test_feature_duration_time.py
@@ -86,7 +86,7 @@ def model_generator(
             scen.add_set("map_temporal_hierarchy", [tmp_lvl, h, p])
 
             # Duration time is relative to the duration of the parent temporal level
-            dur_parent = float(scen.par("duration_time", {"time": p})["value"])
+            dur_parent = scen.par("duration_time", {"time": p}).at[0, "value"]
             scen.add_par("duration_time", [h], dur_parent / number, "-")
 
     # Adding "demand" at a temporal level (total demand divided by the number of

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -41,9 +41,12 @@ def check_solution(scen: Scenario) -> None:
         act.loc[
             (act["time"] == h) & (act["technology"] == "gas_ppl"),
             "capacity-corrected",
-        ] = act["lvl"] / float(scen.par("duration_time", {"time": h})["value"])
-    assert max(act.loc[act["technology"] == "gas_ppl", "capacity-corrected"]) == float(
-        scen.var("CAP", {"technology": "gas_ppl"})["lvl"]
+        ] = (
+            act["lvl"] / scen.par("duration_time", {"time": h}).at[0, "value"]
+        )
+    assert (
+        max(act.loc[act["technology"] == "gas_ppl", "capacity-corrected"])
+        == scen.var("CAP", {"technology": "gas_ppl"}).at[0, "lvl"]
     )
 
 

--- a/message_ix/tests/test_soft_constraints.py
+++ b/message_ix/tests/test_soft_constraints.py
@@ -36,26 +36,22 @@ def test_soft_constraint(test_mp):
     # Ensure that the value for 'ACT_UP' is correct.
     # The value of ACT_UP should be equal to the historical
     # activity of coal_ppl
-    val = float(
-        round(
-            s.par("historical_activity", filters={"technology": "coal_ppl"})["value"], 6
-        )
-    )
-
     exp = pd.DataFrame(
         {
             "node": ["Westeros"],
             "technology": "coal_ppl",
             "year": 700,
             "time": "year",
-            "lvl": val,
+            "lvl": s.par("historical_activity", filters={"technology": "coal_ppl"}).at[
+                0, "value"
+            ],
             "mrg": 0.0,
         }
     )
 
     obs = s.var("ACT_UP")
 
-    pdt.assert_frame_equal(exp, obs, check_dtype=False)
+    pdt.assert_frame_equal(exp, obs, check_dtype=False, rtol=1e-6)
 
     # Ensure that the objective function is the same
     assert np.isclose(s.var("OBJ")["lvl"], 173408.40625)

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -27,9 +27,9 @@ MARK = [
         condition=GHA and sys.platform == "win32",
         reason="Fails occasionally on GitHub Actions runners for Windows",
     ),
-    pytest.mark.xfail(
-        condition=GHA and sys.platform == "darwin",
-        reason="Flaky; CellTimeoutError occurs on first executed cell",
+    pytest.mark.flaky(
+        condition=GHA and sys.platform in ("darwin", "win32"),
+        reason="Flaky; fails occasionally on GitHub Actions runners",
     ),
 ]
 

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -32,6 +32,10 @@ MARK = [
         condition=GHA and sys.platform in ("darwin", "win32"),
         reason="Flaky; fails occasionally on GitHub Actions runners",
     ),
+    pytest.mark.xfail(
+        condition=sys.version_info.minor >= 11,
+        reason="pyam-iamc does not support Python 3.11; see IAMconsortium/pyam#744",
+    ),
 ]
 
 # Affects all tests in the file.
@@ -88,7 +92,7 @@ TUTORIALS: List[Tuple] = [
     _t("w0", f"{W}_historical_new_capacity"),
     _t("w0", f"{W}_multinode"),
     # NB this is the same value as in test_reporter()
-    _t(None, f"{W}_report", check=[("len-rep-graph", 13074)], marks=[MARK[2]]),
+    _t(None, f"{W}_report", check=[("len-rep-graph", 13074)], marks=[MARK[2], MARK[4]]),
     _t("at0", "austria", check=[("solve-objective-value", 206321.90625)]),
     _t("at0", "austria_single_policy", check=[("solve-objective-value", 205310.34375)]),
     _t("at0", "austria_multiple_policies"),

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -29,7 +29,7 @@ MARK = [
     ),
     pytest.mark.flaky(
         reruns=3,
-        condition=GHA and sys.platform in ("darwin", "win32"),
+        condition=GHA,
         reason="Flaky; fails occasionally on GitHub Actions runners",
     ),
     pytest.mark.xfail(

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -28,6 +28,7 @@ MARK = [
         reason="Fails occasionally on GitHub Actions runners for Windows",
     ),
     pytest.mark.flaky(
+        reruns=3,
         condition=GHA and sys.platform in ("darwin", "win32"),
         reason="Flaky; fails occasionally on GitHub Actions runners",
     ),

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -125,6 +125,15 @@ def nb_path(request, tutorial_path):
     yield tutorial_path.joinpath(*request.param).with_suffix(".ipynb")
 
 
+def default_args():
+    """Default arguments for :func:`.run_notebook."""
+    if GHA and sys.platform == "darwin":
+        # Use a longer timeout
+        return dict(timeout=30)
+    else:
+        return dict()
+
+
 # Parametrize the first 3 arguments using the variables *TUTORIALS* and *IDS*.
 # Argument 'nb_path' is indirect so that the above function can modify it.
 @pytest.mark.parametrize("nb_path,checks", TUTORIALS, ids=IDS, indirect=["nb_path"])
@@ -139,7 +148,7 @@ def test_tutorial(nb_path, checks, tmp_path, tmp_env):
             copyfile(nb_path.parent / name, tmp_path / name)
 
     # Determine arguments for run_notebook()
-    args = dict()
+    args = default_args()
     if nb_path.name.startswith("R_"):
         args.update(kernel_name="IR")
 

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -29,6 +29,7 @@ MARK = [
     ),
     pytest.mark.flaky(
         reruns=3,
+        rerun_delay=2,
         condition=GHA,
         reason="Flaky; fails occasionally on GitHub Actions runners",
     ),

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -14,33 +14,27 @@ W = "westeros"
 # Common marks for some test cases
 GHA = "GITHUB_ACTIONS" in os.environ
 MARK = [
-    pytest.mark.skipif(
+    pytest.mark.skipif(  # 0
         condition=GHA and sys.platform == "linux",
         reason="IR kernel times out on GitHub Actions Ubuntu runners",
     ),
-    # This mark does *not* affect macos-latest-py3.9, which must still pass
-    pytest.mark.xfail(
-        condition=GHA and sys.platform == "darwin" and sys.version_info.minor == 8,
-        reason="Fails occasionally on GitHub Actions runners for macOS / Python 3.8",
+    pytest.mark.xfail(  # 1
+        condition=GHA and sys.platform == "darwin",
+        reason="Always fails on GitHub Action macOS runners",
     ),
-    pytest.mark.xfail(
-        condition=GHA and sys.platform == "win32",
-        reason="Fails occasionally on GitHub Actions runners for Windows",
-    ),
-    pytest.mark.flaky(
-        reruns=3,
-        rerun_delay=2,
-        condition=GHA,
-        reason="Flaky; fails occasionally on GitHub Actions runners",
-    ),
-    pytest.mark.xfail(
+    pytest.mark.xfail(  # 2
         condition=sys.version_info.minor >= 11,
         reason="pyam-iamc does not support Python 3.11; see IAMconsortium/pyam#744",
     ),
 ]
 
-# Affects all tests in the file.
-pytestmark = MARK[3]
+# Affects all tests in the file
+pytestmark = pytest.mark.flaky(
+    reruns=3,
+    rerun_delay=2,
+    condition=GHA,
+    reason="Flaky; fails occasionally on GitHub Actions runners",
+)
 
 
 def _t(group: Union[str, None], basename: str, *, check=None, marks=None):
@@ -93,15 +87,15 @@ TUTORIALS: List[Tuple] = [
     _t("w0", f"{W}_historical_new_capacity"),
     _t("w0", f"{W}_multinode"),
     # NB this is the same value as in test_reporter()
-    _t(None, f"{W}_report", check=[("len-rep-graph", 13074)], marks=[MARK[2], MARK[4]]),
+    _t(None, f"{W}_report", check=[("len-rep-graph", 13074)], marks=MARK[2]),
     _t("at0", "austria", check=[("solve-objective-value", 206321.90625)]),
     _t("at0", "austria_single_policy", check=[("solve-objective-value", 205310.34375)]),
     _t("at0", "austria_multiple_policies"),
     _t("at0", "austria_multiple_policies-answers"),
     _t("at0", "austria_load_scenario"),
     # R tutorials using the IR Jupyter kernel
-    _t("at1", "R_austria", marks=MARK[:3]),
-    _t("at1", "R_austria_load_scenario", marks=[MARK[0], MARK[2]]),
+    _t("at1", "R_austria", marks=[MARK[0], MARK[1]]),
+    _t("at1", "R_austria_load_scenario", marks=[MARK[0], MARK[1]]),
 ]
 
 # Short, readable IDs for the tests. Use getattr() to unpack the values from

--- a/message_ix/tests/tools/test_add_year.py
+++ b/message_ix/tests/tools/test_add_year.py
@@ -54,8 +54,9 @@ def assert_function(scen_ref, scen_new, years_new, yr_test):
     parname = "technical_lifetime"
     ref = scen_ref.par(parname, {"technology": "tec", "year_vtg": [yr_pre, yr_next]})
     value_ref = ref["value"].mean()
-    new = scen_new.par(parname, {"technology": "tec", "year_vtg": yr_test})
-    value_new = float(new["value"])
+    value_new = scen_new.par(parname, {"technology": "tec", "year_vtg": yr_test}).at[
+        0, "value"
+    ]
     assert value_new == pytest.approx(value_ref, rel=1e-04)
 
     # 3. Testing parameter "var_cost" (function interpolate_2d)
@@ -70,12 +71,11 @@ def assert_function(scen_ref, scen_new, years_new, yr_test):
 
     value_ref = ref["value"].mean()
 
-    new = scen_new.par(
+    value_new = scen_new.par(
         "var_cost", {"technology": "tec", "year_act": yr_test, "year_vtg": yr_test}
-    )
+    ).at[0, "value"]
 
     # Asserting if the missing data is generated accurately by interpolation
-    value_new = float(new["value"])
     assert value_new == pytest.approx(value_ref, rel=1e-04)
 
 

--- a/message_ix/tests/tools/test_add_year.py
+++ b/message_ix/tests/tools/test_add_year.py
@@ -124,8 +124,7 @@ def test_add_year_cli(message_ix_cli, base_scen_mp):
     del test_mp, scen_ref
 
     r = message_ix_cli(*cmd)
-    print(r.output, r.exception)
-    assert r.exit_code == 0
+    assert r.exit_code == 0, (r.output, r.exception)
 
     # Re-load the base Scenario
     mp = Platform(name=platform_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ tests = [
   "pyam-iamc >= 0.6",
   "pytest >= 5",
   "pytest-cov",
+  "pytest-rerunfailures",
   "pytest-xdist",
   "requests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: R",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Information Analysis"


### PR DESCRIPTION
Some of the tutorial tests are "flaky": they occasionally fail on the GitHub Actions runners, e.g. [here](https://github.com/iiasa/message_ix/actions/runs/5030524087/jobs/9023255135). This necessitates daily work to restart the CI runs.

Per the [Pytest docs on flaky tests](https://docs.pytest.org/en/stable/explanation/flaky.html), this PR:

- Adds [`pytest-rerunfailures`](https://github.com/pytest-dev/pytest-rerunfailures) to the tests dependencies.
- Applies the "flaky" marker to these tutorial tests.

Also:

- Advertise Python 3.11 support in classifiers, and test against Python 3.11 on CI (parallel to iiasa/ixmp#481).
- Update deprecated usage in the test suite: mainly of `float(…)` to get a single value from a pandas.DataFrame; using `DataFrame.at[…]` or `.item()` instead.

## How to review

Confirm at least one instance where a test initially fails, and the usage of the plugin succeeds in allowing the test to pass on re-run.

This should appear somewhat like this in the log output:
```
test_all.py::test_example RERUN   [100%]
test_all.py::test_example RERUN   [100%]
test_all.py::test_example PASSED  [100%]

====== 1 passed, 2 rerun in 0.01s ======
```

→ here, at [L314](https://github.com/iiasa/message_ix/actions/runs/5037859539/jobs/9034961374#step:12:314), re-run at L318, and summarized at [L17008](https://github.com/iiasa/message_ix/actions/runs/5037859539/jobs/9034961374#step:12:17008).

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, testing only
- ~Update release notes.~