### PR TITLE
Make test more specific to avoid error

### DIFF
--- a/message_ix/tests/test_macro.py
+++ b/message_ix/tests/test_macro.py
@@ -117,7 +117,7 @@ def test_config(westeros_solved, w_data_path):
 
     # Missing columns in config raises an exception
     data = c.get("data")
-    data["config"] = data["config"][["node", "sector"]]
+    data["config"] = data["config"][["node", "sector", "commodity", "year"]]
     c = macro.prepare_computer(westeros_solved, data=data)
     with pytest.raises(Exception, match="level"):
         c.get("check all")


### PR DESCRIPTION
The recent dask update has brought to light an issue with one of our tests. `test_macro.py:test_config` wants to test, among others, that a missing column is causing a related error message. However, the test deletes three columns from the config and with the recent update, a different column from the expected one is picked up for the error message. This PR changes the test to delete only the one column from the config that we expect in the error message. 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [ ] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just tests
- ~[ ] Update release notes.~ Just tests

