### PR TITLE
Add GitPython to "docs" optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ documentation = "https://docs.messageix.org"
 
 [project.optional-dependencies]
 docs = [
+  "GitPython",
   "message_ix[report]",
   "numpydoc",
   "sphinx >= 4.0",


### PR DESCRIPTION
This was missed in #719. It is required during the Sphinx docs build, in order for the `ixmp.utils.sphinx_linkcode_github` extension to identify the branch name to link, in both:
- RTD (example failed build [here](https://readthedocs.com/projects/iiasa-energy-program-message-ix/builds/1619490/)).
- The "pytest" CI workflow run on a schedule event (example failed job [here](https://github.com/iiasa/message_ix/actions/runs/5664864272/job/15348807463#step:13:23)).

This issue was/is not visible on the CI workflow job on the PR branch, because in that case the explicitly supplied head_ref is used: https://github.com/iiasa/message_ix/blob/4034d8c462bceef8b675ea84f0546bd60be93add/.github/workflows/pytest.yaml#L127-L131

The added dependency mirrors ixmp; in the ixmp CI the extension is working properly.

## How to review

See the log of [this example build from the current branch](https://readthedocs.com/projects/iiasa-energy-program-message-ix/builds/1621511/). In the final step, the 4th line of output is:
```
linkcode base URL: https://github.com/iiasa/message_ix/blob/fix/docs-ci
```

This indicates the branch is correctly identified using GitPython.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update release notes.~