### PR TITLE
Make tests robust & independent

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -162,9 +162,11 @@ jobs:
       # By default, the below installs ixmp from the main branch. To run against
       # other code, e.g. other branches for open PRs), temporarily edit as
       # appropriate. DO NOT merge such changes to `main`.
+      # plotnine: temporary work around for https://github.com/has2k1/plotnine/pull/751
       run: |
         pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
         pip install .[tests]
+        pip install "plotnine != 0.13.0"
 
     - name: Install R dependencies and tutorial requirements
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     language: python
     entry: bash -c ". ${PRE_COMMIT_MYPY_VENV:-/dev/null}/bin/activate 2>/dev/null; mypy $0 $@"
     additional_dependencies:
-    - mypy
+    - mypy >= 1.8.0
     - asyncssh
     - git+https://github.com/iiasa/ixmp.git@main
     - importlib_resources
@@ -19,11 +19,9 @@ repos:
     - types-PyYAML
     - types-requests
     args: ["."]
-- repo: https://github.com/psf/black
-  rev: 23.7.0
-  hooks:
-  - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.287
+  rev: v0.3.0
   hooks:
   - id: ruff
+  - id: ruff-format
+    args: [ --check ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     - mypy
     - asyncssh
     - git+https://github.com/iiasa/ixmp.git@main
+    - importlib_resources
     - pytest
     - Sphinx
     - types-PyYAML

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,7 +4,9 @@ Next release
 All changes
 -----------
 
-- :func:`.make_df` can create partly-filled :class:`DataFrames <pandas.DataFrame>` for indexed sets; not only parameters (:pull:`784`).
+- :func:`.make_df` can now create partly-filled :class:`DataFrames <pandas.DataFrame>` for indexed sets; not only parameters (:pull:`784`).
+- New function :func:`.util.copy_model` that exposes the behaviour of the :program:`message-ix copy-model` CLI command to other Python code (:pull:`784`).
+- New test fixture :func:`.tmp_model_dir` (:pull:`784`).
 - Bug fix: :meth:`.Scenario.rename` would not rename keys where the index set and index name differed (:issue:`601`, :pull:`791`).
 - Increase minimum requirement for genno dependency to 1.20 (:pull:`783`).
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :func:`.make_df` can create partly-filled :class:`DataFrames <pandas.DataFrame>` for indexed sets; not only parameters (:pull:`784`).
 - Bug fix: :meth:`.Scenario.rename` would not rename keys where the index set and index name differed (:issue:`601`, :pull:`791`).
 - Increase minimum requirement for genno dependency to 1.20 (:pull:`783`).
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,22 +1,2 @@
-import os
-from pathlib import Path
-
-# Use the fixtures test_mp, test_mp_props, and tmp_env from ixmp.testing
+# Use Pytest hooks and fixtures from this package and from ixmp
 pytest_plugins = ["ixmp.testing", "message_ix.testing"]
-
-# Hooks
-
-
-def pytest_sessionstart(session):
-    """Use only 2 threads for CPLEX on GitHub Actions runners with 2 CPU cores."""
-    import message_ix.models
-
-    if "GITHUB_ACTIONS" in os.environ:
-        message_ix.models.DEFAULT_CPLEX_OPTIONS["threads"] = 2
-
-
-def pytest_report_header(config, startdir):
-    """Add the message_ix import path to the pytest report header."""
-    import message_ix
-
-    return f"message_ix location: {Path(message_ix.__file__).parent}"

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 # Use the fixtures test_mp, test_mp_props, and tmp_env from ixmp.testing
-pytest_plugins = ["ixmp.testing"]
+pytest_plugins = ["ixmp.testing", "message_ix.testing"]
 
 # Hooks
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -252,14 +252,14 @@ Utility methods
 ---------------
 
 .. automodule:: message_ix.util
-   :members: expand_dims, make_df
+   :members: expand_dims, copy_model, make_df
 
 
 Testing utilities
 -----------------
 
 .. automodule:: message_ix.testing
-   :members: make_dantzig, make_westeros
+   :members: make_austria, make_dantzig, make_westeros, tmp_model_dir
 
 .. automodule:: message_ix.testing.nightly
    :members:

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -187,20 +187,19 @@ Code style
 - **Python** code:
 
   - Follow the `PEP 8 naming conventions <https://www.python.org/dev/peps/pep-0008/#naming-conventions>`_.
-  - Apply `black <https://black.readthedocs.io>`_ code formatting.
-  - Use `ruff <https://beta.ruff.rs/docs>`_ to check code quality.
+  - Use `ruff <https://docs.astral.sh/ruff>`_ to check code formatting (:program:`ruff format`, which applies the "black" format) and quality (:program:`ruff check`).
     In particular, through :file:`pyproject.toml`, :mod:`message_ix` uses the following rule sets to ensure:
 
-    - `"F" <https://beta.ruff.rs/docs/rules/#pyflakes-f>`_: code is free of basic errors, equivalent to Pyflakes or `flake8 <https://flake8.pycqa.org>`_.
-    - `"E", "W" <https://beta.ruff.rs/docs/rules/#pycodestyle-e-w>`_: code conforms to `PEP 8 <https://www.python.org/dev/peps/pep-0008>`_, equivalent to using pycodestyle.
-    - `"I" <https://beta.ruff.rs/docs/rules/#isort-i>`_: :py:`import` statements are sorted in a consistent way, equivalent to `isort <https://pypi.org/project/isort/>`_.
-    - `"C90" <https://beta.ruff.rs/docs/rules/#mccabe-c90>`_: the McCabe complexity of code is below a fixed threshold, equivalent to using `mccabe <https://pypi.org/project/mccabe/>`_ via flake8.
+    - `"F" <https://docs.astral.sh/ruff/rules/#pyflakes-f>`_: code is free of basic errors, equivalent to Pyflakes or `flake8 <https://flake8.pycqa.org>`_.
+    - `"E", "W" <https://docs.astral.sh/ruff/rules/#pycodestyle-e-w>`_: code conforms to `PEP 8 <https://www.python.org/dev/peps/pep-0008>`_, equivalent to using pycodestyle.
+    - `"I" <https://docs.astral.sh/ruff/rules/#isort-i>`_: :py:`import` statements are sorted in a consistent way, equivalent to `isort <https://pypi.org/project/isort/>`_.
+    - `"C90" <https://docs.astral.sh/ruff/rules/#mccabe-c90>`_: the McCabe complexity of code is below a fixed threshold, equivalent to using `mccabe <https://pypi.org/project/mccabe/>`_ via flake8.
 
   - Add type hints to new or changed functions, methods, and global variables, and check these using the `mypy <https://mypy.readthedocs.io>`_ static type checker.
 
   To simplify the use of these tools:
 
-  - Black, ruff, and mypy can each be configured to run automatically within your code editor with an extension, plugin, or script (see their respective documentation for links and details).
+  - Ruff and mypy can each be configured to run automatically within your code editor with an extension, plugin, or script (see their respective documentation for links and details).
     These tools help apply the code style every time a file is saved, or even as you type.
   - The source repository contains configuration for `pre-commit <https://pre-commit.com>`_, a tool that invokes multiple actions via `git hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks>`_.
     This runs all of the above checks every time you do a :program:`git commit`.
@@ -240,7 +239,7 @@ Documentation
   3. Inline documentation in :file:`message_ix/model/*.gms` files.
 
   For (2) and (3), start each sentence on a new line, and do not hard-wrap within sentences.
-  For (1), wrap at the same 88 characters as :command:`black` enforces for code.
+  For (1), wrap at the same 88 characters as :command:`ruff` enforces for code.
 
 - Ensure Sphinx does not give warnings about ReST syntax for new or modified documentation.
 

--- a/message_ix/report/operator.py
+++ b/message_ix/report/operator.py
@@ -92,11 +92,8 @@ def plot_cumulative(x, y, labels):
     d0, d1, d2 = y.dims
 
     assert (
-        d0,
-        d1,
-    ) == x.dims, (
-        f"dimensions of x {repr(x.dims)} != first dimensions of y {repr((d0, d1))}"
-    )
+        (d0, d1) == x.dims
+    ), f"dimensions of x {repr(x.dims)} != first dimensions of y {repr((d0, d1))}"
 
     # Check that all data have the same value in the first dimension
     d0_labels = set(x.coords[d0].values) | set(y.coords[d0].values)

