### PR TITLE
Use mamba solver instead of conda solver

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -62,13 +62,15 @@ jobs:
 
     - name: Configure conda channels, update, create environment, and install message-ix
       run: |
+        conda install -n base conda-libmamba-solver
+        conda config --set solver libmamba
         conda config --prepend channels conda-forge
         conda config --set channel_priority strict
         conda update -n base -c defaults conda
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix=3.7.0 ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda create --quiet --name testenv message-ix ${{ matrix.extra-deps }} pytest asyncssh sphinx
         conda list --name testenv
 
     - name: Check CLI commands and run test

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -68,7 +68,7 @@ jobs:
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix=3.6.0 ${{ matrix.extra-deps }} pytest asyncssh sphinx
+        conda create --quiet --name testenv message-ix=3.7.0 ${{ matrix.extra-deps }} pytest asyncssh sphinx
         conda list --name testenv
 
     - name: Check CLI commands and run test


### PR DESCRIPTION
~Since we pinned the message-ix version to help the conda workflow pass, we need to keep this version number up-to-date.~

The above was true in principle, but did not solve our CI conda-forge test problems. As suggested in conda/conda/issues/12741, replacing the conda solver with the mamba solver did. This even allows us to remove the message_ix version pin entirely.

<!-- Optional: write a longer description to help a reviewer understand the PR in ~3 minutes. -->

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
