### PR TITLE
Address failures in nightly CI

### DIFF
--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -121,7 +121,7 @@ def nb_path(request, tutorial_path):
 
 def default_args():
     """Default arguments for :func:`.run_notebook."""
-    if GHA and sys.platform == "darwin":
+    if GHA and sys.platform in ("darwin", "win32"):
         # Use a longer timeout
         return dict(timeout=30)
     else:


### PR DESCRIPTION
Frequently 1–4 of the jobs in this workflow will fail. Some recurring cases:
- The R_*.ipynb notebooks on Windows, especially Windows 3.10 and 3.11

This PR adjusts:
- Increase the timeout for these (and other) cases from 10 to 30 seconds.

## How to review

- Read the diff and note that the CI checks all pass.
- Re-run the "pytest" CI workflow one or a few times, checking that there are no timeouts.

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
  <!--
  The following items are all *required* if the PR results in changes to user-
  facing behaviour, e.g. new features or fixes to existing behaviour. They are
  *optional* if the changes are solely to documentation, CI configuration, etc.

  In ambiguous cases, strike them out and add a short explanation, e.g.

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
