### PR TITLE
Add warning in docs about #723

### DIFF
--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -141,6 +141,9 @@ Variables
 * :math:`\text{GDP}_{n,y} \in \mathbb{R}`                                     Gross domestic product (GDP) in market exchange rates for MACRO reporting
 * =========================================================================== ======================================================================================================
 *
+* .. warning::
+*    Please be aware that transitioning from one period length to another for consecutive periods may result in false values of :math:`\text{PRICE_EMISSION}`. 
+*    Please see `this issue <https://github.com/iiasa/message_ix/issues/723>`_ for further information. We are currently working on a fix.
 ***
 
 Variables


### PR DESCRIPTION
Since we won't be able to merge #723 in time, this PR adds a warning in the docs to where `PRICE_EMISSION` [is defined](https://docs.messageix.org/en/latest/model/MESSAGE/model_core.html#auxiliary-variables). This will allow us to postpone the fix for 3.8.1 in January.

I'm actually not sure: should we update the release notes?


## How to review

- Read the diff and note that the CI checks all pass.
- Check the documentation built by the RTD check below and look at MESSAGE core formulation -> Variable Definitions -> Auxiliary Variables.

## PR checklist

- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Only docs
- [x] Add, expand, or update documentation.
- [x] Update release notes.