--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -272,7 +272,14 @@ def make_austria(mp, solve=False, quiet=True):  # noqa: C901
     return scen
 
 
-def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
+def make_dantzig(
+    mp,
+    solve=False,
+    multi_year=False,
+    *,
+    request: Optional["pytest.FixtureRequest"] = None,
+    **solve_opts,
+):
     """Return an :class:`message_ix.Scenario` for Dantzig's canning problem.
 
     Parameters
@@ -291,10 +298,15 @@ def make_dantzig(mp, solve=False, multi_year=False, **solve_opts):
     mp.add_region("DantzigLand", "country")
 
     # initialize a new (empty) instance of an `ixmp.Scenario`
+    if request:
+        scenario_name = request.node.name
+    else:
+        scenario_name = "multi-year" if multi_year else "standard"
+
     scen = Scenario(
         mp,
         model=SCENARIO["dantzig"]["model"],
-        scenario="multi-year" if multi_year else "standard",
+        scenario=scenario_name,
         annotation="Dantzig's canning problem as a MESSAGE-scheme Scenario",
         version="new",
     )

--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -1,5 +1,7 @@
 import io
+import os
 from itertools import product
+from pathlib import Path
 from typing import TYPE_CHECKING, Generator, List, Optional, Union
 
 import numpy as np
@@ -12,6 +14,26 @@ from message_ix import Scenario, make_df
 if TYPE_CHECKING:
     import pathlib
 
+
+# Pytest hooks
+
+
+def pytest_report_header(config, start_path):
+    """Add the message_ix import path to the pytest report header."""
+    import message_ix
+
+    return f"message_ix location: {Path(message_ix.__file__).parent}"
+
+
+def pytest_sessionstart():
+    """Use only 2 threads for CPLEX on GitHub Actions runners with 2 CPU cores."""
+    import message_ix.models
+
+    if "GITHUB_ACTIONS" in os.environ:
+        message_ix.models.DEFAULT_CPLEX_OPTIONS["threads"] = 2
+
+
+# Data for testing
 
 SCENARIO = {
     "austria": dict(model="Austrian energy model", scenario="baseline"),

--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -297,19 +297,20 @@ def make_dantzig(
     mp.add_unit("case")
     mp.add_region("DantzigLand", "country")
 
-    # initialize a new (empty) instance of an `ixmp.Scenario`
-    if request:
-        scenario_name = request.node.name
-    else:
-        scenario_name = "multi-year" if multi_year else "standard"
-
-    scen = Scenario(
-        mp,
+    # Scenario identifiers
+    args = dict(
         model=SCENARIO["dantzig"]["model"],
-        scenario=scenario_name,
-        annotation="Dantzig's canning problem as a MESSAGE-scheme Scenario",
         version="new",
+        annotation="Dantzig's canning problem as a MESSAGE-scheme Scenario",
     )
+    if request:
+        # Use a distinct scenario name for a particular test
+        args.update(scenario=request.node.name)
+    else:
+        args.update(scenario="multi-year" if multi_year else "standard")
+
+    # Initialize a new (empty) instance of an `ixmp.Scenario`
+    scen = Scenario(mp, **args)
 
     # Sets
     # NB commit() is refused if technology and year are not given

--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -1,15 +1,16 @@
 import io
 from itertools import product
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Generator, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+import pytest
 from ixmp import IAMC_IDX
 
 from message_ix import Scenario, make_df
 
 if TYPE_CHECKING:
-    import pytest
+    import pathlib
 
 
 SCENARIO = {
@@ -794,3 +795,21 @@ def make_subannual(
     scen.solve()
 
     return scen
+
+
+@pytest.fixture(scope="function")
+def tmp_model_dir(tmp_path) -> Generator["pathlib.Path", None, None]:
+    """Temporary directory containing a copy of the MESSAGE model files.
+
+    This may be used, among other purposes, to isolate the writing/reading of
+    :file:`cplex.opt` from other tests.
+
+    See also
+    --------
+    :func:`.copy_model`
+    """
+    from message_ix.util import copy_model
+
+    copy_model(tmp_path, overwrite=False, set_default=False, quiet=True)
+
+    yield tmp_path

--- a/message_ix/testing/nightly.py
+++ b/message_ix/testing/nightly.py
@@ -64,12 +64,15 @@ def iter_scenarios():
         )
 
     for id, data in scenarios.items():
-        yield id, (
-            data["model"],
-            data["scenario"],
-            data["solve"],
-            data.get("solve_options", {}),
-            data["cases"],
+        yield (
+            id,
+            (
+                data["model"],
+                data["scenario"],
+                data["solve"],
+                data.get("solve_options", {}),
+                data["cases"],
+            ),
         )
 
 

--- a/message_ix/tests/test_cli.py
+++ b/message_ix/tests/test_cli.py
@@ -26,7 +26,7 @@ def test_copy_model(monkeypatch, message_ix_cli, tmp_path, tmp_env):
     # Copying with --overwrite succeeds
     r = message_ix_cli("copy-model", "--overwrite", str(tmp_path))
     assert r.exit_code == 0
-    assert "Overwriting" in r.output
+    assert "Overwrite" in r.output
 
     # --set-default causes a configuration change
     assert config.get("message model dir") == Path(message_ix.__file__).parent / "model"

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -90,7 +90,7 @@ class TestScenario:
         clone.solve(quiet=True)
         assert np.isclose(clone.var("OBJ")["lvl"], 153.675)
 
-    def test_rename2(self, request, dantzig_message_scenario):
+    def test_rename2(self, dantzig_message_scenario):
         """Test :meth:`.rename` for parameters with 2+ indexes for the same set."""
         scen = dantzig_message_scenario
 
@@ -543,20 +543,20 @@ def test_new_timeseries_long_name64plus(message_test_mp):
     scen.commit("importing a testing timeseries")
 
 
-def test_excel_read_write(message_test_mp, tmp_path):
+def test_excel_read_write(message_test_mp, tmp_path, request):
     # Path to temporary file
-    tmp_path /= "excel_read_write.xlsx"
+    tmp_path /= request.node.name + "_excel_read_write.xlsx"
     # Convert to string to ensure this can be handled
     fname = str(tmp_path)
 
     scen1 = Scenario(message_test_mp, **SCENARIO["dantzig"])
-    scen1 = scen1.clone(keep_solution=False)
-    scen1.check_out()
-    scen1.init_set("new_set")
-    scen1.add_set("new_set", "member")
-    scen1.init_par("new_par", idx_sets=["new_set"])
-    scen1.add_par("new_par", "member", 2, "-")
-    scen1.commit("new set and parameter added.")
+    scen1 = make_dantzig(mp=message_test_mp, request=request)
+    scen1 = scen1.clone(scenario=request.node.name + "_clone", keep_solution=False)
+    with scen1.transact(message="new set and parameter added."):
+        scen1.init_set("new_set")
+        scen1.add_set("new_set", "member")
+        scen1.init_par("new_par", idx_sets=["new_set"])
+        scen1.add_par("new_par", "member", 2, "-")
 
     # Writing to Excel without solving
     scen1.to_excel(fname)

--- a/message_ix/tests/test_feature_bound_activity_shares.py
+++ b/message_ix/tests/test_feature_bound_activity_shares.py
@@ -13,7 +13,10 @@ def calculate_activity(scen, tec="transport_from_seattle"):
 
 
 def test_add_bound_activity_up(request, message_test_mp):
-    scen = make_dantzig(message_test_mp, solve=True, request=request)
+    scen = Scenario(message_test_mp, **SCENARIO["dantzig"]).clone(
+        scenario=request.node.name
+    )
+    scen.solve(quiet=True)
 
     # data for act bound
     exp = 0.5 * calculate_activity(scen).sum()
@@ -66,9 +69,10 @@ def test_add_bound_activity_up_all_modes(request, message_test_mp):
     - the resulting bound on activity for seattle, therefore is below what is required
       for "to_chicago".
     """
