### PR TITLE
Save minutes by avoiding duplicate test runs

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,8 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   # 05:00 UTC = 06:00 CET = 07:00 CEST


### PR DESCRIPTION
This PR removes the trigger for CI runs on pushed to main to avoid duplicate test runs. This avoids duplicate runs.

In order for this to work properly, we should make sure that

- [x] main can only be reached via PRs
- [x] PRs need to be up to date with main
- [x] PRs require several tests to be successful before merging

We might also want to 

- [x] expand the number of tests we require to be successful

All of which can be done via the [settings -> branches](https://github.com/iiasa/message_ix/settings/branch_protection_rules/17138230).

For now, we require the py3.12 and tutorial checks for macos, ubuntu, and windows to be successful.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Just changing how often tests are run.
- ~[ ] Add, expand, or update documentation.~ Just changing how often tests are run.
- ~[ ] Update release notes.~ Just changing how often tests are run.

