### PR TITLE
Update tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
     - name: Check out ixmp
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: iiasa/ixmp
         path: ixmp
         fetch-depth: ${{ env.depth }}
 
     - name: Check out message_ix
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: message_ix
         fetch-depth: ${{ env.depth }}
@@ -38,7 +38,7 @@ jobs:
         (cd ixmp; git fetch --tags --depth=${{ env.depth }})
         (cd message_ix; git fetch --tags --depth=${{ env.depth }})
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         # If the "Latest version testable on GitHub Actions" in pytest.yaml
         # is not the latest 3.x stable version, adjust here to match:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -85,6 +85,8 @@ jobs:
       run: |
         pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
         pip install .[tests]
+        # TEMPORARY work around iiasa/message_ix#788
+        pip install "genno<1.23"
 
     - name: Run test suite using pytest
       env:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -47,14 +47,14 @@ jobs:
 
     steps:
     - name: Check out message_ix
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.depth }}
 
     - name: Fetch tags (for setuptools-scm)
       run: git fetch --tags --depth=${{ env.depth }}
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -116,11 +116,11 @@ jobs:
 
     steps:
     - name: Check out message_ix
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.depth }}
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         cache: pip
@@ -191,8 +191,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:  # Same as the "Latest version supported by message_ix", above
         python-version: "3.11"
 

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -188,14 +188,17 @@ def test_add_horizon(test_mp, args, kwargs, exp):
 
     # Call completes successfully
     if isinstance(args[0], dict):
-        with pytest.warns(
-            DeprecationWarning,
-            match=(
-                r"dict\(\) argument to add_horizon\(\); use year= and "
-                "firstmodelyear="
-            ),
-        ):
+        if "data" in args[0].keys():
             scen.add_horizon(*args, **kwargs)
+        else:
+            with pytest.warns(
+                DeprecationWarning,
+                match=(
+                    r"dict\(\) argument to add_horizon\(\); use year= and "
+                    "firstmodelyear="
+                ),
+            ):
+                scen.add_horizon(*args, **kwargs)
     else:
         scen.add_horizon(*args, **kwargs)
 

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -188,7 +188,7 @@ def test_add_horizon(test_mp, args, kwargs, exp):
 
     # Call completes successfully
     if isinstance(args[0], dict):
-        if "data" in args[0].keys():
+        if "data" in kwargs.keys():
             scen.add_horizon(*args, **kwargs)
         else:
             with pytest.warns(

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -187,18 +187,15 @@ def test_add_horizon(test_mp, args, kwargs, exp):
     scen = Scenario(test_mp, **SCENARIO["dantzig"], version="new")
 
     # Call completes successfully
-    if isinstance(args[0], dict):
-        if "data" in kwargs.keys():
+    if isinstance(args[0], dict) and "data" not in kwargs:
+        with pytest.warns(
+            DeprecationWarning,
+            match=(
+                r"dict\(\) argument to add_horizon\(\); use year= and "
+                "firstmodelyear="
+            ),
+        ):
             scen.add_horizon(*args, **kwargs)
-        else:
-            with pytest.warns(
-                DeprecationWarning,
-                match=(
-                    r"dict\(\) argument to add_horizon\(\); use year= and "
-                    "firstmodelyear="
-                ),
-            ):
-                scen.add_horizon(*args, **kwargs)
     else:
         scen.add_horizon(*args, **kwargs)
 


### PR DESCRIPTION
The current CI failures have multiple causes. One is pytest 8.0.0, for which this PR adjusts. The affected test was working properly, as far as I can tell, by raising a ValueError before the DeprecationWarning. In the past, since a ValueError was given as the expected result of the test, this was fine; but now, pytest wants to see the DeprecationWarning.
On other tests, one can run `with pytest.raises(ValueError, match="something")` to specify which ValueError is raised -- which would have made us aware of this issue long ago since `Scenario.add_horizon()` raises ValueErrors on multiple occasions. From [pytest's docs](https://docs.pytest.org/en/stable/reference/reference.html#pytest-mark-xfail-ref), it doesn't look like we can pass a `match=` string to the xfail mark, so I'm wondering how much refactoring if would take to implement this. Another option would be to subclass ValueError and raise custom unique errors for the various fail cases, which we can then tell pytest to expect.

This PR also temporarily pins genno < 1.23 and can be used to upgrade Node.js actions as GHA recommends.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just updating tests
- ~[ ] Update release notes.~ Just updating tests
