### PR TITLE
Include dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2 
+updates: 
+  - package-ecosystem: "pip" 
+    directory: "/" 
+    schedule: 
+      interval: "weekly" 
+    # Add assignees 
+    assignees: 
+      - "glatterf42" 
+      - "khaeru" 
+    # Specify labels 
+    labels: 
+      - "dependencies" 
+    # Add reviewers: 
+      - "glatterf42" 
+      - "khaeru" 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     # Specify labels 
     labels: 
       - "dependencies" 
-    # Add reviewers: 
+    # Add reviewers:
+    reviewers: 
       - "glatterf42" 
       - "khaeru" 


### PR DESCRIPTION
This PR introduces a dependabot configuration file with the aim of automatically setting @khaeru and myself as assignees and reviewers for dependabot PRs.


## How to review
I'm not entirely sure how to best test this config file. Can we point dependabot to this branch and wait for the next PR to pop up?
Apart from that, you can check that the file is following the official guidelines. It pieces together a few options, namely [assignees](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees), [labels](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels), and [reviewers](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers). The [package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) is the same for pip and poetry and there is [a note for pip and pip-compile](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#pip-and-pip-compile).

- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ No new functionality.
- ~[ ] Add, expand, or update documentation.~ Nothing user facing added.
- ~[ ] Update release notes.~ Nothing user facing added.