-    scen = make_dantzig(
-        message_test_mp, solve=True, request=request, solve_options=dict(lpmethod=2)
+    scen = Scenario(message_test_mp, **SCENARIO["dantzig"]).clone(
+        scenario=request.node.name
     )
+    scen.solve(quiet=True, solve_options=dict(lpmethod=2))
 
     # data for act bound
     # print(calculate_activity(scen))

--- a/message_ix/tests/test_feature_bound_activity_shares.py
+++ b/message_ix/tests/test_feature_bound_activity_shares.py
@@ -96,9 +96,7 @@ def assert_dantzig_solution(s: "Scenario", lp_method: int) -> None:
     "constraint_value",
     (pytest.param(299, marks=pytest.mark.xfail(raises=ModelError)), 301, 325),
 )
-def test_add_bound_activity_up_all_modes(
-    request, test_mp, tmp_model_dir, lp_method, constraint_value
-):
+def test_b_a_u_all_modes(request, test_mp, tmp_model_dir, lp_method, constraint_value):
     """Test ``bound_activity_up`` values applied mode="all".
 
     - In the unconstrained Dantzig problem:

--- a/message_ix/tests/test_feature_capacity_factor.py
+++ b/message_ix/tests/test_feature_capacity_factor.py
@@ -1,4 +1,5 @@
 """Test ``capacity_factor`` effects, mainly for models with sub-annual resolution."""
+
 import pytest
 
 from message_ix import ModelError, Scenario

--- a/message_ix/tests/test_feature_storage.py
+++ b/message_ix/tests/test_feature_storage.py
@@ -8,6 +8,7 @@ functionality of storage equations. The workflow is as follows:
 - Add storage implementation (dam: storage device, pump: charger, turbine: discharger).
 - Test storage functionality and equations.
 """
