### PR TITLE
Enable pdf build of the docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -160,6 +160,10 @@ storage_self_discharge"""
 mathjax3_config = dict(
     tex=dict(
         macros={k.replace("_", ""): r"\text{" + k + "}" for k in text_macros.split()},
+        packages={"[+]": ["textmacros"]},
+    ),
+    loader=dict(
+        load=["[tex]/textmacros"],
     ),
 )
 

--- a/doc/efficiency.rst
+++ b/doc/efficiency.rst
@@ -16,7 +16,7 @@ As an additional benefit, we do not need to define an explicit efficiency parame
 or "main" input and output fuels.  
 
 The recommended approach is illustrated below for multiple examples. 
-The decision variables :math:`\text{CAP_NEW}`, :math:`\text{CAP}` and :math:`\text{ACT}` as well as all bounds 
+The decision variables :math:`\text{CAP\_NEW}`, :math:`\text{CAP}` and :math:`\text{ACT}` as well as all bounds 
 are always understood to be in the same units. All cost parameters also have to be provided 
 in monetary units per these units - there is no "automatic rescaling" done either within the ixmp API
 or in the GAMS implementation pre- or postprocessing.

--- a/doc/time.rst
+++ b/doc/time.rst
@@ -82,9 +82,9 @@ Example 5
    Using the same setup as Example 2:
 
    - Discounting for the element ``1010`` involves discounting for years ``1001``, ``1002``, ... , ``1010``.
-   - Using the standard PV formula, we have that, for the year ``1001`` the discount factor would be :math:`(1 + \text{interest_rate})^{1000 - 1001}`, for the year  ``1002`` the discount factor would be :math:`(1 + \text{interest_rate})^{1000 - 1002}`, and so on.
-   - Therefore, the period discount factor for the element ``1010`` is :math:`\text{df}_{1010} = (1 + \text{interest_rate})^{1000 - 1001} + ... + (1 + \text{interest_rate})^{1000 - 1010}`
-   - Analogously, the period discount factor for the element ``1020`` is :math:`\text{df}_{1020} = (1 + \text{interest_rate})^{1000 - 1011} + ... + (1 + \text{interest_rate})^{1000 - 1020}`
+   - Using the standard PV formula, we have that, for the year ``1001`` the discount factor would be :math:`(1 + \text{interest\_rate})^{1000 - 1001}`, for the year  ``1002`` the discount factor would be :math:`(1 + \text{interest\_rate})^{1000 - 1002}`, and so on.
+   - Therefore, the period discount factor for the element ``1010`` is :math:`\text{df}_{1010} = (1 + \text{interest\_rate})^{1000 - 1001} + ... + (1 + \text{interest\_rate})^{1000 - 1010}`
+   - Analogously, the period discount factor for the element ``1020`` is :math:`\text{df}_{1020} = (1 + \text{interest\_rate})^{1000 - 1011} + ... + (1 + \text{interest\_rate})^{1000 - 1020}`
    - So, if we have a cost of ``K_1010`` for the element ``1010``, its discounted value would be ``df_1010 * K_1010``, which means, all the years in  element ``1010`` have a representative cost of ``K_1010`` that is discounted up to the initial ``year`` of the setup, namely, the year ``1000``.
 
 In practice, since the representative year of a period is always its final year, the actual calculation of the period discount factor within the model is performed backwards, i.e., starting from the final year of the period until the initial year.

--- a/message_ix/model/MACRO/macro_core.gms
+++ b/message_ix/model/MACRO/macro_core.gms
@@ -32,25 +32,25 @@
 *
 * A listing of all parameters used in MACRO together with a decription can be found in the table below.
 *
-* ================================== ================================================================================================================================
-* Parameter                          Description
-* ================================== ================================================================================================================================
-* :math:`\text{duration_period}_y`   Number of years in time period :math:`y` (forward diff)
-* :math:`\text{total_cost}_{n,y}`    Total system costs in region :math:`n` and period :math:`y` from MESSAGE model run
-* :math:`\text{enestart}_{n,s,y}`    Consumption level of (commercial) end-use services :math:`s` in region :math:`n` and period :math:`y` from MESSAGE model run
-* :math:`\text{eneprice}_{n,s,y}`    Shadow prices of (commercial) end-use services :math:`s` in region :math:`n` and period :math:`y` from MESSAGE model run
-* :math:`\epsilon_n`                 Elasticity of substitution between capital-labor and total energy in region :math:`n`
-* :math:`\rho_n`                     :math:`\epsilon - 1 / \epsilon` where :math:`\epsilon` is the elasticity of subsitution in region :math:`n`
-* :math:`\text{depr}_n`              Annual depreciation rate in region :math:`n`
-* :math:`\alpha_n`                   Capital value share parameter in region :math:`n`
-* :math:`a_n`                        Production function coefficient of capital and labor in region :math:`n`
-* :math:`b_{n,s}`                    Production function coefficients of the different end-use sectors in region :math:`n`, sector :math:`s` and period :math:`y`
-* :math:`\text{udf}_{n,y}`           Utility discount factor in period year in region :math:`n` and period :math:`y`
-* :math:`\text{newlab}_{n,y}`        New vintage of labor force in region :math:`n` and period :math:`y`
-* :math:`\text{grow}_{n,y}`          Annual growth rates of potential GDP in region :math:`n` and period :math:`y`
-* :math:`\text{aeei}_{n,s,y}`        Autonomous energy efficiency improvement (AEEI) in region :math:`n`, sector :math:`s` and period :math:`y`
-* :math:`\text{fin_time}_{n,y}`      finite time horizon correction factor in utility function in region :math:`n` and period :math:`y`
-* ================================== ================================================================================================================================
+* =================================== ================================================================================================================================
+* Parameter                           Description
+* =================================== ================================================================================================================================
+* :math:`\text{duration\_period}_y`   Number of years in time period :math:`y` (forward diff)
+* :math:`\text{total\_cost}_{n,y}`    Total system costs in region :math:`n` and period :math:`y` from MESSAGE model run
+* :math:`\text{enestart}_{n,s,y}`     Consumption level of (commercial) end-use services :math:`s` in region :math:`n` and period :math:`y` from MESSAGE model run
+* :math:`\text{eneprice}_{n,s,y}`     Shadow prices of (commercial) end-use services :math:`s` in region :math:`n` and period :math:`y` from MESSAGE model run
+* :math:`\epsilon_n`                  Elasticity of substitution between capital-labor and total energy in region :math:`n`
+* :math:`\rho_n`                      :math:`\epsilon - 1 / \epsilon` where :math:`\epsilon` is the elasticity of subsitution in region :math:`n`
+* :math:`\text{depr}_n`               Annual depreciation rate in region :math:`n`
+* :math:`\alpha_n`                    Capital value share parameter in region :math:`n`
+* :math:`a_n`                         Production function coefficient of capital and labor in region :math:`n`
+* :math:`b_{n,s}`                     Production function coefficients of the different end-use sectors in region :math:`n`, sector :math:`s` and period :math:`y`
+* :math:`\text{udf}_{n,y}`            Utility discount factor in period year in region :math:`n` and period :math:`y`
+* :math:`\text{newlab}_{n,y}`         New vintage of labor force in region :math:`n` and period :math:`y`
+* :math:`\text{grow}_{n,y}`           Annual growth rates of potential GDP in region :math:`n` and period :math:`y`
+* :math:`\text{aeei}_{n,s,y}`         Autonomous energy efficiency improvement (AEEI) in region :math:`n`, sector :math:`s` and period :math:`y`
+* :math:`\text{fin\_time}_{n,y}`      finite time horizon correction factor in utility function in region :math:`n` and period :math:`y`
+* =================================== ================================================================================================================================
 ***
 
 *----------------------------------------------------------------------------------------------------------------------*
@@ -138,14 +138,14 @@ EQUATIONS
 * The utility function which is maximized sums up the discounted logarithm of consumption of a single representative producer-consumer over the entire time horizon
 * of the model.
 *
-* .. math:: \text{UTILITY} = \sum_{n} \bigg( &  \sum_{y |  (  (  {ord}( y )   >  1 )  \wedge  (  {ord}( y )   <   | y |  )  )} \text{udf}_{n, y} \cdot {\log}( \text{C}_{n, y} ) \cdot \text{duration_period}_{y} \\
-*                                 + &\sum_{y |  (  {ord}( y ) =  | y | ) } \text{udf}_{n, y} \cdot {\log}( \text{C}_{n, y} ) \cdot \big( \text{duration_period}_{y-1} + \frac{1}{\text{fin_time}_{n, y}} \big) \bigg)
+* .. math:: \text{UTILITY} = \sum_{n} \bigg( &  \sum_{y |  (  (  {ord}( y )   >  1 )  \wedge  (  {ord}( y )   <   | y |  )  )} \text{udf}_{n, y} \cdot {\log}( \text{C}_{n, y} ) \cdot \text{duration\_period}_{y} \\
+*                                 + &\sum_{y |  (  {ord}( y ) =  | y | ) } \text{udf}_{n, y} \cdot {\log}( \text{C}_{n, y} ) \cdot \big( \text{duration\_period}_{y-1} + \frac{1}{\text{fin\_time}_{n, y}} \big) \bigg)
 *
 * The utility discount rate for period :math:`y` is set to :math:`\text{drate}_{n} - \text{grow}_{n,y}`, where :math:`\text{drate}_{n}` is the discount rate used in MESSAGE, typically set to 5%,
 * and :math:`\text{grow}` is the potential GDP growth rate. This choice ensures that in the steady state, the optimal growth rate is identical to the potential GDP growth rates :math:`\text{grow}`.
-* The values for the utility discount rates are chosen for descriptive rather than normative reasons. The term :math:`\frac{\text{duration_period}_{y} + \text{duration_period}_{y-1}}{2}` mutliples the
-* discounted logarithm of consumption with the period length. The final period is treated separately to include a correction factor :math:`\frac{1}{\text{fin_time}_{n, y}}` reflecting
-* the finite time horizon of the model. Note that the sum over nodes :math:`\text{node_active}` is artificial, because :math:`\text{node_active}` only contains one element.
+* The values for the utility discount rates are chosen for descriptive rather than normative reasons. The term :math:`\frac{\text{duration\_period}_{y} + \text{duration\_period}_{y-1}}{2}` mutliples the
+* discounted logarithm of consumption with the period length. The final period is treated separately to include a correction factor :math:`\frac{1}{\text{fin\_time}_{n, y}}` reflecting
+* the finite time horizon of the model. Note that the sum over nodes :math:`\text{node\_active}` is artificial, because :math:`\text{node\_active}` only contains one element.
 *
 ***
 
@@ -181,7 +181,7 @@ C(node_active, year) + I(node_active, year) + EC(node_active, year)
 * The accumulation of capital in the sectors not represented in MESSAGE is governed by new capital stock equation. Net capital formation :math:`\text{KN}_{n,y}` is derived from gross
 * investments :math:`\text{I}_{n,y}` minus depreciation of previsouly existing capital stock.
 *
-* .. math:: \text{KN}_{n,y} = \text{duration_period}_{y} \cdot \text{I}_{n,y} \qquad \forall{n, y > 1}
+* .. math:: \text{KN}_{n,y} = \text{duration\_period}_{y} \cdot \text{I}_{n,y} \qquad \forall{n, y > 1}
 *
 * Here, the initial boundary condition for the base year :math:`y_0` implies for the investments that :math:`\text{I}_{n,y_0} = (\text{grow}_{n,y_0} + \text{depr}_{n}) \cdot \text{kgdp}_{n} \cdot \text{gdp}_{n,y_0}`.
 ***
@@ -212,7 +212,7 @@ YN(node_active, year) =E=
 * Equivalent to the total production equation above, the total capital stock, again excluding those sectors which are modeled in MESSAGE, is then simply a summation
 * of capital stock in the previous period :math:`y-1`, depreciated with the depreciation rate :math:`\text{depr}_{n}`, and the capital stock added in the current period :math:`y`.
 *
-* .. math:: \text{K}_{n, y} = \text{K}_{n, y-1} \cdot { \left( 1 - \text{depr}_n \right) }^{\text{duration_period}_{y}} + \text{KN}_{n, y} \qquad \forall{ n, y > 1}
+* .. math:: \text{K}_{n, y} = \text{K}_{n, y-1} \cdot { \left( 1 - \text{depr}_n \right) }^{\text{duration\_period}_{y}} + \text{KN}_{n, y} \qquad \forall{ n, y > 1}
 *
 ***
 
@@ -227,7 +227,7 @@ SUM(year2$( seq_period(year2,year) ), K(node_active, year2)) * (1 - depr(node_ac
 * Total production in the economy (excluding energy sectors) is the sum of production from  assets that were already existing in the previous period :math:`y-1`,
 * depreciated with the depreciation rate :math:`\text{depr}_{n}`, and the new vintage of production from period :math:`y`.
 *
-* .. math:: \text{Y}_{n, y} = \text{Y}_{n, y-1} \cdot { \left( 1 - \text{depr}_n \right) }^{\text{duration_period}_{y}} + \text{YN}_{n, y} \qquad \forall{ n, y > 1}
+* .. math:: \text{Y}_{n, y} = \text{Y}_{n, y-1} \cdot { \left( 1 - \text{depr}_n \right) }^{\text{duration\_period}_{y}} + \text{YN}_{n, y} \qquad \forall{ n, y > 1}
 *
 ***
 
@@ -243,7 +243,7 @@ SUM(year2$( seq_period(year2,year) ), Y(node_active, year2)) * (1 - depr(node_ac
 * in the previous period :math:`y-1`, depreciated with the depreciation rate :math:`\text{depr}_{n}`, and the the new vintage of energy production from
 * period :math:`y`.
 *
-* .. math:: \text{PRODENE}_{n, s, y} = \text{PRODENE}_{n, s, y-1} \cdot { \left( 1 - \text{depr}_n \right) }^{\text{duration_period}_{y}} + \text{NEWENE}_{n, s, y} \qquad \forall{ n, s, y > 1}
+* .. math:: \text{PRODENE}_{n, s, y} = \text{PRODENE}_{n, s, y-1} \cdot { \left( 1 - \text{depr}_n \right) }^{\text{duration\_period}_{y}} + \text{NEWENE}_{n, s, y} \qquad \forall{ n, s, y > 1}
 *
 ***
 
@@ -258,11 +258,11 @@ SUM(year2$( seq_period(year2,year) ), PRODENE(node_active, sector, year2)) * (1 
 * The relationship below establishes the link between physical energy :math:`\text{PHYSENE}_{r, s, y}` as accounted in MESSAGE for the six commerical energy demands :math:`s` and
 * energy in terms of monetary value :math:`\text{PRODENE}_{n, s, y}` as specified in the production function of MACRO.
 *
-* .. math:: \text{PHYSENE}_{n, s, y} \geq \text{PRODENE}_{n, s, y} \cdot \text{aeei_factor}_{n, s, y} \qquad \forall{ n, s, y > 1}
+* .. math:: \text{PHYSENE}_{n, s, y} \geq \text{PRODENE}_{n, s, y} \cdot \text{aeei\_factor}_{n, s, y} \qquad \forall{ n, s, y > 1}
 *
 * The cumulative effect of autonomous energy efficiency improvements (AEEI) is captured in
-* :math:`\text{aeei_factor}_{n,s,y} = \text{aeei_factor}_{n, s, y-1} \cdot (1 - \text{aeei}_{n,s,y})^{\text{duration_period}_{y}}`
-* with :math:`\text{aeei_factor}_{n,s,y=1} = 1`. Therefore, choosing the :math:`\text{aeei}_{n,s,y}` coefficients appropriately offers the possibility to calibrate MACRO to a certain energy demand trajectory
+* :math:`\text{aeei\_factor}_{n,s,y} = \text{aeei\_factor}_{n, s, y-1} \cdot (1 - \text{aeei}_{n,s,y})^{\text{duration\_period}_{y}}`
+* with :math:`\text{aeei\_factor}_{n,s,y=1} = 1`. Therefore, choosing the :math:`\text{aeei}_{n,s,y}` coefficients appropriately offers the possibility to calibrate MACRO to a certain energy demand trajectory
 * from MESSAGE.
 *
 ***
@@ -278,7 +278,7 @@ PRODENE(node_active, sector, year) * aeei_factor(node_active, sector, year)
 * Energy system costs are based on a previous MESSAGE model run. The approximation of energy system costs in vicinity of the MESSAGE solution are approximated by a Taylor expansion with the
 * first order term using shadow prices :math:`\text{eneprice}_{s, y, n}` of the MESSAGE model's solution and a quadratic second-order term.
 *
-* .. math:: \text{EC}_{n, y} =  & \text{total_cost}_{n, r} \\
+* .. math:: \text{EC}_{n, y} =  & \text{total\_cost}_{n, r} \\
 *                        + & \displaystyle \sum_{s} \text{eneprice}_{s, y, n} \cdot \left( \text{PHYSENE}_{n, s, y} - \text{enestart}_{s, y, n} \right) \\
 *                        + & \displaystyle \sum_{s} \frac{\text{eneprice}_{s, y, n}}{\text{enestart}_{s, y, n}} \cdot \left( \text{PHYSENE}_{n, s, y} - \text{enestart}_{s, y, n} \right)^2 \qquad \forall{ n, y > 1}
 *

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -28,44 +28,44 @@
 *
 * Decision variables
 * ^^^^^^^^^^^^^^^^^^
-* =============================================================== ====================================================================================
-* Variable                                                        Explanatory text
-* =============================================================== ====================================================================================
-* :math:`\text{OBJ} \in \mathbb{R}`                               Objective value of the optimization program
-* :math:`\text{EXT}_{n,c,g,y} \in \mathbb{R}_+`                   Extraction of non-renewable/exhaustible resources from reserves
-* :math:`\text{STOCK}_{n,c,l,y} \in \mathbb{R}_+`                 Quantity in stock (storage) at start of period :math:`y`
-* :math:`\text{STOCK_CHG}_{n,c,l,y,h} \in \mathbb{R}`             Input or output quantity into intertemporal commodity stock (storage)
-* :math:`\text{COST_NODAL}_{n,y} \in \mathbb{R}`                  System costs at the node level over time
-* :math:`\text{REN}_{n,t,c,g,y,h} \in \mathbb{R}_+`               Activity of renewable technologies per grade
-* :math:`\text{CAP_NEW}_{n,t,y} \in \mathbb{R}_+`                 Newly installed capacity (yearly average over period duration)
-* :math:`\text{CAP}_{n,t,y^V,y} \in \mathbb{R}_+`                 Maintained capacity in year :math:`y` of vintage :math:`y^V`
-* :math:`\text{CAP_FIRM}_{n,t,c,l,y,q} \in \mathbb{R}_+`          Capacity counting towards firm (dispatchable)
-* :math:`\text{ACT}_{n,t,y^V,y,m,h} \in \mathbb{R}`               Activity of a technology (by vintage, mode, subannual time)
-* :math:`\text{ACT_RATING}_{n,t,y^V,y,c,l,h,q} \in \mathbb{R}_+`  Auxiliary variable for activity attributed to a particular rating bin [#ACT_RATING]_
-* :math:`\text{CAP_NEW_UP}_{n,t,y} \in \mathbb{R}_+`              Relaxation of upper dynamic constraint on new capacity
-* :math:`\text{CAP_NEW_LO}_{n,t,y} \in \mathbb{R}_+`              Relaxation of lower dynamic constraint on new capacity
-* :math:`\text{ACT_UP}_{n,t,y,h} \in \mathbb{R}_+`                Relaxation of upper dynamic constraint on activity [#ACT_BD]_
-* :math:`\text{ACT_LO}_{n,t,y,h} \in \mathbb{R}_+`                Relaxation of lower dynamic constraint on activity [#ACT_BD]_
-* :math:`\text{LAND}_{n,s,y} \in [0,1]`                           Relative share of land-use scenario (for land-use model emulator)
-* :math:`\text{EMISS}_{n,e,\widehat{t},y} \in \mathbb{R}`         Auxiliary variable for aggregate emissions by technology type
-* :math:`\text{REL}_{r,n,y} \in \mathbb{R}`                       Auxiliary variable for left-hand side of relations (linear constraints)
-* :math:`\text{COMMODITY_USE}_{n,c,l,y} \in \mathbb{R}`           Auxiliary variable for amount of commodity used at specific level
-* :math:`\text{COMMODITY_BALANCE}_{n,c,l,y,h} \in \mathbb{R}`     Auxiliary variable for right-hand side of :ref:`commodity_balance`
-* :math:`\text{STORAGE}_{n,t,m,l,c,y,h} \in \mathbb{R}`           State of charge or content of storage at each sub-annual time slice
-* :math:`\text{STORAGE_CHARGE}_{n,t,m,l,c,y,h} \in \mathbb{R}`    Charging of storage in each sub-annual time slice (negative for discharging)
-* =============================================================== ====================================================================================
+* ================================================================= ====================================================================================
+* Variable                                                          Explanatory text
+* ================================================================= ====================================================================================
+* :math:`\text{OBJ} \in \mathbb{R}`                                 Objective value of the optimization program
+* :math:`\text{EXT}_{n,c,g,y} \in \mathbb{R}_+`                     Extraction of non-renewable/exhaustible resources from reserves
+* :math:`\text{STOCK}_{n,c,l,y} \in \mathbb{R}_+`                   Quantity in stock (storage) at start of period :math:`y`
+* :math:`\text{STOCK\_CHG}_{n,c,l,y,h} \in \mathbb{R}`              Input or output quantity into intertemporal commodity stock (storage)
+* :math:`\text{COST\_NODAL}_{n,y} \in \mathbb{R}`                   System costs at the node level over time
+* :math:`\text{REN}_{n,t,c,g,y,h} \in \mathbb{R}_+`                 Activity of renewable technologies per grade
+* :math:`\text{CAP\_NEW}_{n,t,y} \in \mathbb{R}_+`                  Newly installed capacity (yearly average over period duration)
+* :math:`\text{CAP}_{n,t,y^V,y} \in \mathbb{R}_+`                   Maintained capacity in year :math:`y` of vintage :math:`y^V`
+* :math:`\text{CAP\_FIRM}_{n,t,c,l,y,q} \in \mathbb{R}_+`           Capacity counting towards firm (dispatchable)
+* :math:`\text{ACT}_{n,t,y^V,y,m,h} \in \mathbb{R}`                 Activity of a technology (by vintage, mode, subannual time)
+* :math:`\text{ACT\_RATING}_{n,t,y^V,y,c,l,h,q} \in \mathbb{R}_+`   Auxiliary variable for activity attributed to a particular rating bin [#ACT_RATING]_
+* :math:`\text{CAP\_NEW\_UP}_{n,t,y} \in \mathbb{R}_+`              Relaxation of upper dynamic constraint on new capacity
+* :math:`\text{CAP\_NEW\_LO}_{n,t,y} \in \mathbb{R}_+`              Relaxation of lower dynamic constraint on new capacity
+* :math:`\text{ACT\_UP}_{n,t,y,h} \in \mathbb{R}_+`                 Relaxation of upper dynamic constraint on activity [#ACT_BD]_
+* :math:`\text{ACT\_LO}_{n,t,y,h} \in \mathbb{R}_+`                 Relaxation of lower dynamic constraint on activity [#ACT_BD]_
+* :math:`\text{LAND}_{n,s,y} \in [0,1]`                             Relative share of land-use scenario (for land-use model emulator)
+* :math:`\text{EMISS}_{n,e,\widehat{t},y} \in \mathbb{R}`           Auxiliary variable for aggregate emissions by technology type
+* :math:`\text{REL}_{r,n,y} \in \mathbb{R}`                         Auxiliary variable for left-hand side of relations (linear constraints)
+* :math:`\text{COMMODITY\_USE}_{n,c,l,y} \in \mathbb{R}`            Auxiliary variable for amount of commodity used at specific level
+* :math:`\text{COMMODITY\_BALANCE}_{n,c,l,y,h} \in \mathbb{R}`      Auxiliary variable for right-hand side of :ref:`commodity_balance`
+* :math:`\text{STORAGE}_{n,t,m,l,c,y,h} \in \mathbb{R}`             State of charge or content of storage at each sub-annual time slice
+* :math:`\text{STORAGE\_CHARGE}_{n,t,m,l,c,y,h} \in \mathbb{R}`     Charging of storage in each sub-annual time slice (negative for discharging)
+* ================================================================= ====================================================================================
 *
 * The index :math:`y^V` is the year of construction (vintage) wherever it is necessary to
 * clearly distinguish between year of construction and the year of operation.
 *
 * All decision variables are by year, not by (multi-year) period, except :math:`\text{STOCK}_{n,c,l,y}`.
-* In particular, the new capacity variable :math:`\text{CAP_NEW}_{n,t,y}` has to be multiplied by the number of years
-* in a period :math:`|y| = \text{duration_period}_{y}` to determine the available capacity :math:`\text{CAP}_{n,t,y^V,y}`
+* In particular, the new capacity variable :math:`\text{CAP\_NEW}_{n,t,y}` has to be multiplied by the number of years
+* in a period :math:`|y| = \text{duration\_period}_{y}` to determine the available capacity :math:`\text{CAP}_{n,t,y^V,y}`
 * in subsequent periods (assuming the newly build capacity is not immediately decommissioned):
 *
-* :math:`\text{CAP}_{n,t,y^V,y} = \text{CAP_NEW}_{n,t,y} \cdot \text{duration_period}_{y}`
+* :math:`\text{CAP}_{n,t,y^V,y} = \text{CAP\_NEW}_{n,t,y} \cdot \text{duration\_period}_{y}`
 *
-* :math:`\text{CAP_NEW}_{n,t,y}` is therefore the amount of newly installed capacity *in one year* and
+* :math:`\text{CAP\_NEW}_{n,t,y}` is therefore the amount of newly installed capacity *in one year* and
 * :math:`\text{CAP}_{n,t,y^V,y}` the amount, which is installed at the *end of a (usually multi-year) period*.
 * This formulation gives more flexibility when it comes to using periods of different duration
 * (more intuitive comparison across different periods).
@@ -73,7 +73,7 @@
 * The current model framework allows both input or output normalized formulation.
 * This will affect the parametrization, see Section :ref:`efficiency_output` for more details.
 *
-* .. [#ACT_RATING] The auxiliary variable :math:`\text{ACT_RATING}_{n,t,y^V,y,c,l,h,q}` is defined in terms of input or
+* .. [#ACT_RATING] The auxiliary variable :math:`\text{ACT\_RATING}_{n,t,y^V,y,c,l,h,q}` is defined in terms of input or
 *    output of the technology.
 *
 * .. [#ACT_BD] The dynamic activity constraints are implemented as summed over all modes;
@@ -131,15 +131,15 @@ Variables
 *
 * Auxiliary variables
 * ^^^^^^^^^^^^^^^^^^^
-* =========================================================================== ======================================================================================================
-* Variable                                                                    Explanatory text
-* =========================================================================== ======================================================================================================
-* :math:`\text{DEMAND}_{n,c,l,y,h} \in \mathbb{R}`                            Demand level (in equilibrium with MACRO integration)
-* :math:`\text{PRICE_COMMODITY}_{n,c,l,y,h} \in \mathbb{R}`                   Commodity price (undiscounted marginals of :ref:`commodity_balance_gt` and :ref:`commodity_balance_lt`)
-* :math:`\text{PRICE_EMISSION}_{n,\widehat{e},\widehat{t},y} \in \mathbb{R}`  Emission price (undiscounted marginals of :ref:`emission_constraint`)
-* :math:`\text{COST_NODAL_NET}_{n,y} \in \mathbb{R}`                          System costs at the node level net of energy trade revenues/cost
-* :math:`\text{GDP}_{n,y} \in \mathbb{R}`                                     Gross domestic product (GDP) in market exchange rates for MACRO reporting
-* =========================================================================== ======================================================================================================
+* ============================================================================= ======================================================================================================
+* Variable                                                                      Explanatory text
+* ============================================================================= ======================================================================================================
+* :math:`\text{DEMAND}_{n,c,l,y,h} \in \mathbb{R}`                              Demand level (in equilibrium with MACRO integration)
+* :math:`\text{PRICE\_COMMODITY}_{n,c,l,y,h} \in \mathbb{R}`                    Commodity price (undiscounted marginals of :ref:`commodity_balance_gt` and :ref:`commodity_balance_lt`)
+* :math:`\text{PRICE\_EMISSION}_{n,\widehat{e},\widehat{t},y} \in \mathbb{R}`   Emission price (undiscounted marginals of :ref:`emission_constraint`)
+* :math:`\text{COST\_NODAL\_NET}_{n,y} \in \mathbb{R}`                          System costs at the node level net of energy trade revenues/cost
+* :math:`\text{GDP}_{n,y} \in \mathbb{R}`                                       Gross domestic product (GDP) in market exchange rates for MACRO reporting
+* ============================================================================= ======================================================================================================
 *
 ***
 
@@ -313,7 +313,7 @@ Equations
 * relaxations of dynamic constraints
 *
 * .. math::
-*    \text{OBJ} = \sum_{n,y \in Y^{M}} \text{df_period}_{y} \cdot \text{COST_NODAL}_{n,y}
+*    \text{OBJ} = \sum_{n,y \in Y^{M}} \text{df\_period}_{y} \cdot \text{COST\_NODAL}_{n,y}
 *
 ***
 OBJECTIVE..
@@ -336,33 +336,33 @@ OBJECTIVE..
 * and linear relations.
 *
 * .. math::
-*    \text{COST_NODAL}_{n,y} & = \sum_{c,g} \ \text{resource_cost}_{n,c,g,y} \cdot \text{EXT}_{n,c,g,y} \\
+*    \text{COST\_NODAL}_{n,y} & = \sum_{c,g} \ \text{resource\_cost}_{n,c,g,y} \cdot \text{EXT}_{n,c,g,y} \\
 *      & + \sum_{t} \
-*          \bigg( \text{inv_cost}_{n,t,y} \cdot \text{construction_time_factor}_{n,t,y} \\
-*      & \quad \quad \quad \cdot \text{end_of_horizon_factor}_{n,t,y} \cdot \text{CAP_NEW}_{n,t,y} \\[4 pt]
-*      & \quad \quad + \sum_{y^V \leq y} \ \text{fix_cost}_{n,t,y^V,y} \cdot \text{CAP}_{n,t,y^V,y} \\
-*      & \quad \quad + \sum_{\substack{y^V \leq y \\ m,h}} \ \text{var_cost}_{n,t,y^V,y,m,h} \cdot \text{ACT}_{n,t,y^V,y,m,h} \\
-*      & \quad \quad + \Big( \text{abs_cost_new_capacity_soft_up}_{n,t,y} \\
+*          \bigg( \text{inv\_cost}_{n,t,y} \cdot \text{construction\_time\_factor}_{n,t,y} \\
+*      & \quad \quad \quad \cdot \text{end\_of\_horizon\_factor}_{n,t,y} \cdot \text{CAP\_NEW}_{n,t,y} \\[4 pt]
+*      & \quad \quad + \sum_{y^V \leq y} \ \text{fix\_cost}_{n,t,y^V,y} \cdot \text{CAP}_{n,t,y^V,y} \\
+*      & \quad \quad + \sum_{\substack{y^V \leq y \\ m,h}} \ \text{var\_cost}_{n,t,y^V,y,m,h} \cdot \text{ACT}_{n,t,y^V,y,m,h} \\
+*      & \quad \quad + \Big( \text{abs\_cost\_new\_capacity\_soft\_up}_{n,t,y} \\
 *      & \quad \quad \quad
-*          + \text{level_cost_new_capacity_soft_up}_{n,t,y} \cdot\ \text{inv_cost}_{n,t,y}
-*          \Big) \cdot \text{CAP_NEW_UP}_{n,t,y} \\[4pt]
-*      & \quad \quad + \Big( \text{abs_cost_new_capacity_soft_lo}_{n,t,y} \\
+*          + \text{level\_cost\_new\_capacity\_soft\_up}_{n,t,y} \cdot\ \text{inv\_cost}_{n,t,y}
+*          \Big) \cdot \text{CAP\_NEW\_UP}_{n,t,y} \\[4pt]
+*      & \quad \quad + \Big( \text{abs\_cost\_new\_capacity\_soft\_lo}_{n,t,y} \\
 *      & \quad \quad \quad
-*          + \text{level_cost_new_capacity_soft_lo}_{n,t,y} \cdot\ \text{inv_cost}_{n,t,y}
-*          \Big) \cdot \text{CAP_NEW_LO}_{n,t,y} \\[4pt]
-*      & \quad \quad + \sum_{m,h} \ \Big( \text{abs_cost_activity_soft_up}_{n,t,y,m,h} \\
+*          + \text{level\_cost\_new\_capacity\_soft\_lo}_{n,t,y} \cdot\ \text{inv\_cost}_{n,t,y}
+*          \Big) \cdot \text{CAP\_NEW\_LO}_{n,t,y} \\[4pt]
+*      & \quad \quad + \sum_{m,h} \ \Big( \text{abs\_cost\_activity\_soft\_up}_{n,t,y,m,h} \\
 *      & \quad \quad \quad
-*          + \text{level_cost_activity_soft_up}_{n,t,y,m,h} \cdot\ \text{levelized_cost}_{n,t,y,m,h}
-*          \Big) \cdot \text{ACT_UP}_{n,t,y,h} \\
-*      & \quad \quad + \sum_{m,h} \ \Big( \text{abs_cost_activity_soft_lo}_{n,t,y,m,h} \\
+*          + \text{level\_cost\_activity\_soft\_up}_{n,t,y,m,h} \cdot\ \text{levelized\_cost}_{n,t,y,m,h}
+*          \Big) \cdot \text{ACT\_UP}_{n,t,y,h} \\
+*      & \quad \quad + \sum_{m,h} \ \Big( \text{abs\_cost\_activity\_soft\_lo}_{n,t,y,m,h} \\
 *      & \quad \quad \quad
-*          + \text{level_cost_activity_soft_lo}_{n,t,y,m,h} \cdot\ \text{levelized_cost}_{n,t,y,m,h}
-*          \Big) \cdot \text{ACT_LO}_{n,t,y,h} \bigg) \\
+*          + \text{level\_cost\_activity\_soft\_lo}_{n,t,y,m,h} \cdot\ \text{levelized\_cost}_{n,t,y,m,h}
+*          \Big) \cdot \text{ACT\_LO}_{n,t,y,h} \bigg) \\
 *      & + \sum_{\substack{\widehat{e},\widehat{t} \\ e \in E(\widehat{e})}}
-*            \text{emission_scaling}_{\widehat{e},e} \cdot \ \text{emission_tax}_{n,\widehat{e},\widehat{t},y}
+*            \text{emission\_scaling}_{\widehat{e},e} \cdot \ \text{emission\_tax}_{n,\widehat{e},\widehat{t},y}
 *            \cdot \text{EMISS}_{n,e,\widehat{t},y} \\
-*      & + \sum_{s} \text{land_cost}_{n,s,y} \cdot \text{LAND}_{n,s,y} \\
-*      & + \sum_{r} \text{relation_cost}_{r,n,y} \cdot \text{REL}_{r,n,y}
+*      & + \sum_{s} \text{land\_cost}_{n,s,y} \cdot \text{LAND}_{n,s,y} \\
+*      & + \sum_{r} \text{relation\_cost}_{r,n,y} \cdot \text{REL}_{r,n,y}
 ***
 
 COST_ACCOUNTING_NODAL(node, year)..
@@ -496,7 +496,7 @@ EXTRACTION_EQUIVALENCE(node,commodity,year)..
 * This constraint specifies an upper bound on resource extraction by grade.
 *
 *  .. math::
-*     \text{EXT}_{n,c,g,y} \leq \text{bound_extraction_up}_{n,c,g,y}
+*     \text{EXT}_{n,c,g,y} \leq \text{bound\_extraction\_up}_{n,c,g,y}
 *
 ***
 EXTRACTION_BOUND_UP(node,commodity,grade,year)$( map_resource(node,commodity,grade,year)
@@ -514,9 +514,9 @@ EXTRACTION_BOUND_UP(node,commodity,grade,year)$( map_resource(node,commodity,gra
 *
 *  .. math::
 *     \text{EXT}_{n,c,g,y} \leq
-*     \text{resource_remaining}_{n,c,g,y} \cdot
-*         \Big( & \text{resource_volume}_{n,c,g} \\
-*               & - \sum_{y' < y} \text{duration_period}_{y'} \cdot \text{EXT}_{n,c,g,y'} \Big)
+*     \text{resource\_remaining}_{n,c,g,y} \cdot
+*         \Big( & \text{resource\_volume}_{n,c,g} \\
+*               & - \sum_{y' < y} \text{duration\_period}_{y'} \cdot \text{EXT}_{n,c,g,y'} \Big)
 *
 ***
 RESOURCE_CONSTRAINT(node,commodity,grade,year)$( map_resource(node,commodity,grade,year)
@@ -537,7 +537,7 @@ RESOURCE_CONSTRAINT(node,commodity,grade,year)$( map_resource(node,commodity,gra
 * This constraint ensures that total resource extraction over the model horizon does not exceed the available resources.
 *
 *  .. math::
-*     \sum_{y} \text{duration_period}_{y} \cdot \text{EXT}_{n,c,g,y} \leq  \text{resource_volume}_{n,c,g}
+*     \sum_{y} \text{duration\_period}_{y} \cdot \text{EXT}_{n,c,g,y} \leq  \text{resource\_volume}_{n,c,g}
 *
 ***
 RESOURCE_HORIZON(node,commodity,grade)$( SUM(year$map_resource(node,commodity,grade,year), 1 ) )..
@@ -552,17 +552,17 @@ RESOURCE_HORIZON(node,commodity,grade)$( SUM(year$map_resource(node,commodity,gr
 *
 * Auxiliary COMMODITY_BALANCE
 * """""""""""""""""""""""""""
