### PR TITLE
Improve `Scenario.rename()` to address #601

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- Resolve the bug in ``Scenario.rename()`` explained in issue #601 (:pull:`791`).
 - Increase minimum requirement for genno dependency to 1.20 (:pull:`783`).
 
 .. _v3.8.0:

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,7 +4,7 @@ Next release
 All changes
 -----------
 
-- Resolve the bug in ``Scenario.rename()`` explained in issue #601 (:pull:`791`).
+- Bug fix: :meth:`.Scenario.rename` would not rename keys where the index set and index name differed (:issue:`601`, :pull:`791`).
 - Increase minimum requirement for genno dependency to 1.20 (:pull:`783`).
 
 .. _v3.8.0:

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -751,8 +751,12 @@ class Scenario(ixmp.Scenario):
             if isinstance(ix_set, pd.DataFrame):
                 if name in self.idx_sets(item) and not ix_set.empty:
                     for key, value in mapping.items():
-                        columns = [x for x in self.idx_names(item) if
-                                   self.idx_sets(item)[self.idx_names(item).index(x)] == name]
+                        columns = [
+                            x
+                            for x in self.idx_names(item)
+                            if self.idx_sets(item)[self.idx_names(item).index(x)]
+                            == name
+                        ]
                         for col in columns:
                             df = ix_set[ix_set[col] == key]
                             if not df.empty:
@@ -768,8 +772,11 @@ class Scenario(ixmp.Scenario):
             if name not in self.idx_sets(item):
                 continue
             for key, value in mapping.items():
-                columns = [x for x in self.idx_names(item) if
-                           self.idx_sets(item)[self.idx_names(item).index(x)] == name]
+                columns = [
+                    x
+                    for x in self.idx_names(item)
+                    if self.idx_sets(item)[self.idx_names(item).index(x)] == name
+                ]
                 for col in columns:
                     df = self.par(item, filters={col: [key]})
                     if not df.empty:

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -727,14 +727,20 @@ class Scenario(ixmp.Scenario):
         return clone
 
     def rename(self, name: str, mapping: Mapping[str, str], keep: bool = False) -> None:
-        """Rename an element in a set.
+        """Rename elements in the set `name` and transform data indexed by old name(s).
 
-        Data in all parameters indexed by the set `name` is also modified.
+        - All new set element names per `mapping` are added to the set `name`, if not
+          already present.
+        - Data in all sets and parameters indexed by the set `name` is also either
+          duplicated (if :py:`keep=True`) or replaced (if :py:`keep=False`) with mapped
+          keys.
 
         Parameters
         ----------
         name : str
-            Name of the set to change, for instance :py:`"technology"`.
+            Name of the set to change, for instance :py:`"technology"`. Note that
+            renaming the "year" set may require further adjustments for a feasible
+            scenario.
         mapping : dict
             Mapping from old/current to new set element names.
         keep : bool, optional
@@ -742,6 +748,14 @@ class Scenario(ixmp.Scenario):
             entirely from the Scenario.
             If :any:`True`, old/current set elements *and* all parameter data indexed by
             them is retained.