+
 import logging
 from itertools import product
 

--- a/message_ix/tests/test_feature_temporal_level.py
+++ b/message_ix/tests/test_feature_temporal_level.py
@@ -8,6 +8,7 @@ In these tests, "demand" is defined in different time slices with different
 fuel from a supply technology ("gas_supply"). Different temporal level hierarchies are
 tested, by linkages of "ACT" with "demand" and "CAP".
 """
+
 import pytest
 
 from message_ix import ModelError, Scenario
@@ -41,9 +42,7 @@ def check_solution(scen: Scenario) -> None:
         act.loc[
             (act["time"] == h) & (act["technology"] == "gas_ppl"),
             "capacity-corrected",
-        ] = (
-            act["lvl"] / scen.par("duration_time", {"time": h}).at[0, "value"]
-        )
+        ] = act["lvl"] / scen.par("duration_time", {"time": h}).at[0, "value"]
     assert (
         max(act.loc[act["technology"] == "gas_ppl", "capacity-corrected"])
         == scen.var("CAP", {"technology": "gas_ppl"}).at[0, "lvl"]

--- a/message_ix/tests/test_integration.py
+++ b/message_ix/tests/test_integration.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 import pytest
 from ixmp import Platform
@@ -10,38 +8,43 @@ from message_ix import Scenario
 from message_ix.testing import SCENARIO, TS_DF, TS_DF_CLEARED, make_dantzig
 
 
-def test_run_clone(tmpdir):
+def test_run_clone(tmpdir, request):
     # this test is designed to cover the full functionality of the GAMS API
     # - initialize a new ixmp platform instance
     # - create a new scenario based on Dantzigs tutorial transport model
     # - solve the model and read back the solution from the output
     # - perform tests on the objective value and the timeseries data
     mp = Platform(driver="hsqldb", path=tmpdir / "db")
-    scen = make_dantzig(mp, solve=True)
+    scen = make_dantzig(mp, solve=True, request=request)
     assert np.isclose(scen.var("OBJ")["lvl"], 153.675)
     assert scen.firstmodelyear == 1963
-    assert_frame_equal(scen.timeseries(iamc=True), TS_DF)
+    expected = TS_DF.assign(scenario=request.node.name)
+    assert_frame_equal(scen.timeseries(iamc=True), expected)
 
     # cloning with `keep_solution=True` keeps all timeseries and the solution
     # (same behaviour as `ixmp.Scenario`)
-    scen2 = scen.clone(keep_solution=True)
+    scen2 = scen.clone(scenario=request.node.name + "_clone", keep_solution=True)
     assert np.isclose(scen2.var("OBJ")["lvl"], 153.675)
     assert scen2.firstmodelyear == 1963
-    assert_frame_equal(scen2.timeseries(iamc=True), TS_DF)
+    expected = TS_DF.assign(scenario=request.node.name + "_clone")
+    assert_frame_equal(scen2.timeseries(iamc=True), expected)
 
     # cloning with `keep_solution=False` drops the solution and only keeps
     # timeseries set as `meta=True` or prior to the first model year
     # (DIFFERENT behaviour from `ixmp.Scenario`)
-    scen3 = scen.clone(keep_solution=False)
+    scen3 = scen.clone(scenario=request.node.name + "_clone_2", keep_solution=False)
     assert np.isnan(scen3.var("OBJ")["lvl"])
     assert scen3.firstmodelyear == 1963
-    assert_frame_equal(scen3.timeseries(iamc=True), TS_DF_CLEARED)
+    expected = TS_DF_CLEARED.assign(scenario=request.node.name + "_clone_2")
+    assert_frame_equal(scen3.timeseries(iamc=True), expected)
 
 
-def test_run_remove_solution(test_mp):
+def test_run_remove_solution(test_mp, request):
     # create a new instance of the transport problem and solve it
-    name = "test_run_remove_solution"
-    scen = make_dantzig(test_mp, solve=True, quiet=True).clone(scenario=name)
+    name = "_test_run_remove_solution"
+    scen = make_dantzig(test_mp, solve=True, quiet=True, request=request).clone(
+        scenario=request.node.name + name
+    )
     assert np.isclose(scen.var("OBJ")["lvl"], 153.675)
 
     # check that re-solving the model will raise an error if a solution exists
@@ -55,21 +58,28 @@ def test_run_remove_solution(test_mp):
     # before first model year (DIFFERENT behaviour from `ixmp.Scenario`)
     scen.remove_solution()
     assert scen.firstmodelyear == 1963
-    assert_frame_equal(scen.timeseries(iamc=True), TS_DF_CLEARED.assign(scenario=name))
+    assert_frame_equal(
+        scen.timeseries(iamc=True),
+        TS_DF_CLEARED.assign(scenario=request.node.name + name),
+    )
 
 
-def test_shift_first_model_year(test_mp):
-    scen = make_dantzig(test_mp, solve=True, multi_year=True, quiet=True)
+def test_shift_first_model_year(test_mp, request):
+    scen = make_dantzig(
+        test_mp, solve=True, multi_year=True, quiet=True, request=request
+    )
 
     # assert that `historical_activity` is empty in the source scenario
     assert scen.par("historical_activity").empty
 
     # clone and shift first model year
-    clone = scen.clone(shift_first_model_year=1964)
+    clone = scen.clone(
+        scenario=request.node.name + "_multi-year", shift_first_model_year=1964
+    )
 
     exp = TS_DF.copy()
     exp.loc[0, 1964] = np.nan
-    exp["scenario"] = "multi-year"
+    exp["scenario"] = request.node.name + "_multi-year"
 
     # check that solution and timeseries in new model horizon have been removed
     assert np.isnan(clone.var("OBJ")["lvl"])
@@ -84,19 +94,15 @@ def scenario_list(mp):
 
 
 def assert_multi_db(mp1, mp2):
+    print(scenario_list(mp1))
+    print(scenario_list(mp2))
     assert_frame_equal(scenario_list(mp1), scenario_list(mp2))
 
 
-@pytest.mark.flaky(
-    reruns=5,
-    rerun_delay=2,
-    condition="GITHUB_ACTIONS" in os.environ,
-    reason="Flaky; see iiasa/message_ix#731",
-)
-def test_multi_db_run(tmpdir):
+def test_multi_db_run(tmpdir, request):
     # create a new instance of the transport problem and solve it
     mp1 = Platform(driver="hsqldb", path=tmpdir / "mp1")
-    scen1 = make_dantzig(mp1, solve=True, quiet=True)
+    scen1 = make_dantzig(mp1, solve=True, quiet=True, request=request)
 
     mp2 = Platform(driver="hsqldb", path=tmpdir / "mp2")
     # add other unit to make sure that the mapping is correct during clone
@@ -109,7 +115,7 @@ def test_multi_db_run(tmpdir):
     pytest.raises(NotImplementedError, scen1.clone, shift_first_model_year=1964, **dest)
 
     # clone solved model across platforms (with default settings)
-    scen1.clone(platform=mp2, keep_solution=True)
+    scen1.clone(platform=mp2, scenario=request.node.name, keep_solution=True)
 
     # close the db to ensure that data and solution of the clone are saved
     mp2.close_db()
@@ -117,7 +123,9 @@ def test_multi_db_run(tmpdir):
 
     # reopen the connection to the second platform and reload scenario
     _mp2 = Platform(driver="hsqldb", path=tmpdir / "mp2")
-    scen2 = Scenario(_mp2, **SCENARIO["dantzig"])
+    to_be_loaded = SCENARIO["dantzig"]
+    to_be_loaded["scenario"] = request.node.name
+    scen2 = Scenario(_mp2, **to_be_loaded)
     assert_multi_db(mp1, _mp2)
 
     # check that sets, variables and parameter were copied correctly
@@ -128,4 +136,6 @@ def test_multi_db_run(tmpdir):
     assert_frame_equal(scen1.var("ACT"), scen2.var("ACT"))
 
     # check that custom unit, region and timeseries are migrated correctly
-    assert_frame_equal(scen2.timeseries(iamc=True), TS_DF)
+    assert_frame_equal(
+        scen2.timeseries(iamc=True), TS_DF.assign(scenario=request.node.name)
+    )

--- a/message_ix/tests/test_integration.py
+++ b/message_ix/tests/test_integration.py
@@ -105,8 +105,6 @@ def scenario_list(mp):
 
 
 def assert_multi_db(mp1, mp2):
-    print(scenario_list(mp1))
-    print(scenario_list(mp2))
     assert_frame_equal(scenario_list(mp1), scenario_list(mp2))
 
 

--- a/message_ix/tests/test_integration.py
+++ b/message_ix/tests/test_integration.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 import pytest
 from ixmp import Platform
@@ -132,7 +134,7 @@ def test_multi_db_run(tmpdir, request):
 
     # reopen the connection to the second platform and reload scenario
     _mp2 = Platform(driver="hsqldb", path=tmpdir / "mp2")
-    to_be_loaded = SCENARIO["dantzig"]
+    to_be_loaded = copy.deepcopy(SCENARIO["dantzig"])
     to_be_loaded["scenario"] = request.node.name
     scen2 = Scenario(_mp2, **to_be_loaded)
     assert_multi_db(mp1, _mp2)

--- a/message_ix/tests/test_integration.py
+++ b/message_ix/tests/test_integration.py
@@ -51,10 +51,7 @@ def test_run_clone(tmpdir, request):
 
 def test_run_remove_solution(test_mp, request):
     # create a new instance of the transport problem and solve it
-    name = "_test_run_remove_solution"
-    scen = make_dantzig(test_mp, solve=True, quiet=True, request=request).clone(
-        scenario=request.node.name + name
-    )
+    scen = make_dantzig(test_mp, solve=True, quiet=True, request=request)
     assert np.isclose(scen.var("OBJ")["lvl"], 153.675)
 
     # check that re-solving the model will raise an error if a solution exists
@@ -68,10 +65,8 @@ def test_run_remove_solution(test_mp, request):
     # before first model year (DIFFERENT behaviour from `ixmp.Scenario`)
     scen.remove_solution()
     assert scen.firstmodelyear == 1963
-    expected = TS_DF_CLEARED.copy()
     assert_frame_equal(
-        scen.timeseries(iamc=True),
-        expected.assign(scenario=request.node.name + name),
+        scen.timeseries(iamc=True), TS_DF_CLEARED.assign(scenario=scen.scenario)
     )
 
 

--- a/message_ix/tests/test_integration.py
+++ b/message_ix/tests/test_integration.py
@@ -18,16 +18,21 @@ def test_run_clone(tmpdir, request):
     scen = make_dantzig(mp, solve=True, request=request)
     assert np.isclose(scen.var("OBJ")["lvl"], 153.675)
     assert scen.firstmodelyear == 1963
-    expected = TS_DF.assign(scenario=request.node.name)
-    assert_frame_equal(scen.timeseries(iamc=True), expected)
+    expected = TS_DF.copy()
+    assert_frame_equal(
+        scen.timeseries(iamc=True), expected.assign(scenario=request.node.name)
+    )
 
     # cloning with `keep_solution=True` keeps all timeseries and the solution
     # (same behaviour as `ixmp.Scenario`)
     scen2 = scen.clone(scenario=request.node.name + "_clone", keep_solution=True)
     assert np.isclose(scen2.var("OBJ")["lvl"], 153.675)
     assert scen2.firstmodelyear == 1963
-    expected = TS_DF.assign(scenario=request.node.name + "_clone")
-    assert_frame_equal(scen2.timeseries(iamc=True), expected)
+    expected = TS_DF.copy()
+    assert_frame_equal(
+        scen2.timeseries(iamc=True),
+        expected.assign(scenario=request.node.name + "_clone"),
+    )
 
     # cloning with `keep_solution=False` drops the solution and only keeps
     # timeseries set as `meta=True` or prior to the first model year
@@ -35,8 +40,11 @@ def test_run_clone(tmpdir, request):
     scen3 = scen.clone(scenario=request.node.name + "_clone_2", keep_solution=False)
     assert np.isnan(scen3.var("OBJ")["lvl"])
     assert scen3.firstmodelyear == 1963
-    expected = TS_DF_CLEARED.assign(scenario=request.node.name + "_clone_2")
-    assert_frame_equal(scen3.timeseries(iamc=True), expected)
+    expected = TS_DF_CLEARED.copy()
+    assert_frame_equal(
+        scen3.timeseries(iamc=True),
+        expected.assign(scenario=request.node.name + "_clone_2"),
+    )
 
 
 def test_run_remove_solution(test_mp, request):
@@ -58,9 +66,10 @@ def test_run_remove_solution(test_mp, request):
     # before first model year (DIFFERENT behaviour from `ixmp.Scenario`)
     scen.remove_solution()
     assert scen.firstmodelyear == 1963
+    expected = TS_DF_CLEARED.copy()
     assert_frame_equal(
         scen.timeseries(iamc=True),
-        TS_DF_CLEARED.assign(scenario=request.node.name + name),
+        expected.assign(scenario=request.node.name + name),
     )
 
 
@@ -135,7 +144,8 @@ def test_multi_db_run(tmpdir, request):
     assert np.isclose(scen2.var("OBJ")["lvl"], 153.675)
     assert_frame_equal(scen1.var("ACT"), scen2.var("ACT"))
 
+    expected = TS_DF.copy()
     # check that custom unit, region and timeseries are migrated correctly
     assert_frame_equal(
-        scen2.timeseries(iamc=True), TS_DF.assign(scenario=request.node.name)
+        scen2.timeseries(iamc=True), expected.assign(scenario=request.node.name)
     )

--- a/message_ix/tests/test_legacy_version.py
+++ b/message_ix/tests/test_legacy_version.py
@@ -1,27 +1,21 @@
-import os
-import platform
-
 import numpy as np
-import pytest
 from ixmp import Platform
 from ixmp.testing import create_test_platform
 
 from message_ix import Scenario
 
 
-@pytest.mark.flaky(
-    reruns=5,
-    rerun_delay=2,
-    condition="GITHUB_ACTIONS" in os.environ and platform.system() == "Darwin",
-    reason="Flaky; see iiasa/message_ix#731",
-)
-def test_solve_legacy_scenario(tmp_path, test_data_path):
+def test_solve_legacy_scenario(tmp_path, test_data_path, request):
     db_path = create_test_platform(tmp_path, test_data_path, "legacy")
     mp = Platform(backend="jdbc", driver="hsqldb", path=db_path)
-    scen = Scenario(mp, model="canning problem (MESSAGE scheme)", scenario="standard")
+    scen = Scenario(
+        mp,
+        model="canning problem (MESSAGE scheme)",
+        scenario="standard",
+    )
     exp = scen.var("OBJ")["lvl"]
 
     # solve scenario, assert that the new objective value is close to previous
-    scen = scen.clone(keep_solution=False)
+    scen = scen.clone(scenario=request.node.name + "_clone", keep_solution=False)
     scen.solve()
     assert np.isclose(exp, scen.var("OBJ")["lvl"])

--- a/message_ix/tests/test_macro.py
+++ b/message_ix/tests/test_macro.py
@@ -1,5 +1,3 @@
-import os
-import platform
 from pathlib import Path
 
 import numpy as np
@@ -11,13 +9,6 @@ from message_ix import Scenario, macro
 from message_ix.models import MACRO
 from message_ix.report import Quantity
 from message_ix.testing import SCENARIO, make_westeros
-
-FLAKY = pytest.mark.flaky(
-    reruns=5,
-    rerun_delay=2,
-    condition="GITHUB_ACTIONS" in os.environ and platform.system() == "Darwin",
-    reason="Flaky; see iiasa/message_ix#731",
-)
 
 # Fixtures
 
@@ -62,7 +53,6 @@ def westeros_not_solved(request, _ws):
 # Tests
 
 
-@FLAKY
 def test_calc_valid_data_file(westeros_solved, w_data_path):
     c = macro.prepare_computer(westeros_solved, data=w_data_path)
     c.get("check all")
@@ -109,7 +99,6 @@ def test_calc_no_solution(westeros_not_solved, w_data_path):
         macro.prepare_computer(s, data=w_data_path)
 
 
-@FLAKY
 def test_config(westeros_solved, w_data_path):
     c = macro.prepare_computer(westeros_solved, data=w_data_path)
     assert "config::macro" in c.graph
@@ -185,7 +174,6 @@ def test_calc_data_missing_datapoint(westeros_solved, w_data):
 #
 
 
-@FLAKY
 @pytest.mark.parametrize(
     "key, test, expected",
     (
@@ -250,7 +238,6 @@ def test_init(message_test_mp):
     assert "COST_ACCOUNTING_NODAL" in scen.equ_list()
 
 
-@FLAKY
 def test_add_model_data(westeros_solved, w_data_path):
     base = westeros_solved
     clone = base.clone(scenario=f"{base.scenario} cloned", keep_solution=False)
@@ -312,9 +299,9 @@ def test_calibrate_roundtrip(westeros_solved, w_data_path):
 
 
 @pytest.fixture
-def mr_scenario(test_mp):
+def mr_scenario(test_mp, request):
     """Fixture with a multi-region, multi-sector scenario."""
-    scenario = make_westeros(test_mp)
+    scenario = make_westeros(test_mp, request=request)
     with scenario.transact():
         scenario.add_set("year", [2020, 2030, 2040])
 

--- a/message_ix/tests/test_nightly.py
+++ b/message_ix/tests/test_nightly.py
@@ -1,4 +1,5 @@
 """Slow-running tests for nightly continuous integration."""
+
 from functools import partial  # noqa: F401
 
 import ixmp

--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -314,9 +314,9 @@ def add_year_set(
         if not yr_cat.loc[yr_cat["type_year"] == "baseyear_macro", "year"].empty:
             yr_cat.loc[yr_cat["type_year"] == "baseyear_macro", "year"] = baseyear_macro
         if not yr_cat.loc[yr_cat["type_year"] == "initializeyear_macro", "year"].empty:
-            yr_cat.loc[
-                yr_cat["type_year"] == "initializeyear_macro", "year"
-            ] = baseyear_macro
+            yr_cat.loc[yr_cat["type_year"] == "initializeyear_macro", "year"] = (
+                baseyear_macro
+            )
 
     yr_pair = []
     for yr in years_new:

--- a/message_ix/tools/add_year/cli.py
+++ b/message_ix/tools/add_year/cli.py
@@ -21,6 +21,7 @@ If --bound_extend is True (the default), data from previous timestep is copied
 if only one data point is available for extrapolation.
 
 """
