### PR TITLE
Update CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,34 @@ updates:
     # Add reviewers:
     reviewers: 
       - "glatterf42" 
+      - "khaeru"
+  - package-ecosystem: "github-actions"
+    # Only update major versions
+    ignore:
+      - dependency-name: "*"
+        update-types:
+        - "version-update:semver-minor"
+        - "version-update:semver-patch"
+    # Below config mirrors the example at
+    # https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"
+    groups:
+      all-actions:
+        patterns: [ "*" ]
+     # Add assignees 
+    assignees: 
+      - "glatterf42" 
       - "khaeru" 
+    # Specify labels 
+    labels: 
+      - "dependencies" 
+    # Add reviewers:
+    reviewers: 
+      - "glatterf42" 
+      - "khaeru" 
+  
     

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Cache Anaconda installer, conda packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           $CONDA/pkgs

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -50,7 +50,7 @@ jobs:
       run: python -m pip install --upgrade pip setuptools-scm wheel
 
     - name: Cache GAMS installer and Python packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: gams
         key: ubuntu-latest-gams${{ env.GAMS_VERSION }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -65,7 +65,7 @@ jobs:
         macos-skip-brew-update: true
 
     - name: Cache GAMS installer and R packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           gams
@@ -85,8 +85,6 @@ jobs:
       run: |
         pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
         pip install .[tests]
-        # TEMPORARY work around iiasa/message_ix#788
-        pip install "genno<1.23"
 
     - name: Run test suite using pytest
       env:
@@ -101,7 +99,9 @@ jobs:
       shell: bash
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   tutorials:
     strategy:
@@ -141,7 +141,7 @@ jobs:
       id: setup-r
 
     - name: Cache GAMS installer and R packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           gams
@@ -185,7 +185,9 @@ jobs:
       shell: bash
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pre-commit:
     name: Code quality

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -59,11 +59,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: "**/pyproject.toml"
-  
+
     - uses: ts-graphviz/setup-graphviz@v2
       with:
         macos-skip-brew-update: true
-      
+
     - name: Cache GAMS installer and R packages
       uses: actions/cache@v4
       with:
@@ -132,7 +132,7 @@ jobs:
       # Use the environment variable set by the setup-python action, above.
       run: echo "RETICULATE_PYTHON=$pythonLocation" >> "$GITHUB_ENV"
       shell: bash
-    
+
     - uses: ts-graphviz/setup-graphviz@v2
       with:
         macos-skip-brew-update: true

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -59,11 +59,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: "**/pyproject.toml"
-
-    - uses: ts-graphviz/setup-graphviz@v1.2.0
+  
+    - uses: ts-graphviz/setup-graphviz@v2
       with:
         macos-skip-brew-update: true
-
+      
     - name: Cache GAMS installer and R packages
       uses: actions/cache@v4
       with:
@@ -132,13 +132,15 @@ jobs:
       # Use the environment variable set by the setup-python action, above.
       run: echo "RETICULATE_PYTHON=$pythonLocation" >> "$GITHUB_ENV"
       shell: bash
-
-    - uses: ts-graphviz/setup-graphviz@v1.2.0
+    
+    - uses: ts-graphviz/setup-graphviz@v2
       with:
         macos-skip-brew-update: true
 
     - uses: r-lib/actions/setup-r@v2
       id: setup-r
+      with:
+        windows-path-include-rtools: false
 
     - name: Cache GAMS installer and R packages
       uses: actions/cache@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -130,7 +130,7 @@ jobs:
 
     - name: Set RETICULATE_PYTHON
       # Use the environment variable set by the setup-python action, above.
-      run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
+      run: echo "RETICULATE_PYTHON=$pythonLocation" >> "$GITHUB_ENV"
       shell: bash
 
     - uses: ts-graphviz/setup-graphviz@v1.2.0

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -188,8 +188,8 @@ jobs:
 
     - name: Upload test coverage to Codecov.io
       uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} # required
 
   pre-commit:
     name: Code quality


### PR DESCRIPTION
Closes #788. This PR updates the CI to address several minor issues:

* Bump cache-action version
* Bump Codecov-action version using newly added repo secret
* Remove temporary genno pin

We can also use this to solve the current CI failure of the windows-tutorials test. As far as I can see, this failure stems from a cache being used -- at least, the setup-gams step does not fail for the other windows-CI-tests not using a cache for gams. (was resolved by iiasa/actions#12)

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI updates
- ~[ ] Update release notes.~ Just CI updates

