### PR TITLE
Reduce number of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/" 
     schedule: 
       interval: "weekly" 
+    groups:
+      # Specify a name for the group, which will be used in pull request titles
+      # and branch names
+      all-dependencies:
+        # Define patterns to include dependencies in the group (based on
+        # dependency name)
+        patterns:
+          - "*" # All dependencies in the package-ecosystem
     # Add assignees 
     assignees: 
       - "glatterf42" 
@@ -15,3 +23,4 @@ updates:
     reviewers: 
       - "glatterf42" 
       - "khaeru" 
+    

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip" 
     directory: "/" 
     schedule: 
-      interval: "weekly" 
+      interval: "monthly" 
     groups:
       # Specify a name for the group, which will be used in pull request titles
       # and branch names


### PR DESCRIPTION
This PR adapts the dependabot config file to reduce the number of PRs created by bumping versions. It does so in two ways:

1. [Group all dependencies together](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#example-2) so that version updates will only be one PR
2. Decrease the [`schedule.interval`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval) to monthly

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ No functionality added.
- ~[ ] Add, expand, or update documentation.~ Nothing user-facing added.
- ~[ ] Update release notes.~ Nothing user-facing added.