-* For the commodity balance constraints below, we introduce an auxiliary variable called :math:`\text{COMMODITY_BALANCE}`. This is implemented
+* For the commodity balance constraints below, we introduce an auxiliary variable called :math:`\text{COMMODITY\_BALANCE}`. This is implemented
 * as a GAMS ``$macro`` function.
 *
 *  .. math::
 *     \sum_{\substack{n^L,t,m,h^A \\ y^V \leq y}} \text{output}_{n^L,t,y^V,y,m,n,c,l,h^A,h}
-*         \cdot \text{duration_time_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A} & \\
+*         \cdot \text{duration\_time\_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A} & \\
 *     - \sum_{\substack{n^L,t,m,h^A \\ y^V \leq y}} \text{input}_{n^L,t,y^V,y,m,n,c,l,h^A,h}
-*         \cdot \text{duration_time_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,m,y,h^A} & \\
-*     + \ \text{STOCK_CHG}_{n,c,l,y,h} + \ \sum_s \Big( \text{land_output}_{n,s,y,c,l,h} - \text{land_input}_{n,s,y,c,l,h} \Big) \cdot & \text{LAND}_{n,s,y} \\[4pt]
+*         \cdot \text{duration\_time\_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,m,y,h^A} & \\
+*     + \ \text{STOCK\_CHG}_{n,c,l,y,h} + \ \sum_s \Big( \text{land\_output}_{n,s,y,c,l,h} - \text{land\_input}_{n,s,y,c,l,h} \Big) \cdot & \text{LAND}_{n,s,y} \\[4pt]
 *     - \ \text{demand_fixed}_{n,c,l,y,h}