+
 from functools import partial
 from timeit import default_timer as timer
 
@@ -259,8 +260,7 @@ def main(
     )
 
     print(
-        "> New scenario with additional years is:\n"
-        "  ixmp://{}/{}/{}#{}".format(
-            sc_new.platform.name, sc_new.model, sc_new.scenario, sc_new.version
-        )
+        "> New scenario with additional years is:",
+        f"ixmp://{sc_new.platform.name}/{sc_new.url}",
+        sep="\n",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,17 +115,15 @@ markers = [
   "tutorial: Tests of the tutorial Jupyter notebooks",
 ]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["C9", "E", "F", "I", "W"]
-
-[tool.ruff.mccabe]
 # Exceptions:
 # - message_ix/core.py:716:5: C901 'Scenario.rename' is too complex (18)
 # - message_ix/tools/add_year/__init__.py:86:1: C901 'add_year' is too complex (17)
 # - message_ix/tools/add_year/__init__.py:533:1: C901 'interpolate_1d' is too complex (19)
 # - message_ix/tools/add_year/__init__.py:687:1: C901 'interpolate_2d' is too complex (38)
 # - message_ix/testing/__init__.py:91:1: C901 'make_austria' is too complex (18)
-max-complexity = 14
+mccabe.max-complexity = 14
 
 [tool.setuptools.packages]
 find = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
   "click",
+  "importlib_resources; python_version <= '3.8'",
   "ixmp >= 3.8.0",
   "genno[pyam] >= 1.20",
   "numpy",


### PR DESCRIPTION
This PR is to collect changes related to #776. As we notice tests "flaking", we can adjust them on this branch, and then merge once we feel we've addressed all observed flaky tests. The PR will thus remain open for a while until we're convinced we've reached that point.

- Job [1](https://github.com/iiasa/message_ix/actions/runs/7592300001/job/20681496117#step:9:439): `test_add_bound_activity_up_all_modes` fails with `assert np.isclose(300.0, 332.5)`.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
  <!--
  The following items are all *required* if the PR results in changes to user-
  facing behaviour, e.g. new features or fixes to existing behaviour. They are
  *optional* if the changes are solely to documentation, CI configuration, etc.

  In ambiguous cases, strike them out and add a short explanation, e.g.

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
- [x] FAILED message_ix/tests/test_feature_bound_activity_shares.py::test_add_bound_activity_up - assert False
     +  where False = <function isclose at 0x105ed3f70>(300.0, 150.0)
     +    where <function isclose at 0x105ed3f70> = np.isclose
    On: macos-latest-py3.8
- [x] FAILED message_ix/tests/test_feature_bound_activity_shares.py::test_add_bound_activity_up_all_modes - ixmp.model.base.ModelError: GAMS errored with return code 3:
    There was an execution error

    For details, see the terminal output above, plus:
    Listing   : /Users/runner/work/message_ix/message_ix/message_ix/model/MESSAGE_run.lst
    Input data: /Users/runner/work/message_ix/message_ix/message_ix/model    /data/MsgData_Canning_problem_(MESSAGE_scheme)_test_add_bound_activity_up_all_modes_cloned.gdx
    On: macos-latest-py3.8, macos-latest-py3.11, macos-latest-py3.12
- [x] FAILED message_ix/tests/test_core.py::test_excel_read_write - assert False
     +  where False = <function isclose at 0x107384eb0>(155.02499389648438, 153.6750030517578)
     +    where <function isclose at 0x107384eb0> = np.isclose
    On: macos-latest-py3.12
- [x] FAILED message_ix/tests/test_integration.py::test_run_clone - RuntimeError: unhandled Java exception: The index set 'year' does not have an element '2010'!
On: macos-latest-py3.11 (x2)
- [x] FAILED message_ix/tests/test_legacy_version.py::test_solve_legacy_scenario - RuntimeError: unhandled Java exception: The index set 'year' does not have an element '1963'!
On: windows-latest-py3.11, windows-latest-py3.10
- [x] ERROR message_ix/tests/test_macro.py::test_multiregion_derive_data_2 - RuntimeError: unhandled Java exception: The index set 'emission' does not have an element 'CO2'!
On: macos-latest-py3.9
- [x] ERROR message_ix/tests/tools/test_add_year.py::test_add_year - RuntimeError: unhandled Java exception: Error opening GDX file: Expected data marker (BOI) not found in GDX file
On: windows-latest-py3.11
- [ ] FAILED message_ix/tests/test_integration.py::test_run_remove_solution - assert False
   where False = <function isclose at 0x106197490>(nan, 153.675)
     where <function isclose at 0x106197490> = np.isclose
 On: macos-latest-py3.10
- [x] FAILED message_ix/tests/report/test_operator.py::test_plot_cumulative
  (worker 'gw3' crashed while running 'message_ix/tests/report/test_operator.py::test_plot_cumulative')
  On: macos-latest-py3.9
- [x] ERROR message_ix/tests/test_macro.py::test_multiregion_derive_data_2 - RuntimeError: unhandled Java exception: Error opening GDX file: File not recognized as a GDX file
  On: macos-latest-py3.8
- [x] ERROR message_ix/tests/test_macro.py::test_multiregion_derive_data_2 - RuntimeError: unhandled Java exception: The index set 'emission' does not have an element 'CO2'!
  On: macos-latest-py3.9

