### PR TITLE
Introduce some additional labels in docs

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -229,6 +229,8 @@ Next:
     $ pytest -m rmessageix
 
 
+.. _common-issues:
+
 Common issues
 =============
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -7,6 +7,8 @@ Installation
 Ensure you have first read the :doc:`prerequisites <prereqs>` for understanding and using |MESSAGEix|.
 These include specific points of knowledge that are necessary to understand these instructions and choose among different installation options.
 
+.. _system-dependencies:
+
 Install system dependencies
 ===========================
 


### PR DESCRIPTION
For https://github.com/iiasa/message-ix-models/pull/157, we want to link to the message_ix docs via intersphinx. That works fine for the most part, but we are missing labels for some subsections, so they are not yet reachable via intersphinx. This PR adds these labels.

## How to review

- Read the diff and note that the CI checks all pass.
- Check that the documentation is built without error.

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Only adding docs labels
- [x] Add, expand, or update documentation.
- ~[ ] Update release notes.~ Only adding docs labels