-*     = \text{COMMODITY_BALANCE}_{n,c,l,y,h} \quad \forall \ l \notin (L^{\text{RES}}, & L^{\text{REN}}, L^{\text{STOR}} \subseteq L)
+*     = \text{COMMODITY\_BALANCE}_{n,c,l,y,h} \quad \forall \ l \notin (L^{\text{RES}}, \& L^{\text{REN}}, L^{\text{STOR}} \subseteq L)
 *
 * The commodity balance constraint at the resource level is included in the `Equation RESOURCE_CONSTRAINT`_,
 * while at the renewable level, it is included in the `Equation RENEWABLES_EQUIVALENCE`_,
@@ -595,7 +595,7 @@ $macro COMMODITY_BALANCE(node,commodity,level,year,time) (                      
 * This constraint ensures that supply is greater or equal than demand for every commodity-level combination.
 *
 *  .. math::
-*     \text{COMMODITY_BALANCE}_{n,c,l,y,h} \geq 0
+*     \text{COMMODITY\_BALANCE}_{n,c,l,y,h} \geq 0
 *
 ***
 COMMODITY_BALANCE_GT(node,commodity,level,year,time)$( map_commodity(node,commodity,level,year,time)
@@ -611,11 +611,11 @@ COMMODITY_BALANCE_GT(node,commodity,level,year,time)$( map_commodity(node,commod
 * Equation COMMODITY_BALANCE_LT
 * """""""""""""""""""""""""""""
 * This constraint ensures that the supply is smaller than or equal to the demand for all commodity-level combinations
-* given in the :math:`\text{balance_equality}_{c,l}`. In combination with the constraint above, it ensures that supply
+* given in the :math:`\text{balance\_equality}_{c,l}`. In combination with the constraint above, it ensures that supply
 * is (exactly) equal to demand.
 *
 *  .. math::
-*     \text{COMMODITY_BALANCE}_{n,c,l,y,h} \leq 0
+*     \text{COMMODITY\_BALANCE}_{n,c,l,y,h} \leq 0
 *
 ***
 COMMODITY_BALANCE_LT(node,commodity,level,year,time)$( map_commodity(node,commodity,level,year,time)
@@ -632,11 +632,11 @@ COMMODITY_BALANCE_LT(node,commodity,level,year,time)$( map_commodity(node,commod
 * Equation STOCKS_BALANCE
 * """""""""""""""""""""""
 * This constraint ensures the inter-temporal balance of commodity stocks.
-* The parameter :math:`\text{commodity_stocks}_{n,c,l}` can be used to model exogenous additions to the stock
+* The parameter :math:`\text{commodity\_stocks}_{n,c,l}` can be used to model exogenous additions to the stock
 *
 *  .. math::
-*     \text{STOCK}_{n,c,l,y} + \text{commodity_stock}_{n,c,l,y} =
-*         \text{duration_period}_{y} \cdot & \sum_{h} \text{STOCK_CHG}_{n,c,l,y,h} \\
+*     \text{STOCK}_{n,c,l,y} + \text{commodity\_stock}_{n,c,l,y} =
+*         \text{duration\_period}_{y} \cdot & \sum_{h} \text{STOCK\_CHG}_{n,c,l,y,h} \\
 *                                    & + \text{STOCK}_{n,c,l,y+1}
 *
 ***
@@ -666,11 +666,11 @@ STOCKS_BALANCE(node,commodity,level,year)$( map_stocks(node,commodity,level,year
 * Equation CAPACITY_CONSTRAINT
 * """"""""""""""""""""""""""""
 * This constraint ensures that the actual activity of a technology at a node cannot exceed available (maintained)
-* capacity summed over all vintages, including the technology capacity factor :math:`\text{capacity_factor}_{n,t,y,t}`.
+* capacity summed over all vintages, including the technology capacity factor :math:`\text{capacity\_factor}_{n,t,y,t}`.
 *
 *  .. math::
 *     \sum_{m} \text{ACT}_{n,t,y^V,y,m,h}
-*         \leq \text{duration_time}_{h} \cdot \text{capacity_factor}_{n,t,y^V,y,h} \cdot \text{CAP}_{n,t,y^V,y}
+*         \leq \text{duration\_time}_{h} \cdot \text{capacity\_factor}_{n,t,y^V,y,h} \cdot \text{CAP}_{n,t,y^V,y}
 *         \quad \forall \ t \ \in \ T^{\text{INV}}
 *
 ***
@@ -692,11 +692,11 @@ CAPACITY_CONSTRAINT(node,inv_tec,vintage,year,time)$( map_tec_time(node,inv_tec,
 * as installed capacity in the first model period.
 *
 *   .. math::
-*      \text{CAP}_{n,t,y^V,\text{'first_period'}} & \leq
-*          \text{remaining_capacity}_{n,t,y^V,\text{'first_period'}} \cdot
-*          \text{duration_period}_{y^V} \cdot
-*          \text{historical_new_capacity}_{n,t,y^V} \\
-*      & \text{if } y^V  < \text{'first_period'} \text{ and } |y| - |y^V| < \text{technical_lifetime}_{n,t,y^V}
+*      \text{CAP}_{n,t,y^V,\text{'first\_period'}} & \leq
+*          \text{remaining\_capacity}_{n,t,y^V,\text{'first\_period'}} \cdot
+*          \text{duration\_period}_{y^V} \cdot
+*          \text{historical\_new\_capacity}_{n,t,y^V} \\
+*      & \text{if } y^V  < \text{'first\_period'} \text{ and } |y| - |y^V| < \text{technical\_lifetime}_{n,t,y^V}
 *      \quad \forall \ t \in T^{\text{INV}}
 *
 ***
@@ -716,9 +716,9 @@ CAPACITY_MAINTENANCE_HIST(node,inv_tec,vintage,first_period)$( map_tec_lifetime(
 *
 *   .. math::
 *      \text{CAP}_{n,t,y^V,y^V} =
-*          \text{remaining_capacity}_{n,t,y^V,y^V} \cdot
-*          \text{duration_period}_{y^V} \cdot
-*          \text{CAP_NEW}_{n,t,y^V}
+*          \text{remaining\_capacity}_{n,t,y^V,y^V} \cdot
+*          \text{duration\_period}_{y^V} \cdot
+*          \text{CAP\_NEW}_{n,t,y^V}
 *      \quad \forall \ t \in T^{\text{INV}}
 *
 * The current formulation does not account for construction time in the constraints, but only adds a mark-up
@@ -739,9 +739,9 @@ CAPACITY_MAINTENANCE_NEW(node,inv_tec,vintage,vintage)$( map_tec_lifetime(node,i
 *
 *   .. math::
 *      \text{CAP}_{n,t,y^V,y} & \leq
-*          \text{remaining_capacity}_{n,t,y^V,y} \cdot
+*          \text{remaining\_capacity}_{n,t,y^V,y} \cdot
 *          \text{CAP}_{n,t,y^V,y-1} \\
-*      \quad & \text{if } y > y^V \text{ and } y^V  > \text{'first_period'} \text{ and } |y| - |y^V| < \text{technical_lifetime}_{n,t,y^V}
+*      \quad & \text{if } y > y^V \text{ and } y^V  > \text{'first\_period'} \text{ and } |y| - |y^V| < \text{technical\_lifetime}_{n,t,y^V}
 *      \quad \forall \ t \in T^{\text{INV}}
 *
 ***
@@ -762,10 +762,10 @@ CAPACITY_MAINTENANCE(node,inv_tec,vintage,year)$( map_tec_lifetime(node,inv_tec,
 *
 *   .. math::
 *      \sum_{m,h} \text{ACT}_{n,t,y^V,y,m,h}
-*          \leq \text{operation_factor}_{n,t,y^V,y} \cdot \text{capacity_factor}_{n,t,y^V,y,m,\text{'year'}} \cdot \text{CAP}_{n,t,y^V,y}
+*          \leq \text{operation\_factor}_{n,t,y^V,y} \cdot \text{capacity\_factor}_{n,t,y^V,y,m,\text{'year'}} \cdot \text{CAP}_{n,t,y^V,y}
 *      \quad \forall \ t \in T^{\text{INV}}
 *
-* This constraint is only active if :math:`\text{operation_factor}_{n,t,y^V,y} < 1`.
+* This constraint is only active if :math:`\text{operation\_factor}_{n,t,y^V,y} < 1`.
 ***
 OPERATION_CONSTRAINT(node,inv_tec,vintage,year)$( map_tec_lifetime(node,inv_tec,vintage,year)
         AND operation_factor(node,inv_tec,vintage,year) < 1 )..
@@ -781,10 +781,10 @@ OPERATION_CONSTRAINT(node,inv_tec,vintage,year)$( map_tec_lifetime(node,inv_tec,
 * This constraint provides a lower bound on the total utilization of installed capacity over a year.
 *
 *   .. math::
-*      \sum_{m,h} \text{ACT}_{n,t,y^V,y,m,h} \geq \text{min_utilization_factor}_{n,t,y^V,y} \cdot \text{CAP}_{n,t,y^V,y}
+*      \sum_{m,h} \text{ACT}_{n,t,y^V,y,m,h} \geq \text{min\_utilization\_factor}_{n,t,y^V,y} \cdot \text{CAP}_{n,t,y^V,y}
 *      \quad \forall \ t \in T^{\text{INV}}
 *
-* This constraint is only active if :math:`\text{min_utilization_factor}_{n,t,y^V,y}` is defined.
+* This constraint is only active if :math:`\text{min\_utilization\_factor}_{n,t,y^V,y}` is defined.
 ***
 MIN_UTILIZATION_CONSTRAINT(node,inv_tec,vintage,year)$( map_tec_lifetime(node,inv_tec,vintage,year)
         AND min_utilization_factor(node,inv_tec,vintage,year) )..
@@ -830,7 +830,7 @@ RENEWABLES_EQUIVALENCE(node,renewable_tec,commodity,year,time)$(
 *
 *  .. math::
 *     \sum_{\substack{t,h \\ \ t \in T^{R} \subseteq t }} \text{REN}_{n,t,c,g,y,h}
-*         \leq \sum_{\substack{l \\ l \in L^{R} \subseteq L }} \text{renewable_potential}_{n,c,g,l,y}
+*         \leq \sum_{\substack{l \\ l \in L^{R} \subseteq L }} \text{renewable\_potential}_{n,c,g,l,y}
 *
 ***
 RENEWABLES_POTENTIAL_CONSTRAINT(node,commodity,grade,year)$( map_ren_grade(node,commodity,grade,year) )..
@@ -851,10 +851,10 @@ RENEWABLES_POTENTIAL_CONSTRAINT(node,commodity,grade,year)$( map_ren_grade(node,
 * capacities to provide their full potential.
 *
 *  .. math::
-*     \sum_{y^V, h} & \text{CAP}_{n,t,y^V,y} \cdot \text{operation_factor}_{n,t,y^V,y} \cdot \text{capacity_factor}_{n,t,y^V,y,h} \\
-*        & \quad \geq \sum_{g,h,l} \frac{1}{\text{renewable_capacity_factor}_{n,c,g,l,y}} \cdot \text{REN}_{n,t,c,g,y,h}
+*     \sum_{y^V, h} & \text{CAP}_{n,t,y^V,y} \cdot \text{operation\_factor}_{n,t,y^V,y} \cdot \text{capacity\_factor}_{n,t,y^V,y,h} \\
+*        & \quad \geq \sum_{g,h,l} \frac{1}{\text{renewable\_capacity\_factor}_{n,c,g,l,y}} \cdot \text{REN}_{n,t,c,g,y,h}
 *
-* This constraint is only active if :math:`\text{renewable_capacity_factor}_{n,c,g,l,y}` is defined.
+* This constraint is only active if :math:`\text{renewable\_capacity\_factor}_{n,c,g,l,y}` is defined.
 ***
 RENEWABLES_CAPACITY_REQUIREMENT(node,inv_tec,commodity,year)$(
         SUM( (vintage,mode,time,grade,level_renewable),
@@ -887,8 +887,8 @@ RENEWABLES_CAPACITY_REQUIREMENT(node,inv_tec,commodity,year)$(
 *      \sum_{\substack{t^a, y^V \leq y}} \text{ACT}_{n,t^a,y^V,y,m,h}
 *      \leq
 *      \sum_{\substack{t, y^V \leq y}}
-*          & \text{addon_up}_{n,t,y,m,h,\widehat{t^a}} \cdot
-*          \text{addon_conversion}_{n,t,y^V,y,m,h,\widehat{t^a}} \\
+*          & \text{addon\_up}_{n,t,y,m,h,\widehat{t^a}} \cdot
+*          \text{addon\_conversion}_{n,t,y^V,y,m,h,\widehat{t^a}} \\
 *          & \cdot \text{ACT}_{n,t,y^V,y,m,h} \quad \forall \ t^a \in T^{A}
 *
 ***
@@ -926,8 +926,8 @@ ADDON_ACTIVITY_UP(node,type_addon,year,mode,time)..
 *      \sum_{\substack{t^a, y^V \leq y}} \text{ACT}_{n,t^a,y^V,y,m,h}
 *      \geq
 *      \sum_{\substack{t, y^V \leq y}}
-*          & \text{addon_lo}_{n,t,y,m,h,\widehat{t^a}} \cdot
-*          \text{addon_conversion}_{n,t,y^V,y,m,h,\widehat{t^a}} \\
+*          & \text{addon\_lo}_{n,t,y,m,h,\widehat{t^a}} \cdot
+*          \text{addon\_conversion}_{n,t,y^V,y,m,h,\widehat{t^a}} \\
 *          & \cdot \text{ACT}_{n,t,y^V,y,m,h} \quad \forall \ t^a \in T^{A}
 *
 ***
@@ -967,16 +967,16 @@ ADDON_ACTIVITY_LO(node,type_addon,year,mode,time)..
 *
 * Equation COMMODITY_USE_LEVEL
 * """"""""""""""""""""""""""""
-* This constraint defines the auxiliary variable :math:`\text{COMMODITY_USE}_{n,c,l,y}`, which is used to define
+* This constraint defines the auxiliary variable :math:`\text{COMMODITY\_USE}_{n,c,l,y}`, which is used to define
 * the rating bins and the peak-load that needs to be offset with firm (dispatchable) capacity.
 *
 *   .. math::
-*      \text{COMMODITY_USE}_{n,c,l,y}
+*      \text{COMMODITY\_USE}_{n,c,l,y}
 *      = & \sum_{n^L,t,y^V,m,h} \text{input}_{n^L,t,y^V,y,m,n,c,l,h,h} \\
-*        & \quad    \cdot \text{duration_time_rel}_{h,h} \cdot \text{ACT}_{n^L,t,y^V,y,m,h}
+*        & \quad    \cdot \text{duration\_time\_rel}_{h,h} \cdot \text{ACT}_{n^L,t,y^V,y,m,h}
 *
-* This constraint and the auxiliary variable is only active if :math:`\text{peak_load_factor}_{n,c,l,y,h}` or
-* :math:`\text{flexibility_factor}_{n,t,y^V,y,m,c,l,h,r}` is defined.
+* This constraint and the auxiliary variable is only active if :math:`\text{peak\_load\_factor}_{n,c,l,y,h}` or
+* :math:`\text{flexibility\_factor}_{n,t,y^V,y,m,c,l,h,r}` is defined.
 ***
 COMMODITY_USE_LEVEL(node,commodity,level,year,time)$(
          peak_load_factor(node,commodity,level,year,time) OR
@@ -1005,8 +1005,8 @@ COMMODITY_USE_LEVEL(node,commodity,level,year,time)$(
 * the share of the rating bin in relation to the total commodity use.
 *
 * .. math::
-*    \text{ACT_RATING}_{n,t,y^V,y,c,l,h,q}
-*    \leq \text{rating_bin}_{n,t,y,c,l,h,q} \cdot \text{COMMODITY_USE}_{n,c,l,y}
+*    \text{ACT\_RATING}_{n,t,y^V,y,c,l,h,q}
+*    \leq \text{rating\_bin}_{n,t,y,c,l,h,q} \cdot \text{COMMODITY\_USE}_{n,c,l,y}
 *
 ***
 ACTIVITY_BY_RATING(node,tec,year,commodity,level,time,rating)$(
@@ -1025,10 +1025,10 @@ ACTIVITY_BY_RATING(node,tec,year,commodity,level,time,rating)$(
 * of the technology.
 *
 * .. math::
-*    \sum_q \text{ACT_RATING}_{n,t,y^V,y,c,l,h,q}
+*    \sum_q \text{ACT\_RATING}_{n,t,y^V,y,c,l,h,q}
 *    = \sum_{\substack{n^L,t,m,h^A \\ y^V \leq y}} &
 *         ( \text{input}_{n^L,t,y^V,y,m,n,c,l,h^A,h} + \text{output}_{n^L,t,y^V,y,m,n,c,l,h^A,h} ) \\
-*      & \quad    \cdot \text{duration_time_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A} \\
+*      & \quad    \cdot \text{duration\_time\_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A} \\
 *
 ***
 ACTIVITY_RATING_TOTAL(node,tec,vintage,year,commodity,level,time)$(
@@ -1053,23 +1053,23 @@ ACTIVITY_RATING_TOTAL(node,tec,vintage,year,commodity,level,time)$(
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * The "firm capacity" that a technology can contribute to system reliability depends on its dispatch characteristics.
 * For dispatchable technologies, the total installed capacity counts toward the firm capacity constraint.
-* This is active if the parameter is defined over :math:`\text{reliability_factor}_{n,t,y,c,l,h,\text{'firm'}}`.
+* This is active if the parameter is defined over :math:`\text{reliability\_factor}_{n,t,y,c,l,h,\text{'firm'}}`.
 * For non-dispatchable technologies, or those that do not have explicit investment decisions,
 * the contribution to system reliability is calculated
-* by using the auxiliary variable :math:`\text{ACT_RATING}_{n,t,y^V,y,c,l,h,q}` as a proxy,
-* with the :math:`\text{reliability_factor}_{n,t,y,c,l,h,q}` defined per rating bin :math:`q`.
+* by using the auxiliary variable :math:`\text{ACT\_RATING}_{n,t,y^V,y,c,l,h,q}` as a proxy,
+* with the :math:`\text{reliability\_factor}_{n,t,y,c,l,h,q}` defined per rating bin :math:`q`.
 *
 * .. _equation_firm_capacity_provision:
 *
 * Equation FIRM_CAPACITY_PROVISION
 * """"""""""""""""""""""""""""""""
 * Technologies where the reliability factor is defined with the rating `firm`
-* have an auxiliary variable :math:`\text{CAP_FIRM}_{n,t,c,l,y}`, defined in terms of output.
+* have an auxiliary variable :math:`\text{CAP\_FIRM}_{n,t,c,l,y}`, defined in terms of output.
 *
 *   .. math::
-*      \text{CAP_FIRM}_{n,t,c,l,y}
-*      = \sum_{y^V \leq y} & \text{output}_{n^L,t,y^V,y,m,n,c,l,h^A,h} \cdot \text{duration_time}_h \\
-*        & \quad    \cdot \text{capacity_factor}_{n,t,y^V,y,h} \cdot \text{CAP}_{n,t,y^Y,y}
+*      \text{CAP\_FIRM}_{n,t,c,l,y}
+*      = \sum_{y^V \leq y} & \text{output}_{n^L,t,y^V,y,m,n,c,l,h^A,h} \cdot \text{duration\_time}_h \\
+*        & \quad    \cdot \text{capacity\_factor}_{n,t,y^V,y,h} \cdot \text{CAP}_{n,t,y^Y,y}
 *      \quad \forall \ t \in T^{\text{INV}}
 *
 ***
@@ -1094,14 +1094,14 @@ FIRM_CAPACITY_PROVISION(node,inv_tec,year,commodity,level,time)$(
 *
 *   .. math::
 *      \sum_{t, q \substack{t \in T^{\text{INV}} \\ y^V \leq y} } &
-*          \text{reliability_factor}_{n,t,y,c,l,h,\text{'firm'}}
-*          \cdot \text{CAP_FIRM}_{n,t,c,l,y} \\
+*          \text{reliability\_factor}_{n,t,y,c,l,h,\text{'firm'}}
+*          \cdot \text{CAP\_FIRM}_{n,t,c,l,y} \\
 *      + \sum_{t,q,y^V \leq y} &
-*          \text{reliability_factor}_{n,t,y,c,l,h,q}
-*         \cdot \text{ACT_RATING}_{n,t,y^V,y,c,l,h,q} \\
-*         & \quad \geq \text{peak_load_factor}_{n,c,l,y,h} \cdot \text{COMMODITY_USE}_{n,c,l,y}
+*          \text{reliability\_factor}_{n,t,y,c,l,h,q}
+*         \cdot \text{ACT\_RATING}_{n,t,y^V,y,c,l,h,q} \\
+*         & \quad \geq \text{peak\_load\_factor}_{n,c,l,y,h} \cdot \text{COMMODITY\_USE}_{n,c,l,y}
 *
-* This constraint is only active if :math:`\text{peak_load_factor}_{n,c,l,y,h}` is defined.
+* This constraint is only active if :math:`\text{peak\_load\_factor}_{n,c,l,y,h}` is defined.
 ***
 SYSTEM_RELIABILITY_CONSTRAINT(node,commodity,level,year,time)$( peak_load_factor(node,commodity,level,year,time) )..
     SUM(inv_tec$( reliability_factor(node,inv_tec,year,commodity,level,time,'firm') ),
@@ -1125,15 +1125,15 @@ SYSTEM_RELIABILITY_CONSTRAINT(node,commodity,level,year,time)$( peak_load_factor
 *
 *   .. math::
 *      \sum_{\substack{n^L,t,m,h^A \\ y^V \leq y}} &
-*          \text{flexibility_factor}_{n^L,t,y^V,y,m,c,l,h,\text{'unrated'}} \\
+*          \text{flexibility\_factor}_{n^L,t,y^V,y,m,c,l,h,\text{'unrated'}} \\
 *      & \quad   \cdot ( \text{output}_{n^L,t,y^V,y,m,n,c,l,h^A,h} + \text{input}_{n^L,t,y^V,y,m,n,c,l,h^A,h} ) \\
-*      & \quad   \cdot \text{duration_time_rel}_{h,h^A}
+*      & \quad   \cdot \text{duration\_time\_rel}_{h,h^A}
 *                \cdot \text{ACT}_{n,t,y^V,y,m,h} \\
 *      + \sum_{\substack{n^L,t,m,h^A \\ y^V \leq y}} &
-*         \text{flexibility_factor}_{n^L,t,y^V,y,m,c,l,h,1} \\
+*         \text{flexibility\_factor}_{n^L,t,y^V,y,m,c,l,h,1} \\
 *      & \quad   \cdot ( \text{output}_{n^L,t,y^V,y,m,n,c,l,h^A,h} + \text{input}_{n^L,t,y^V,y,m,n,c,l,h^A,h} ) \\
-*      & \quad   \cdot \text{duration_time_rel}_{h,h^A}
-*                \cdot \text{ACT_RATING}_{n,t,y^V,y,c,l,h,q}
+*      & \quad   \cdot \text{duration\_time\_rel}_{h,h^A}
+*                \cdot \text{ACT\_RATING}_{n,t,y^V,y,c,l,h,q}
 *      \geq 0
 *
 ***
@@ -1173,7 +1173,7 @@ ACT.LO(node,tec,vintage,year,mode,time)$sum(
 * This constraint provides upper bounds on new capacity installation.
 *
 *   .. math::
-*      \text{CAP_NEW}_{n,t,y} \leq \text{bound_new_capacity_up}_{n,t,y} \quad \forall \ t \ \in \ T^{\text{INV}}
+*      \text{CAP\_NEW}_{n,t,y} \leq \text{bound\_new\_capacity\_up}_{n,t,y} \quad \forall \ t \ \in \ T^{\text{INV}}
 *
 ***
 NEW_CAPACITY_BOUND_UP(node,inv_tec,year)$( is_bound_new_capacity_up(node,inv_tec,year) )..
@@ -1189,7 +1189,7 @@ NEW_CAPACITY_BOUND_UP(node,inv_tec,year)$( is_bound_new_capacity_up(node,inv_tec
 * This constraint provides lower bounds on new capacity installation.
 *
 *   .. math::
-*      \text{CAP_NEW}_{n,t,y} \geq \text{bound_new_capacity_lo}_{n,t,y} \quad \forall \ t \ \in \ T^{\text{INV}}
+*      \text{CAP\_NEW}_{n,t,y} \geq \text{bound\_new\_capacity\_lo}_{n,t,y} \quad \forall \ t \ \in \ T^{\text{INV}}
 *
 ***
 NEW_CAPACITY_BOUND_LO(node,inv_tec,year)$( is_bound_new_capacity_lo(node,inv_tec,year) )..
@@ -1206,7 +1206,7 @@ NEW_CAPACITY_BOUND_LO(node,inv_tec,year)$( is_bound_new_capacity_lo(node,inv_tec
 * summed over all vintages.
 *
 *   .. math::
-*      \sum_{y^V \leq y} \text{CAP}_{n,t,y,y^V} \leq \text{bound_total_capacity_up}_{n,t,y} \quad \forall \ t \ \in \ T^{\text{INV}}
+*      \sum_{y^V \leq y} \text{CAP}_{n,t,y,y^V} \leq \text{bound\_total\_capacity\_up}_{n,t,y} \quad \forall \ t \ \in \ T^{\text{INV}}
 *
 ***
 TOTAL_CAPACITY_BOUND_UP(node,inv_tec,year)$( is_bound_total_capacity_up(node,inv_tec,year) )..
@@ -1224,7 +1224,7 @@ TOTAL_CAPACITY_BOUND_UP(node,inv_tec,year)$( is_bound_total_capacity_up(node,inv
 * This constraint gives lower bounds on the total installed capacity of a technology.
 *
 *   .. math::
-*      \sum_{y^V \leq y} \text{CAP}_{n,t,y,y^V} \geq \text{bound_total_capacity_lo}_{n,t,y} \quad \forall \ t \ \in \ T^{\text{INV}}
+*      \sum_{y^V \leq y} \text{CAP}_{n,t,y,y^V} \geq \text{bound\_total\_capacity\_lo}_{n,t,y} \quad \forall \ t \ \in \ T^{\text{INV}}
 *
 ***
 TOTAL_CAPACITY_BOUND_LO(node,inv_tec,year)$( is_bound_total_capacity_lo(node,inv_tec,year) )..
@@ -1242,7 +1242,7 @@ TOTAL_CAPACITY_BOUND_LO(node,inv_tec,year)$( is_bound_total_capacity_lo(node,inv
 * This constraint provides upper bounds by mode of a technology activity, summed over all vintages.
 *
 *   .. math::
-*      \sum_{y^V \leq y} \text{ACT}_{n,t,y^V,y,m,h} \leq \text{bound_activity_up}_{n,t,m,y,h}
+*      \sum_{y^V \leq y} \text{ACT}_{n,t,y^V,y,m,h} \leq \text{bound\_activity\_up}_{n,t,m,y,h}
 *
 ***
 ACTIVITY_BOUND_UP(node,tec,year,mode,time)$(
@@ -1265,7 +1265,7 @@ ACTIVITY_BOUND_UP(node,tec,year,mode,time)$(
 * This constraint provides upper bounds of a technology activity across all modes and vintages.
 *
 *   .. math::
-*      \sum_{y^V \leq y, m} \text{ACT}_{n,t,y^V,y,m,h} \leq \text{bound_activity_up}_{n,t,y,'all',h}
+*      \sum_{y^V \leq y, m} \text{ACT}_{n,t,y^V,y,m,h} \leq \text{bound\_activity\_up}_{n,t,y,'all',h}
 *
 ***
 ACTIVITY_BOUND_ALL_MODES_UP(node,tec,year,time)$( is_bound_activity_up(node,tec,year,'all',time) )..
@@ -1287,9 +1287,9 @@ ACTIVITY_BOUND_ALL_MODES_UP(node,tec,year,time)$( is_bound_activity_up(node,tec,
 * all vintages.
 *
 *   .. math::
-*      \sum_{y^V \leq y} \text{ACT}_{n,t,y^V,y,m,h} \geq \text{bound_activity_lo}_{n,t,y,m,h}
+*      \sum_{y^V \leq y} \text{ACT}_{n,t,y^V,y,m,h} \geq \text{bound\_activity\_lo}_{n,t,y,m,h}
 *
-* We assume that :math:`\text{bound_activity_lo}_{n,t,y,m,h} = 0`
+* We assume that :math:`\text{bound\_activity\_lo}_{n,t,y,m,h} = 0`
 * unless explicitly stated otherwise.
 ***
 ACTIVITY_BOUND_LO(node,tec,year,mode,time)$( map_tec_act(node,tec,year,mode,time) )..
@@ -1310,9 +1310,9 @@ ACTIVITY_BOUND_LO(node,tec,year,mode,time)$( map_tec_act(node,tec,year,mode,time
 * This constraint provides lower bounds of a technology activity across all modes and vintages.
 *
 *   .. math::
-*      \sum_{y^V \leq y, m} \text{ACT}_{n,t,y^V,y,m,h} \geq \text{bound_activity_lo}_{n,t,y,'all',h}
+*      \sum_{y^V \leq y, m} \text{ACT}_{n,t,y^V,y,m,h} \geq \text{bound\_activity\_lo}_{n,t,y,'all',h}
 *
-* We assume that :math:`\text{bound_activity_lo}_{n,t,y,'all',h} = 0`
+* We assume that :math:`\text{bound\_activity\_lo}_{n,t,y,'all',h} = 0`
 * unless explicitly stated otherwise.
 ***
 ACTIVITY_BOUND_ALL_MODES_LO(node,tec,year,time)$( bound_activity_lo(node,tec,year,'all',time) )..
@@ -1346,7 +1346,7 @@ ACTIVITY_BOUND_ALL_MODES_LO(node,tec,year,time)$( bound_activity_lo(node,tec,yea
 *
 *   .. math::
 *     \text{ACT}_{n^L,t,y^V,y,m,h^A}
-*     \leq \text{share_mode_up}_{p,n,t,y,m,h} \cdot
+*     \leq \text{share\_mode\_up}_{p,n,t,y,m,h} \cdot
 *     \sum_{m'} \text{ACT}_{n^L,t,y^V,y,m',h^A}
 *
 ***
@@ -1376,7 +1376,7 @@ SHARE_CONSTRAINT_MODE_UP(shares,node,tec,mode,year,time)$(
 *
 *   .. math::
 *     \text{ACT}_{n^L,t,y^V,y,m,h^A}
-*     \geq \text{share_mode_lo}_{p,n,t,y,m,h} \cdot
+*     \geq \text{share\_mode\_lo}_{p,n,t,y,m,h} \cdot
 *     \sum_{m'} \text{ACT}_{n^L,t,y^V,y,m',h^A}
 *
 ***
@@ -1419,14 +1419,14 @@ SHARE_CONSTRAINT_MODE_LO(shares,node,tec,mode,year,time)$(
 *   .. math::
 *      & \sum_{\substack{n^L,t,m,h^A \\ y^V \leq y, (n,\widehat{t},m,c,l) \sim P^{\text{share}}}}
 *         ( \text{output}_{n^L,t,y^V,y,m,n,c,l,h^A,h} + \text{input}_{n^L,t,y^V,y,m,n,c,l,h^A,h} ) \\
-*      & \quad \cdot \text{duration_time_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A} \\
+*      & \quad \cdot \text{duration\_time\_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A} \\
 *      & \geq
-*        \text{share_commodity_up}_{p,n,y,h} \cdot
+*        \text{share\_commodity\_up}_{p,n,y,h} \cdot
 *        \sum_{\substack{n^L,t,m,h^A \\ y^V \leq y, (n,\widehat{t},m,c,l) \sim P^{\text{total}}}}
 *            ( \text{output}_{n^L,t,y^V,y,m,n,c,l,h^A,h} + \text{input}_{n^L,t,y^V,y,m,n,c,l,h^A,h} ) \\
-*      & \quad \cdot \text{duration_time_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A}
+*      & \quad \cdot \text{duration\_time\_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A}
 *
-* This constraint is only active if :math:`\text{share_commodity_up}_{p,n,y,h}` is defined.
+* This constraint is only active if :math:`\text{share\_commodity\_up}_{p,n,y,h}` is defined.
 ***
 SHARE_CONSTRAINT_COMMODITY_UP(shares,node_share,year,time)$( share_commodity_up(shares,node_share,year,time) )..
 * activity by type_tec_share technologies with map_shares_generic_share entries and a specific mode
@@ -1470,14 +1470,14 @@ SHARE_CONSTRAINT_COMMODITY_UP(shares,node_share,year,time)$( share_commodity_up(
 *   .. math::
 *      & \sum_{\substack{n^L,t,m,h^A \\ y^V \leq y, (n,\widehat{t},m,c,l) \sim P^{\text{share}}}}
 *         ( \text{output}_{n^L,t,y^V,y,m,n,c,l,h^A,h} + \text{input}_{n^L,t,y^V,y,m,n,c,l,h^A,h} ) \\
-*      & \quad \cdot \text{duration_time_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A} \\
+*      & \quad \cdot \text{duration\_time\_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A} \\
 *      & \leq
-*        \text{share_commodity_lo}_{p,n,y,h} \cdot
+*        \text{share\_commodity\_lo}_{p,n,y,h} \cdot
 *        \sum_{\substack{n^L,t,m,h^A \\ y^V \leq y, (n,\widehat{t},m,c,l) \sim P^{\text{total}}}}
 *            ( \text{output}_{n^L,t,y^V,y,m,n,c,l,h^A,h} + \text{input}_{n^L,t,y^V,y,m,n,c,l,h^A,h} ) \\
-*      & \quad \cdot \text{duration_time_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A}
+*      & \quad \cdot \text{duration\_time\_rel}_{h,h^A} \cdot \text{ACT}_{n^L,t,y^V,y,m,h^A}
 *
-* This constraint is only active if :math:`\text{share_commodity_lo}_{p,n,y,h}` is defined.
+* This constraint is only active if :math:`\text{share\_commodity\_lo}_{p,n,y,h}` is defined.
 ***
 SHARE_CONSTRAINT_COMMODITY_LO(shares,node_share,year,time)$( share_commodity_lo(shares,node_share,year,time) )..
 * total input and output by `type_tec_share` technologies mapped to respective commodity, level and node
@@ -1535,17 +1535,17 @@ SHARE_CONSTRAINT_COMMODITY_LO(shares,node_share,year,time)$( share_commodity_lo(
 * annual growth of the existing 'capital stock', and a "soft" relaxation of the upper bound.
 *
 *  .. math::
-*     \text{CAP_NEW}_{n,t,y}
-*         \leq & \Bigg(~ \text{initial_new_capacity_up}_{n,t,y}
-*             \cdot \frac{ \Big( 1 + \text{growth_new_capacity_up}_{n,t,y} \Big)^{|y|} - 1 }
-*                        { \text{growth_new_capacity_up}_{n,t,y} } \\
-*              & + \Big( \text{CAP_NEW}_{n,t,y-1} + \text{historical_new_capacity}_{n,t,y-1} \Big) \\
-*              & \hspace{2 cm} \cdot \Big( 1 + \text{growth_new_capacity_up}_{n,t,y} \Big)^{|y|} \\
-*              & + \text{CAP_NEW_UP}_{n,t,y} \cdot \Bigg( \Big( 1 + \text{soft_new_capacity_up}_{n,t,y}\Big)^{|y|} - 1 \Bigg)\Bigg) \\
+*     \text{CAP\_NEW}_{n,t,y}
+*         \leq & \Bigg(~ \text{initial\_new\_capacity\_up}_{n,t,y}
+*             \cdot \frac{ \Big( 1 + \text{growth\_new\_capacity\_up}_{n,t,y} \Big)^{|y|} - 1 }
+*                        { \text{growth\_new\_capacity\_up}_{n,t,y} } \\
+*              & + \Big( \text{CAP\_NEW}_{n,t,y-1} + \text{historical\_new\_capacity}_{n,t,y-1} \Big) \\
+*              & \hspace{2 cm} \cdot \Big( 1 + \text{growth\_new\_capacity\_up}_{n,t,y} \Big)^{|y|} \\
+*              & + \text{CAP\_NEW\_UP}_{n,t,y} \cdot \Bigg( \Big( 1 + \text{soft\_new\_capacity\_up}_{n,t,y}\Big)^{|y|} - 1 \Bigg)\Bigg) \\
 *              & * \frac{|y-1|}{|y|} \\
 *         & \quad \forall \ t \ \in \ T^{\text{INV}}
 *
-* Here, :math:`|y|` is the number of years in period :math:`y`, i.e., :math:`\text{duration_period}_{y}`.
+* Here, :math:`|y|` is the number of years in period :math:`y`, i.e., :math:`\text{duration\_period}_{y}`.
 ***
 NEW_CAPACITY_CONSTRAINT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
         AND is_dynamic_new_capacity_up(node,inv_tec,year) )..
@@ -1589,8 +1589,8 @@ NEW_CAPACITY_CONSTRAINT_UP(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 * the level of the investment in the previous period (cf. Keppo and Strubegger, 2010 :cite:`Keppo-2010`).
 *
 *   .. math::
-*      \text{CAP_NEW_UP}_{n,t,y} \leq \sum_{y-1} \text{CAP_NEW}_{n^L,t,y-1} & \text{if } y \neq \text{'first_period'} \\
-*                                + \sum_{y-1} \text{historical_new_capacity}_{n^L,t,y-1} & \text{if } y = \text{'first_period'} \\
+*      \text{CAP\_NEW\_UP}_{n,t,y} \leq \sum_{y-1} \text{CAP\_NEW}_{n^L,t,y-1} & \text{if } y \neq \text{'first\_period'} \\
+*                                + \sum_{y-1} \text{historical\_new\_capacity}_{n^L,t,y-1} & \text{if } y = \text{'first\_period'} \\
 *                           \quad \forall \ t \ \in \ T^{\text{INV}}
 *
 ***
@@ -1610,13 +1610,13 @@ NEW_CAPACITY_SOFT_CONSTRAINT_UP(node,inv_tec,year)$( soft_new_capacity_up(node,i
 * This constraint gives dynamic lower bounds on new capacity.
 *
 *  .. math::
-*     \text{CAP_NEW}_{n,t,y}
-*         \geq & \Bigg(- \text{initial_new_capacity_lo}_{n,t,y}
-*             \cdot \frac{ \Big( 1 + \text{growth_new_capacity_lo}_{n,t,y} \Big)^{|y|} }
-*                        { \text{growth_new_capacity_lo}_{n,t,y} } \\
-*              & + \Big( \text{CAP_NEW}_{n,t,y-1} + \text{historical_new_capacity}_{n,t,y-1} \Big) \\
-*              & \hspace{2 cm} \cdot \Big( 1 + \text{growth_new_capacity_lo}_{n,t,y} \Big)^{|y|} \\
-*              & - \text{CAP_NEW_LO}_{n,t,y} \cdot \Bigg( \Big( 1 + \text{soft_new_capacity_lo}_{n,t,y}\Big)^{|y|} - 1 \Bigg)\Bigg) \\
+*     \text{CAP\_NEW}_{n,t,y}
+*         \geq & \Bigg(- \text{initial\_new\_capacity\_lo}_{n,t,y}
+*             \cdot \frac{ \Big( 1 + \text{growth\_new\_capacity\_lo}_{n,t,y} \Big)^{|y|} }
+*                        { \text{growth\_new\_capacity\_lo}_{n,t,y} } \\
+*              & + \Big( \text{CAP\_NEW}_{n,t,y-1} + \text{historical\_new\_capacity}_{n,t,y-1} \Big) \\
+*              & \hspace{2 cm} \cdot \Big( 1 + \text{growth\_new\_capacity\_lo}_{n,t,y} \Big)^{|y|} \\
+*              & - \text{CAP\_NEW\_LO}_{n,t,y} \cdot \Bigg( \Big( 1 + \text{soft\_new\_capacity\_lo}_{n,t,y}\Big)^{|y|} - 1 \Bigg)\Bigg) \\
 *              & * \frac{|y-1|}{|y|} \\
 *         & \quad \forall \ t \ \in \ T^{\text{INV}}
 *
@@ -1663,8 +1663,8 @@ NEW_CAPACITY_CONSTRAINT_LO(node,inv_tec,year)$( map_tec(node,inv_tec,year)
 * level of the investment in the previous year.
 *
 *   .. math::
-*      \text{CAP_NEW_LO}_{n,t,y} \leq \sum_{y-1} \text{CAP_NEW}_{n^L,t,y-1} & \text{if } y \neq \text{'first_period'} \\
-*                                + \sum_{y-1} \text{historical_new_capacity}_{n^L,t,y-1} & \text{if } y = \text{'first_period'} \\
+*      \text{CAP\_NEW\_LO}_{n,t,y} \leq \sum_{y-1} \text{CAP\_NEW}_{n^L,t,y-1} & \text{if } y \neq \text{'first\_period'} \\
+*                                + \sum_{y-1} \text{historical\_new\_capacity}_{n^L,t,y-1} & \text{if } y = \text{'first\_period'} \\
 *                           \quad \forall \ t \ \in \ T^{\text{INV}}
 *
 ***
@@ -1685,13 +1685,13 @@ NEW_CAPACITY_SOFT_CONSTRAINT_LO(node,inv_tec,year)$( soft_new_capacity_lo(node,i
 *
 *  .. math::
 *     \sum_{y^V \leq y,m} \text{ACT}_{n,t,y^V,y,m,h}
-*         \leq & ~ \text{initial_activity_up}_{n,t,y,h}
-*             \cdot \frac{ \Big( 1 + \text{growth_activity_up}_{n,t,y,h} \Big)^{|y|} - 1 }
-*                        { \text{growth_activity_up}_{n,t,y,h} } \\
+*         \leq & ~ \text{initial\_activity\_up}_{n,t,y,h}
+*             \cdot \frac{ \Big( 1 + \text{growth\_activity\_up}_{n,t,y,h} \Big)^{|y|} - 1 }
+*                        { \text{growth\_activity\_up}_{n,t,y,h} } \\
 *             & + \bigg( \sum_{y^V \leq y-1,m} \text{ACT}_{n,t,y^V,y-1,m,h}
-*                         + \sum_{m} \text{historical_activity}_{n,t,y-1,m,h} \bigg) \\
-*             & \hspace{2 cm} \cdot \Big( 1 + \text{growth_activity_up}_{n,t,y,h} \Big)^{|y|} \\
-*             & + \text{ACT_UP}_{n,t,y,h} \cdot \Bigg( \Big( 1 + \text{soft_activity_up}_{n,t,y,h} \Big)^{|y|} - 1 \Bigg)
+*                         + \sum_{m} \text{historical\_activity}_{n,t,y-1,m,h} \bigg) \\
+*             & \hspace{2 cm} \cdot \Big( 1 + \text{growth\_activity\_up}_{n,t,y,h} \Big)^{|y|} \\
+*             & + \text{ACT\_UP}_{n,t,y,h} \cdot \Bigg( \Big( 1 + \text{soft\_activity\_up}_{n,t,y,h} \Big)^{|y|} - 1 \Bigg)
 *
 ***
 ACTIVITY_CONSTRAINT_UP(node,tec,year,time)$( map_tec_time(node,tec,year,time)
@@ -1731,8 +1731,8 @@ ACTIVITY_CONSTRAINT_UP(node,tec,year,time)$( map_tec_time(node,tec,year,time)
 * level of the activity in the previous period.
 *
 *   .. math::
-*      \text{ACT_UP}_{n,t,y,h} \leq \sum_{y^V \leq y,m,y-1} \text{ACT}_{n^L,t,y^V,y-1,m,h} & \text{if } y \neq \text{'first_period'} \\
-*                             + \sum_{m,y-1} \text{historical_activity}_{n^L,t,y-1,m,h} & \text{if } y = \text{'first_period'}
+*      \text{ACT\_UP}_{n,t,y,h} \leq \sum_{y^V \leq y,m,y-1} \text{ACT}_{n^L,t,y^V,y-1,m,h} & \text{if } y \neq \text{'first\_period'} \\
+*                             + \sum_{m,y-1} \text{historical\_activity}_{n^L,t,y-1,m,h} & \text{if } y = \text{'first\_period'}
 *
 *
 ***
@@ -1752,13 +1752,13 @@ ACTIVITY_SOFT_CONSTRAINT_UP(node,tec,year,time)$( soft_activity_up(node,tec,year
 *
 *  .. math::
 *     \sum_{y^V \leq y,m} \text{ACT}_{n,t,y^V,y,m,h}
-*         \geq & - \text{initial_activity_lo}_{n,t,y,h}
-*             \cdot \frac{ \Big( 1 + \text{growth_activity_lo}_{n,t,y,h} \Big)^{|y|} - 1 }
-*                        { \text{growth_activity_lo}_{n,t,y,h} } \\
+*         \geq & - \text{initial\_activity\_lo}_{n,t,y,h}
+*             \cdot \frac{ \Big( 1 + \text{growth\_activity\_lo}_{n,t,y,h} \Big)^{|y|} - 1 }
+*                        { \text{growth\_activity\_lo}_{n,t,y,h} } \\
 *             & + \bigg( \sum_{y^V \leq y-1,m} \text{ACT}_{n,t,y^V,y-1,m,h}
-*                         + \sum_{m} \text{historical_activity}_{n,t,y-1,m,h} \bigg) \\
-*             & \hspace{2 cm} \cdot \Big( 1 + \text{growth_activity_lo}_{n,t,y,h} \Big)^{|y|} \\
-*             & - \text{ACT_LO}_{n,t,y,h} \cdot \Bigg( \Big( 1 + \text{soft_activity_lo}_{n,t,y,h} \Big)^{|y|} - 1 \Bigg)
+*                         + \sum_{m} \text{historical\_activity}_{n,t,y-1,m,h} \bigg) \\
+*             & \hspace{2 cm} \cdot \Big( 1 + \text{growth\_activity\_lo}_{n,t,y,h} \Big)^{|y|} \\
+*             & - \text{ACT\_LO}_{n,t,y,h} \cdot \Bigg( \Big( 1 + \text{soft\_activity\_lo}_{n,t,y,h} \Big)^{|y|} - 1 \Bigg)
 *
 ***
 ACTIVITY_CONSTRAINT_LO(node,tec,year,time)$( map_tec_time(node,tec,year,time)
@@ -1798,8 +1798,8 @@ ACTIVITY_CONSTRAINT_LO(node,tec,year,time)$( map_tec_time(node,tec,year,time)
 * level of the activity in the previous period.
 *
 *   .. math::
-*      \text{ACT_LO}_{n,t,y,h} \leq \sum_{y^V \leq y,m,y-1} \text{ACT}_{n^L,t,y^V,y-1,m,h} & \text{if } y \neq \text{'first_period'} \\
-*                             + \sum_{m,y-1} \text{historical_activity}_{n^L,t,y-1,m,h} & \text{if } y = \text{'first_period'}
+*      \text{ACT\_LO}_{n,t,y,h} \leq \sum_{y^V \leq y,m,y-1} \text{ACT}_{n^L,t,y^V,y-1,m,h} & \text{if } y \neq \text{'first\_period'} \\
+*                             + \sum_{m,y-1} \text{historical\_activity}_{n^L,t,y-1,m,h} & \text{if } y = \text{'first\_period'}
 *
 ***
 ACTIVITY_SOFT_CONSTRAINT_LO(node,tec,year,time)$( soft_activity_lo(node,tec,year,time) )..
@@ -1832,8 +1832,8 @@ ACTIVITY_SOFT_CONSTRAINT_LO(node,tec,year,time)$( soft_activity_lo(node,tec,year
 *      \text{EMISS}_{n,e,\widehat{t},y} =
 *          \sum_{n^L \in N(n)} \Bigg(
 *              \sum_{t \in T(\widehat{t}),y^V \leq y,m,h }
-*                  \text{emission_factor}_{n^L,t,y^V,y,m,e} \cdot \text{ACT}_{n^L,t,y^V,y,m,h} \\
-*              + \sum_{s} \ \text{land_emission}_{n^L,s,y,e} \cdot \text{LAND}_{n^L,s,y}
+*                  \text{emission\_factor}_{n^L,t,y^V,y,m,e} \cdot \text{ACT}_{n^L,t,y^V,y,m,h} \\
+*              + \sum_{s} \ \text{land\_emission}_{n^L,s,y,e} \cdot \text{LAND}_{n^L,s,y}
 *                   \text{ if } \widehat{t} \in \widehat{T}^{LAND} \Bigg)
 *
 ***
@@ -1859,7 +1859,7 @@ EMISSION_EQUIVALENCE(node,emission,type_tec,year)..
 * Equation EMISSION_CONSTRAINT
 * """"""""""""""""""""""""""""
 * This constraint enforces upper bounds on emissions (by emission type). For all bounds that include multiple periods,
-* the parameter :math:`\text{bound_emission}_{n,\widehat{e},\widehat{t},\widehat{y}}` is scaled to represent average annual
+* the parameter :math:`\text{bound\_emission}_{n,\widehat{e},\widehat{t},\widehat{y}}` is scaled to represent average annual
 * emissions over all years included in the year-set :math:`\widehat{y}`.
 *
 * The formulation includes historical emissions and allows to model constraints ranging over both the model horizon
@@ -1869,12 +1869,12 @@ EMISSION_EQUIVALENCE(node,emission,type_tec,year)..
 *      \frac{
 *          \sum_{y' \in Y(\widehat{y}), e \in E(\widehat{e})}
 *              \begin{array}{l}
-*                  \text{duration_period}_{y'} \cdot \text{emission_scaling}_{\widehat{e},e} \cdot \\
-*                  \Big( \text{EMISS}_{n,e,\widehat{t},y'} + \sum_{m} \text{historical_emission}_{n,e,\widehat{t},y'} \Big)
+*                  \text{duration\_period}_{y'} \cdot \text{emission\_scaling}_{\widehat{e},e} \cdot \\
+*                  \Big( \text{EMISS}_{n,e,\widehat{t},y'} + \sum_{m} \text{historical\_emission}_{n,e,\widehat{t},y'} \Big)
 *              \end{array}
 *          }
-*        { \sum_{y' \in Y(\widehat{y})} \text{duration_period}_{y'} }
-*      \leq \text{bound_emission}_{n,\widehat{e},\widehat{t},\widehat{y}}
+*        { \sum_{y' \in Y(\widehat{y})} \text{duration\_period}_{y'} }
+*      \leq \text{bound\_emission}_{n,\widehat{e},\widehat{t},\widehat{y}}
 *
 ***
 EMISSION_CONSTRAINT(node,type_emission,type_tec,type_year)$is_bound_emission(node,type_emission,type_tec,type_year)..
@@ -1923,11 +1923,11 @@ LAND_CONSTRAINT(node,year)$( SUM(land_scenario$( map_land(node,land_scenario,yea
 *
 *  .. math::
 *     \text{LAND}_{n,s,y}
-*         \leq & \text{initial_land_scen_up}_{n,s,y}
-*             \cdot \frac{ \Big( 1 + \text{growth_land_scen_up}_{n,s,y} \Big)^{|y|} - 1 }
-*                        { \text{growth_land_scen_up}_{n,s,y} } \\
-*              & + \big( \text{LAND}_{n,s,y-1} + \text{historical_land}_{n,s,y-1} \big)
-*                  \cdot \Big( 1 + \text{growth_land_scen_up}_{n,s,y} \Big)^{|y|}
+*         \leq & \text{initial\_land\_scen\_up}_{n,s,y}
+*             \cdot \frac{ \Big( 1 + \text{growth\_land\_scen\_up}_{n,s,y} \Big)^{|y|} - 1 }
+*                        { \text{growth\_land\_scen\_up}_{n,s,y} } \\
+*              & + \big( \text{LAND}_{n,s,y-1} + \text{historical\_land}_{n,s,y-1} \big)
+*                  \cdot \Big( 1 + \text{growth\_land\_scen\_up}_{n,s,y} \Big)^{|y|}
 *
 ***
 DYNAMIC_LAND_SCEN_CONSTRAINT_UP(node,land_scenario,year)$( map_land(node,land_scenario,year)
@@ -1958,11 +1958,11 @@ DYNAMIC_LAND_SCEN_CONSTRAINT_UP(node,land_scenario,year)$( map_land(node,land_sc
 *
 *  .. math::
 *     \text{LAND}_{n,s,y}
-*         \geq & - \text{initial_land_scen_lo}_{n,s,y}
-*             \cdot \frac{ \Big( 1 + \text{growth_land_scen_lo}_{n,s,y} \Big)^{|y|} - 1 }
-*                        { \text{growth_land_scen_lo}_{n,s,y} } \\
-*              & + \big( \text{LAND}_{n,s,y-1} + \text{historical_land}_{n,s,y-1} \big)
-*                  \cdot \Big( 1 + \text{growth_land_scen_lo}_{n,s,y} \Big)^{|y|}
+*         \geq & - \text{initial\_land\_scen\_lo}_{n,s,y}
+*             \cdot \frac{ \Big( 1 + \text{growth\_land\_scen\_lo}_{n,s,y} \Big)^{|y|} - 1 }
+*                        { \text{growth\_land\_scen\_lo}_{n,s,y} } \\
+*              & + \big( \text{LAND}_{n,s,y-1} + \text{historical\_land}_{n,s,y-1} \big)
+*                  \cdot \Big( 1 + \text{growth\_land\_scen\_lo}_{n,s,y} \Big)^{|y|}
 *
 ***
 DYNAMIC_LAND_SCEN_CONSTRAINT_LO(node,land_scenario,year)$( map_land(node,land_scenario,year)
@@ -1995,14 +1995,14 @@ DYNAMIC_LAND_SCEN_CONSTRAINT_LO(node,land_scenario,year)$( map_land(node,land_sc
 * """"""""""""""""""""""""""""""""""""""""
 *
 *  .. math::
-*     \sum_{s \in S} \text{land_use}_{n,s,y,u} &\cdot \text{LAND}_{n,s,y}
-*         \leq \text{initial_land_up}_{n,y,u}
-*             \cdot \frac{ \Big( 1 + \text{growth_land_up}_{n,y,u} \Big)^{|y|} - 1 }
-*                        { \text{growth_land_up}_{n,y,u} } \\
-*              & + \Big( \sum_{s \in S} \big( \text{land_use}_{n,s,y-1,u}
-*                          + \text{dynamic_land_up}_{n,s,y-1,u} \big) \\
-*                            & \quad \quad \cdot \big( \text{LAND}_{n,s,y-1} + \text{historical_land}_{n,s,y-1} \big) \Big) \\
-*                            & \quad \cdot \Big( 1 + \text{growth_land_up}_{n,y,u} \Big)^{|y|}
+*     \sum_{s \in S} \text{land\_use}_{n,s,y,u} &\cdot \text{LAND}_{n,s,y}
+*         \leq \text{initial\_land\_up}_{n,y,u}
+*             \cdot \frac{ \Big( 1 + \text{growth\_land\_up}_{n,y,u} \Big)^{|y|} - 1 }
+*                        { \text{growth\_land\_up}_{n,y,u} } \\
+*              & + \Big( \sum_{s \in S} \big( \text{land\_use}_{n,s,y-1,u}
+*                          + \text{dynamic\_land\_up}_{n,s,y-1,u} \big) \\
+*                            & \quad \quad \cdot \big( \text{LAND}_{n,s,y-1} + \text{historical\_land}_{n,s,y-1} \big) \Big) \\
+*                            & \quad \cdot \Big( 1 + \text{growth\_land\_up}_{n,y,u} \Big)^{|y|}
 *
 ***
 DYNAMIC_LAND_TYPE_CONSTRAINT_UP(node,year,land_type)$( is_dynamic_land_up(node,year,land_type) )..
@@ -2036,14 +2036,14 @@ DYNAMIC_LAND_TYPE_CONSTRAINT_UP(node,year,land_type)$( is_dynamic_land_up(node,y
 * """"""""""""""""""""""""""""""""""""""""
 *
 *  .. math::
-*     \sum_{s \in S} \text{land_use}_{n,s,y,u} &\cdot \text{LAND}_{n,s,y}
-*         \geq - \text{initial_land_lo}_{n,y,u}
-*             \cdot \frac{ \Big( 1 + \text{growth_land_lo}_{n,y,u} \Big)^{|y|} - 1 }
-*                        { \text{growth_land_lo}_{n,y,u} } \\
-*              & + \Big( \sum_{s \in S} \big( \text{land_use}_{n,s,y-1,u}
-*                          + \text{dynamic_land_lo}_{n,s,y-1,u} \big) \\
-*                            & \quad \quad \cdot \big( \text{LAND}_{n,s,y-1} + \text{historical_land}_{n,s,y-1} \big) \Big) \\
-*                            & \quad \cdot \Big( 1 + \text{growth_land_lo}_{n,y,u} \Big)^{|y|}
+*     \sum_{s \in S} \text{land\_use}_{n,s,y,u} &\cdot \text{LAND}_{n,s,y}
+*         \geq - \text{initial\_land\_lo}_{n,y,u}
+*             \cdot \frac{ \Big( 1 + \text{growth\_land\_lo}_{n,y,u} \Big)^{|y|} - 1 }
+*                        { \text{growth\_land\_lo}_{n,y,u} } \\
+*              & + \Big( \sum_{s \in S} \big( \text{land\_use}_{n,s,y-1,u}
+*                          + \text{dynamic\_land\_lo}_{n,s,y-1,u} \big) \\
+*                            & \quad \quad \cdot \big( \text{LAND}_{n,s,y-1} + \text{historical\_land}_{n,s,y-1} \big) \Big) \\
+*                            & \quad \cdot \Big( 1 + \text{growth\_land\_lo}_{n,y,u} \Big)^{|y|}
 *
 ***
 DYNAMIC_LAND_TYPE_CONSTRAINT_LO(node,year,land_type)$( is_dynamic_land_lo(node,year,land_type) )..
@@ -2089,13 +2089,13 @@ DYNAMIC_LAND_TYPE_CONSTRAINT_LO(node,year,land_type)$( is_dynamic_land_lo(node,y
 * """""""""""""""""""""""""""""
 *   .. math::
 *      \text{REL}_{r,n,y} = \sum_{t} \Bigg(
-*          & \ \text{relation_new_capacity}_{r,n,y,t} \cdot \text{CAP_NEW}_{n,t,y} \\[4 pt]
-*          & + \text{relation_total_capacity}_{r,n,y,t} \cdot \sum_{y^V \leq y} \ \text{CAP}_{n,t,y^V,y} \\
-*          & + \sum_{n^L,y',m,h} \ \text{relation_activity}_{r,n,y,n^L,t,y',m} \\
+*          & \ \text{relation\_new\_capacity}_{r,n,y,t} \cdot \text{CAP\_NEW}_{n,t,y} \\[4 pt]
+*          & + \text{relation\_total\_capacity}_{r,n,y,t} \cdot \sum_{y^V \leq y} \ \text{CAP}_{n,t,y^V,y} \\
+*          & + \sum_{n^L,y',m,h} \ \text{relation\_activity}_{r,n,y,n^L,t,y',m} \\
 *          & \quad \quad \cdot \Big( \sum_{y^V \leq y'} \text{ACT}_{n^L,t,y^V,y',m,h}
-*                              + \text{historical_activity}_{n^L,t,y',m,h} \Big) \Bigg)
+*                              + \text{historical\_activity}_{n^L,t,y',m,h} \Big) \Bigg)
 *
-* The parameter :math:`\text{historical_new_capacity}_{r,n,y}` is not included here, because relations can only be active
+* The parameter :math:`\text{historical\_new\_capacity}_{r,n,y}` is not included here, because relations can only be active
 * in periods included in the model horizon and there is no "writing" of capacity relation factors across periods.
 ***
 
@@ -2124,7 +2124,7 @@ RELATION_EQUIVALENCE(relation,node,year)..
 * Equation RELATION_CONSTRAINT_UP
 * """""""""""""""""""""""""""""""
 *   .. math::
-*      \text{REL}_{r,n,y} \leq \text{relation_upper}_{r,n,y}
+*      \text{REL}_{r,n,y} \leq \text{relation\_upper}_{r,n,y}
 ***
 RELATION_CONSTRAINT_UP(relation,node,year)$( is_relation_upper(relation,node,year) )..
     REL(relation,node,year)
@@ -2137,7 +2137,7 @@ RELATION_CONSTRAINT_UP(relation,node,year)$( is_relation_upper(relation,node,yea
 * Equation RELATION_CONSTRAINT_LO
 * """""""""""""""""""""""""""""""
 *   .. math::
-*      \text{REL}_{r,n,y} \geq \text{relation_lower}_{r,n,y}
+*      \text{REL}_{r,n,y} \geq \text{relation\_lower}_{r,n,y}
 ***
 RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,year) )..
     REL(relation,node,year)
@@ -2189,11 +2189,11 @@ RELATION_CONSTRAINT_LO(relation,node,year)$( is_relation_lower(relation,node,yea
 * - :math:`m^{S}` is `mode` of operation for storage container technology
 
 *   .. math::
-*      \text{STORAGE_CHARGE}_{n,t,m^s,l,c,y,h} =
+*      \text{STORAGE\_CHARGE}_{n,t,m^s,l,c,y,h} =
 *          \sum_{\substack{n^L,m,h-1 \\ y^V \leq y, (n,t^C,t,l,y) \sim S^{\text{storage}}}} \text{output}_{n^L,t^C,y^V,y,m,n,c,l,h-1,h}
 *             \cdot & \text{ACT}_{n^L,t^C,y^V,y,m,h-1} \\
 *          - \sum_{\substack{n^L,m,c,h-1 \\ y^V \leq y, (n,t^D,t,l,y) \sim S^{\text{storage}}}} \text{input}_{n^L,t^D,y^V,y,m,n,c,l,h-1,h}
-*              \cdot \text{ACT}_{n^L,t^D,y^V,y,m,h-1} \quad \forall \ t \in T^{\text{STOR}}, & \forall \ l \in L^{\text{STOR}}
+*              \cdot \text{ACT}_{n^L,t^D,y^V,y,m,h-1} \quad \forall \ t \in T^{\text{STOR}}, \& \forall \ l \in L^{\text{STOR}}
 ***
 STORAGE_CHANGE(node,storage_tec,mode,level_storage,commodity,year,time)$sum(
                (tec,mode2,lvl_temporal), map_tec_storage(node,tec,mode2,storage_tec,mode,level_storage,commodity,lvl_temporal) ) ..
@@ -2224,8 +2224,8 @@ STORAGE_CHANGE(node,storage_tec,mode,level_storage,commodity,year,time)$sum(
 *
 * .. math::
 *    \STORAGE_{ntmlcyh} =\ & \STORAGECHARGE_{ntmlcyh} \\
-*    & + \STORAGE_{ntmlcy(h-1)} \cdot (1 - \storageselfdischarge_{ntmly(h-1)}) \\
-*    \forall\ & t \in T^{\text{STOR}}, l \in L^{\text{STOR}}, \storageinitial_{ntmlcyh} = 0
+*    \& + \STORAGE_{ntmlcy(h-1)} \cdot (1 - \storageselfdischarge_{ntmly(h-1)}) \\
+*    \forall\ \& t \in T^{\text{STOR}}, l \in L^{\text{STOR}}, \storageinitial_{ntmlcyh} = 0
 ***
 STORAGE_BALANCE(node,storage_tec,mode,level,commodity,year,time2,lvl_temporal)$ (
     SUM((tec,mode2), map_tec_storage(node,tec,mode2,storage_tec,mode,level,commodity,lvl_temporal) )
@@ -2253,7 +2253,7 @@ STORAGE_BALANCE(node,storage_tec,mode,level,commodity,year,time2,lvl_temporal)$ 
 * a fraction of installed capacity of storage device (container) that can be filled initially.
 *
 * .. math::
-*    \STORAGE_{ntmlcy(h-1)} \geq &  \storageinitial_{ntmlcyh} \cdot \text{duration_time}_{h} \cdot \text{capacity_factor}_{n,t,y^V,y,h} \cdot \text{CAP}_{n,t,y^V,y}  \\
+*    \STORAGE_{ntmlcy(h-1)} \geq &  \storageinitial_{ntmlcyh} \cdot \text{duration\_time}_{h} \cdot \text{capacity\_factor}_{n,t,y^V,y,h} \cdot \text{CAP}_{n,t,y^V,y}  \\
 *    \quad \forall \ t \ \in \ T^{\text{INV}}, \forall\ & \storageinitial_{ntmlcyh} \neq 0
 ***
 

--- a/message_ix/model/MESSAGE/model_solve.gms
+++ b/message_ix/model/MESSAGE/model_solve.gms
@@ -80,7 +80,7 @@ else
 *     \min_x \ \text{OBJ} = \sum_{y \in \hat{Y}(\hat{y})} \text{OBJ}_y(x_y) \\
 *     \text{s.t. } x_{y'} = x_{y'}^* \quad \forall \ y' < y
 *
-* where :math:`\hat{Y}(\hat{y}) = \{y \in Y | \ |\hat{y}| - |y| < \text{optimization_horizon} \}` and
+* where :math:`\hat{Y}(\hat{y}) = \{y \in Y | \ |\hat{y}| - |y| < \text{optimization\_horizon} \}` and
 * :math:`x_{y'}^*` is the optimal value of :math:`x_{y'}` in iteration :math:`|y'|` of the iterative loop.
 *
 * The advantage of this implementation is that there is no need to 'store' the optimal values of all decision

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -56,7 +56,7 @@
 * .. [#duration_time_year] The element 'Year' in the set of subannual time slices ``time`` has the value of 1.
 *    This value is assigned by default when creating a new :class:`ixmp.Scenario` based on the ``MESSAGE`` scheme.
 *
-* .. [#short_dur] The short-hand notation :math:`|y|` is used for the parameters :math:`\text{duration_period}_y`
+* .. [#short_dur] The short-hand notation :math:`|y|` is used for the parameters :math:`\text{duration\_period}_y`
 *    in the mathematical model documentation for exponents.
 *
 * .. [#year_auto] The values for this parameter are computed automatically when exporting a ``MESSAGE``-scheme
@@ -525,13 +525,13 @@ Parameters
 * The activity in the historic period can be defined with
 *
 * .. math::
-*    \sum_{m} \text{ACT}_{n,t,y^V,y,m,h} \leq \text{duration_time}_{h} \cdot \text{capacity_factor}_{n,t,y^V,y,h} \\
+*    \sum_{m} \text{ACT}_{n,t,y^V,y,m,h} \leq \text{duration\_time}_{h} \cdot \text{capacity\_factor}_{n,t,y^V,y,h} \\
 *    \cdot \text{CAP}_{n,t,y^V,y} \quad t \ \in \ T^{\text{INV}}
 *
 * and the historical new capacity with
 *
 * .. math::
-*    \text{CAP_NEW}_{n,t,y^V} = \frac{\text{CAP}_{n,t,y^V,y}}{\text{duration_period}_{y}}
+*    \text{CAP\_NEW}_{n,t,y^V} = \frac{\text{CAP}_{n,t,y^V,y}}{\text{duration\_period}_{y}}
 *
 * Both equations are equally valid for model periods. However, to calculate ``historical_new_capacity``
 * and ``historical_activity`` all parameters must describe the historic period.
@@ -817,7 +817,7 @@ Parameters
 *    * - fixed_land
 *      - ``node`` | ``land_scenario`` | ``year``
 *
-* Note that the variable :math:`\text{STOCK_CHG}` is determined implicitly by the :math:`\text{STOCK}` variable
+* Note that the variable :math:`\text{STOCK\_CHG}` is determined implicitly by the :math:`\text{STOCK}` variable
 * and therefore does not need to be explicitly fixed.
 ***
 

--- a/message_ix/model/MESSAGE/scaling_investment_costs.gms
+++ b/message_ix/model/MESSAGE/scaling_investment_costs.gms
@@ -16,16 +16,16 @@ beyond_horizon_lifetime(node,inv_tec,vintage)$( beyond_horizon_lifetime(node,inv
 * Levelized costs excluding fuel costs
 * ------------------------------------
 * For the 'soft' relaxations of the dynamic constraints and the associated penalty factor in the objective function,
-* we need to compute the parameter :math:`\text{levelized_cost}_{n,t,y}`.
+* we need to compute the parameter :math:`\text{levelized\_cost}_{n,t,y}`.
 *
 * .. math::
-*    \text{levelized_cost}_{n,t,m,y,h} := \
-*        & \text{inv_cost}_{n,t,y} \cdot \frac{ \text{interestrate}_{y} \cdot \left( 1 + \text{interestrate}_{y} \right)^{|y|} }
+*    \text{levelized\_cost}_{n,t,m,y,h} := \
+*        & \text{inv\_cost}_{n,t,y} \cdot \frac{ \text{interestrate}_{y} \cdot \left( 1 + \text{interestrate}_{y} \right)^{|y|} }
 *                                      { \left( 1 + \text{interestrate}_{y} \right)^{|y|} - 1 } \\
-*        & + \text{fix_cost}_{n,t,y,y} \cdot \frac{ 1 }{ \sum_{h'} \text{duration_time}_{h'} \cdot \text{capacity_factor}_{n,t,y,y,h'} } \\
-*        & + \text{var_cost}_{n,t,y,y,m,h}
+*        & + \text{fix\_cost}_{n,t,y,y} \cdot \frac{ 1 }{ \sum_{h'} \text{duration\_time}_{h'} \cdot \text{capacity\_factor}_{n,t,y,y,h'} } \\
+*        & + \text{var\_cost}_{n,t,y,y,m,h}
 *
-* where :math:`|y| = \text{technical_lifetime}_{n,t,y}`. This formulation implicitly assumes constant fixed
+* where :math:`|y| = \text{technical\_lifetime}_{n,t,y}`. This formulation implicitly assumes constant fixed
 * and variable costs over time.
 *
 * **Warning:** 
@@ -68,9 +68,9 @@ loop((node,tec,year,time)$( levelized_cost(node,tec,year,time) < 0
 * investment costs have to be scaled up accordingly to account for the higher capital costs.
 *
 * .. math::
-*    \text{construction_time_factor}_{n,t,y} = \left( 1 + \text{interestrate}_y \right)^{|y|}
+*    \text{construction\_time\_factor}_{n,t,y} = \left( 1 + \text{interestrate}_y \right)^{|y|}
 *
-* where :math:`|y| = \text{construction_time}_{n,t,y}`. If no construction time is specified, the default value of the
+* where :math:`|y| = \text{construction\_time}_{n,t,y}`. If no construction time is specified, the default value of the
 * investment cost scaling factor defaults to 1. The model assumes that the construction time only plays a role
 * for the investment costs, i.e., each unit of new-built capacity is available instantaneously.
 *
@@ -89,45 +89,45 @@ construction_time_factor(node,inv_tec,year)$( map_tec(node,inv_tec,year) AND con
 * Investment costs beyond the model horizon
 * -----------------------------------------
 * If the technical lifetime of a technology exceeds the model horizon :math:`Y^{\text{model}}`, the model has to add
-* a scaling factor to the investment costs (:math:`\text{end_of_horizon_factor}_{n,t,y}`). Assuming a constant
+* a scaling factor to the investment costs (:math:`\text{end\_of\_horizon\_factor}_{n,t,y}`). Assuming a constant
 * stream of revenue (marginal value of the capacity constraint), this can be computed by annualizing investment costs
 * from the condition that in an optimal solution, the investment costs must equal the discounted future revenues,
-* if the investment variable :math:`\text{CAP_NEW}_{n,t,y} > 0`:
+* if the investment variable :math:`\text{CAP\_NEW}_{n,t,y} > 0`:
 *
 * .. math::
-*    \text{inv_cost}_{n,t,y^V} = \sum_{y \in Y^{\text{lifetime}}_{n,t,y^V}} \text{df_year}_{y} \cdot \beta_{n,t},
+*    \text{inv\_cost}_{n,t,y^V} = \sum_{y \in Y^{\text{lifetime}}_{n,t,y^V}} \text{df\_year}_{y} \cdot \beta_{n,t},
 *
 * Here, :math:`\beta_{n,t} > 0` is the dual variable to the capacity constraint (assumed constant over future periods)
 * and :math:`Y^{\text{lifetime}}_{n,t,y^V}` is the set of periods in the lifetime of a plant built in period :math:`y^V`.
-* Then, the scaling factor :math:`\text{end_of_horizon_factor}_{n,t,y^V}` can be derived as follows:
+* Then, the scaling factor :math:`\text{end\_of\_horizon\_factor}_{n,t,y^V}` can be derived as follows:
 *
 * .. math::
-*    \text{end_of_horizon_factor}_{n,t,y^V} :=
-*    \frac{\sum_{y \in Y^{\text{lifetime}}_{n,t,y^V} \cap Y^{\text{model}}} \text{df_year}_{y} }
-*        {\sum_{y' \in Y^{\text{lifetime}}_{n,t,y^V}} \text{df_year}_{y'} + \text{beyond_horizon_factor}_{n,t,y^V} }
+*    \text{end\_of\_horizon\_factor}_{n,t,y^V} :=
+*    \frac{\sum_{y \in Y^{\text{lifetime}}_{n,t,y^V} \cap Y^{\text{model}}} \text{df\_year}_{y} }
+*        {\sum_{y' \in Y^{\text{lifetime}}_{n,t,y^V}} \text{df\_year}_{y'} + \text{beyond\_horizon\_factor}_{n,t,y^V} }
 *    \in (0,1],
 *
-* where the parameter :math:`\text{beyond_horizon_factor}_{n,t,y^V}` accounts for the discount factor beyond the
+* where the parameter :math:`\text{beyond\_horizon\_factor}_{n,t,y^V}` accounts for the discount factor beyond the
 * overall model horizon (the set :math:`Y` in contrast to the set :math:`Y^{\text{model}} \subseteq Y` of the periods
 * included in the current model iteration (see the page on the recursive-dynamic model solution approach).
 *
 * .. math::
-*    \text{beyond_horizon_lifetime}_{n,t,y^V} :=  \max \Big\{ 0,
-*        \text{economic_lifetime}_{n,t,y^V} - \sum_{y' \geq y^V} \text{duration_period}_{y'} \Big\}
+*    \text{beyond\_horizon\_lifetime}_{n,t,y^V} :=  \max \Big\{ 0,
+*        \text{economic\_lifetime}_{n,t,y^V} - \sum_{y' \geq y^V} \text{duration\_period}_{y'} \Big\}
 *
 * .. math::
-*    \text{beyond_horizon_factor}_{n,t,y^V} :=
-*        \text{df_year}_{\widehat{y}} \cdot \frac{1}{ \left( 1 + \text{interestrate}_{\widehat{y}} \right)^{|\widehat{y}|} }
+*    \text{beyond\_horizon\_factor}_{n,t,y^V} :=
+*        \text{df\_year}_{\widehat{y}} \cdot \frac{1}{ \left( 1 + \text{interestrate}_{\widehat{y}} \right)^{|\widehat{y}|} }
 *        \cdot \frac{ 1 - \left( \frac{1}{1 + \text{interestrate}_{\widehat{y}}} \right)^{|\widetilde{y}|}}
 *                   { 1 - \frac{1}{1 + \text{interestrate}_{\widehat{y}}}}
 *
 * where :math:`\widehat{y}` is the last period included in the overall model horizon,
-* :math:`|\widehat{y}| = \text{duration_period}_{\widehat{y}}`
-* and :math:`|\widetilde{y}| = \text{beyond_horizon_lifetime}_{n,t,y^V}`.
+* :math:`|\widehat{y}| = \text{duration\_period}_{\widehat{y}}`
+* and :math:`|\widetilde{y}| = \text{beyond\_horizon\_lifetime}_{n,t,y^V}`.
 *
 * If the interest rate is zero, i.e., :math:`\text{interestrate}_{\widehat{y}} = 0`,
-* the parameter :math:`\text{beyond_horizon_factor}_{n,t,y^V}` equals the remaining technical lifetime
-* beyond the model horizon and the parameter :math:`\text{end_of_horizon_factor}_{n,t,y^V}` equals
+* the parameter :math:`\text{beyond\_horizon\_factor}_{n,t,y^V}` equals the remaining technical lifetime
+* beyond the model horizon and the parameter :math:`\text{end\_of\_horizon\_factor}_{n,t,y^V}` equals
 * the share of technical lifetime within the model horizon.
 ***
 
@@ -164,7 +164,7 @@ end_of_horizon_factor(node,inv_tec,vintage)$( map_tec(node,inv_tec,vintage) ) =
 * Remaining installed capacity
 * ----------------------------
 * The model has to take into account that the technical lifetime of a technology may not coincide with the cumulative
-* period duration. Therefore, the model introduces the parameter :math:`\text{remaining_capacity}_{n,t,y^V,y}`
+* period duration. Therefore, the model introduces the parameter :math:`\text{remaining\_capacity}_{n,t,y^V,y}`
 * as a factor of remaining technical lifetime in the last period of operation divided by the duration of that period.
 *
 ***

--- a/message_ix/model/MESSAGE/sets_maps_def.gms
+++ b/message_ix/model/MESSAGE/sets_maps_def.gms
@@ -104,7 +104,7 @@ $ONEMPTY
 *
 * .. [#time] The set ``time`` collects all sub-annual temporal units across all levels of temporal disaggregation.
 *    In a ``MESSAGE``-scheme :class:`ixmp.Scenario`, this set always includes an element "year",
-*    and the duration of that element is 1 (:math:`\text{duration_time}_{\text{'year'}} = 1`).
+*    and the duration of that element is 1 (:math:`\text{duration\_time}_{\text{'year'}} = 1`).
 *
 * .. [#shares] A generic formulation of share constraints is implemented in |MESSAGEix|,
 *    see :ref:`share_constraints`.
@@ -209,7 +209,7 @@ Alias(commodity,commodity2);
 *    * - level_renewable (level) [#level_res]_
 *      - :math:`l \in L^{\text{REN}} \subseteq L`
 *      - Levels related to `renewables` representation
-*    * - level_storage(level)
+*    * - level_storage (level)
 *      - :math:`l \in L^{\text{STOR}} \subseteq L`
 *      - Subsets of levels on which commodities are :ref:`stored <gams-storage>`; excluded from :ref:`commodity balances <commodity_balance_lt>`.
 *    * - type_node [#type_node]_


### PR DESCRIPTION
### Context

This PR was created to enable the PDF builds of the docs again since them failing had kept the latest version of the docs from being uploaded to RTD. However, as detailed in the comments below, I ran into more severe issues that would require significant time to fix. Thus, for the time being, we decided to disable the PDF builds with #735 so that the latest version of the docs passes again. If providing a PDF version of the docs becomes higher priority in the future, this PR might include valuable information for further attempts.

### Aim

While the docs seem to build fine for epub and html format, [they do not](https://readthedocs.com/projects/iiasa-energy-program-message-ix/builds/1650455/) for the pdf format, keeping the whole process from succeeding and, thus, a new version from being uploaded. Through comparison with ixmp, I think the issue is the specification of lualatex as the latex engine for building the pdf; at least locally, the `latexmkrc` file looked like the one for ixmp after commenting this out. This PR therefore removes the specification from `doc/conf.py`.

## How to review

- Check that the documentation build on RTD succeeds.
- Read the diff and note that the CI checks all pass.


## PR checklist


- [ ] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Only docs update.
- ~[ ] Add, expand, or update documentation.~ Only docs update.
- ~[ ] Update release notes.~ Only docs update.