+
+        Raises
+        ------
+        KeyError
+            if `name` is the name of a different kind of item (for instance, a
+            parameter) or of no known item.
+        ValueError
+            if `name` is a set indexed by 1 or more others.
         """
         commit = maybe_check_out(self)
 

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -1,9 +1,8 @@
 import logging
 import os
-from collections.abc import Mapping
 from functools import lru_cache
 from itertools import chain, product, zip_longest
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 from warnings import warn
 
 import ixmp

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -48,10 +48,12 @@ class TestScenario:
         scen.solve()
 
         if not keep:
-            # Check if OBJ value remains unchanged when old is removed (keep=False)
+            # Check if "old" is removed (keep=False)
+            assert old not in set(scen.set(set_name))
+            # Check if OBJ value remains unchanged when "old" is removed (keep=False)
             assert scen.var("OBJ")["lvl"] == scen_ref.var("OBJ")["lvl"]
         elif set_name == "node":
-            # Check if OBJ value is as twice when old "node" is kept (keep=True)
+            # Check if OBJ value is as twice when "old" node is kept (keep=True)
             assert scen.var("OBJ")["lvl"] == scen_ref.var("OBJ")["lvl"] * 2
 
     def test_solve(self, dantzig_message_scenario):

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -90,6 +90,24 @@ class TestScenario:
         clone.solve(quiet=True)
         assert np.isclose(clone.var("OBJ")["lvl"], 153.675)
 
+    def test_rename2(self, request, dantzig_message_scenario):
+        """Test :meth:`.rename` for parameters with 2+ indexes for the same set."""
+        scen = dantzig_message_scenario
+
+        # Counts of unique combinations of (node_loc, node_dest)
+        vc_pre = scen.par("output")[["node_loc", "node_dest"]].value_counts()
+        assert 1 == vc_pre[("seattle", "new-york")]
+
+        # Rename
+        scen.rename("node", {"seattle": "redmond", "new-york": "brooklyn"})
+
+        # Same number of unique combinations
+        vc_post = scen.par("output")[["node_loc", "node_dest"]].value_counts()
+        assert len(vc_pre) == len(vc_post)
+
+        # Values are renamed when appearing in either of the sets indexed by `node`
+        assert 1 == vc_post[("redmond", "brooklyn")]
+
     def test_solve(self, dantzig_message_scenario):
         s = dantzig_message_scenario
 

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -53,7 +53,7 @@ class TestScenario:
             # Check if OBJ value remains unchanged when "old" is removed (keep=False)
             assert scen.var("OBJ")["lvl"] == scen_ref.var("OBJ")["lvl"]
         elif set_name == "node":
-            # Check if OBJ value is as twice when "old" node is kept (keep=True)
+            # Check if OBJ value is twice as high when "old" node is kept (keep=True)
             assert scen.var("OBJ")["lvl"] == scen_ref.var("OBJ")["lvl"] * 2
 
     def test_solve(self, dantzig_message_scenario):

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -2,12 +2,13 @@ from pathlib import Path
 from subprocess import run
 
 import ixmp
-import message_ix
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pandas.testing as pdt
 import pytest
+
+import message_ix
 from message_ix import Scenario
 from message_ix.testing import SCENARIO, make_dantzig, make_westeros
 

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -30,8 +30,7 @@ class TestScenario:
         self, test_mp, set_name: str, old: str, new: str, keep: bool, request
     ) -> None:
         # Create a Westeros scenario instance and solve it
-        scen_ref = make_westeros(test_mp, quiet=True, request=request)
-        scen_ref.solve()
+        scen_ref = make_westeros(test_mp, quiet=True, solve=True, request=request)
 
         # Clone the scenario to do renaming and tests
         scen = scen_ref.clone(keep_solution=False)
@@ -45,7 +44,7 @@ class TestScenario:
         assert new in set(scen.set(set_name))
 
         # Check if the scenario solves and the objective function remains the same
-        scen.solve()
+        scen.solve(quiet=True)
 
         if not keep:
             # Check if "old" is removed (keep=False)

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -25,6 +25,23 @@ class TestScenario:
             ("technology", "coal_ppl", "coal_powerplant", False),
             ("node", "Westeros", "Essos", False),
             ("node", "Westeros", "Essos", True),
+            # "year" dimensions: integer instead of string values; model is infeasible
+            # (GAMS error)
+            pytest.param("year", 700, 701, False, marks=pytest.mark.xfail),
+            # Indexed set, doesn't work
+            pytest.param("cat_year", "foo", "bar", False, marks=pytest.mark.xfail),
+            # Name of a parameter, not a set
+            pytest.param(
+                "bound_activity_up",
+                "",
+                "",
+                False,
+                marks=pytest.mark.xfail(raises=KeyError),
+            ),
+            # Not a name of any item
+            pytest.param(
+                "foo", "", "", False, marks=pytest.mark.xfail(raises=KeyError)
+            ),
         ),
     )
     def test_rename0(
@@ -38,7 +55,6 @@ class TestScenario:
 
         # Rename members of a message_ix.set from an "old" name to a "new" name
         scen.check_out()
-        scen.add_set(set_name, new)
         scen.rename(set_name, {old: new}, keep)
 
         # Check if the new member has been added to that set


### PR DESCRIPTION
This PR improves the utility `Scenario.rename()` to resolve the bug identified in issue #601.

## How to review
- Copy the unit test introduced in this PR (see the file `test_core.py` to your message_ix `main` branch. The test should fail with the existing code.
- Checkout to the branch of this PR, test should pass.

## PR checklist
- [x] Continuous integration checks all ✅
- [x] New test is added ✅
- [x] Update release notes.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
