### PR TITLE
Fix documentation build warnings

### DIFF
--- a/ci/rtd-requirements.txt
+++ b/ci/rtd-requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/iiasa/ixmp.git@main#egg=ixmp
+git+https://github.com/iiasa/ixmp.git@main#egg=ixmp[docs]

--- a/doc/macro.rst
+++ b/doc/macro.rst
@@ -235,7 +235,7 @@ Code documentation
    :exclude-members: MACRO_ITEMS
 
    The functions :func:`add_model_data` and :func:`calibrate` are used by :meth:`.Scenario.add_macro`.
-   Others are internal; :func:`prepare_computer` assembles the following functions into a :class:`.genno.Computer` that then executes the necessary calculations to prepare the model data.
+   Others are internal; :func:`prepare_computer` assembles the following functions into a :class:`genno.Computer` that then executes the necessary calculations to prepare the model data.
 
    .. autosummary::
       Structures

--- a/doc/reporting.rst
+++ b/doc/reporting.rst
@@ -284,7 +284,7 @@ Operators
       ~genno.computations.add
       ~genno.computations.aggregate
       ~genno.computations.apply_units
-      ~genno.compat.pyam.computations.as_pyam
+      ~genno.compat.pyam.operator.as_pyam
       ~genno.computations.broadcast_map
       ~genno.computations.combine
       ~genno.computations.concat


### PR DESCRIPTION
Closes #758. This PR addresses some of the docs-build process errors described in that issue. See there for more details.

## How to review

- Read the diff and note that the CI checks all pass.
- Check the RTD-built documentation and check the warnings/that they don't bother us (generally on the [api](https://docs.messageix.org/en/latest/api.html), [reporting](https://docs.messageix.org/en/latest/reporting.html), and [macro](https://docs.messageix.org/en/latest/macro.html) pages)

## PR checklist

- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ No functionality changes.
- [x] Add, expand, or update documentation.
- ~[ ] Update release notes.~ No user-facing changes.

