### PR TITLE
Update minimum version of genno

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,8 +1,10 @@
-.. Next release
-.. ============
+Next release
+============
 
-.. All changes
-.. -----------
+All changes
+-----------
+
+- Increase minimum requirement for genno dependency to 1.20 (:pull:`783`)
 
 .. _v3.8.0:
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,7 +4,7 @@ Next release
 All changes
 -----------
 
-- Increase minimum requirement for genno dependency to 1.20 (:pull:`783`)
+- Increase minimum requirement for genno dependency to 1.20 (:pull:`783`).
 
 .. _v3.8.0:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = ">=3.8"
 dependencies = [
   "click",
   "ixmp >= 3.8.0",
-  "genno[pyam] >= 1.18.1",
+  "genno[pyam] >= 1.20",
   "numpy",
   "pandas >= 1.2",
   "PyYAML",


### PR DESCRIPTION
As noted by @awais307, we should bump the minimum required version of genno to the one that introduces `genno.operator`. 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Just bumping dependency
- ~[ ] Add, expand, or update documentation.~ Just bumping dependency
- ~[ ] Update release notes.~ Just bumping dependency