### PR TITLE
Disable PDF docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,10 +4,9 @@
 # Required
 version: 2
 
-# Build PDF & ePub
+# Build ePub
 formats:
   - epub
-  - pdf
 
 # Set the version of Python and other tools you might need
 build:


### PR DESCRIPTION
As noted in #734, until we decide/invest enough time to enable the PDF builds for our docs (again), we should remove this version of the docs to keep the builds from failing.

## How to review
I don't think we'll be able to build the PDF version from a PR build, we might be able to trigger a run manually on RTD for a branch build that builds epub and html, but no pdf. If not, we will only see this working after the merge, but the changes are small enough to understand they won't break anything.

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ ONly change docs config.
- ~[ ] Add, expand, or update documentation.~ Only change docs config.
- ~[ ] Update release notes.~ Only change docs config.
