### PR TITLE
Housekeeping for 2024-W13

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -162,11 +162,9 @@ jobs:
       # By default, the below installs ixmp from the main branch. To run against
       # other code, e.g. other branches for open PRs), temporarily edit as
       # appropriate. DO NOT merge such changes to `main`.
-      # plotnine: temporary work around for https://github.com/has2k1/plotnine/pull/751
       run: |
         pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
         pip install .[tests]
-        pip install "plotnine != 0.13.0"
 
     - name: Install R dependencies and tutorial requirements
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -200,7 +200,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:  # Same as the "Latest version supported by message_ix", above
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Force recreation of pre-commit virtual environment for mypy
       if: github.event_name == 'schedule'  # Comment this line to run on a PR

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     - types-requests
     args: ["."]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.2
+  rev: v0.3.4
   hooks:
   - id: ruff
   - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ repos:
     - asyncssh
     - git+https://github.com/iiasa/ixmp.git@main
     - importlib_resources
+    - matplotlib
+    - pandas-stubs
     - pytest
     - Sphinx
     - types-PyYAML

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -44,14 +44,8 @@ The full API is also available from R; see :doc:`rmessageix`.
    :show-inheritance:
    :inherited-members:
 
-   This class extends :class:`ixmp.Scenario` and :class:`ixmp.TimeSeries` and
-   inherits all their methods. Documentation of these inherited methods is
-   included here for convenience. :class:`message_ix.Scenario` defines
-   additional methods specific to |MESSAGEix|:
-
-   .. versionchanged:: 3.0
-
-      :meth:`.read_excel` and :meth:`.to_excel` are now methods of :class:`ixmp.Scenario`, but continue to work with message_ix.Scenario.
+   This class extends :class:`ixmp.Scenario` and :class:`ixmp.TimeSeries` and inherits of the methods of those classes, shown below.
+   :class:`message_ix.Scenario` adds or overrides the following methods specific to |MESSAGEix|:
 
    .. autosummary::
 
@@ -61,18 +55,70 @@ The full API is also available from R; see :doc:`rmessageix`.
       add_spatial_sets
       cat
       cat_list
+      clone
       equ
       firstmodelyear
       par
-      read_excel
       rename
-      to_excel
+      set
+      solve
       var
       vintage_and_active_years
       y0
       years_active
       ya
       yv_ya
+
+   Inherited from :class:`.ixmp.Scenario`:
+
+   .. versionchanged:: 3.0
+
+      :meth:`.read_excel` and :meth:`.to_excel` are now methods of :class:`ixmp.Scenario`, but continue to work with message_ix.Scenario.
+
+   .. autosummary::
+
+      add_par
+      add_set
+      change_scalar
+      has_item
+      has_solution
+      idx_names
+      idx_sets
+      init_item
+      init_scalar
+      items
+      list_items
+      load_scenario_data
+      read_excel
+      remove_par
+      remove_set
+      remove_solution
+      scalar
+      to_excel
+
+   Inherited from :class:`.ixmp.TimeSeries`:
+
+   .. autosummary::
+
+      add_geodata
+      add_timeseries
+      check_out
+      commit
+      discard_changes
+      get_geodata
+      get_meta
+      is_default
+      last_update
+      preload_timeseries
+      read_file
+      remove_geodata
+      remove_timeseries
+      run_id
+      set_as_default
+      set_meta
+      timeseries
+      transact
+      url
 
    .. automethod:: add_macro
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,6 +28,7 @@ release = version
 # Add any Sphinx extension module names here, as strings. They can be extensions coming
 # with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
+    # First-party
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
@@ -38,6 +39,8 @@ extensions = [
     "sphinxcontrib.bibtex",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
+    # Others
+    "genno.compat.sphinx.rewrite_refs",
     "ixmp.util.sphinx_linkcode_github",
     "message_ix.util.sphinx_gams",
 ]
@@ -115,6 +118,19 @@ html_theme_options = {"logo_only": True}
 
 # The LaTeX engine to build the docs.
 latex_engine = "lualatex"
+
+# -- Options for genno.compat.sphinx.rewrite_refs --------------------------------------
+
+reference_aliases = {
+    "AnyQuantity": ":data:`genno.core.quantity.AnyQuantity`",
+    r"(genno\.|)Key(?=Seq|[^\w]|$)": "genno.core.key.Key",
+    r"(genno\.|)Quantity": "genno.core.attrseries.AttrSeries",
+    #
+    # Many projects (including Sphinx itself!) do not have a py:module target in for the
+    # top-level module in objects.inv. Resolve these using :doc:`index` or similar for
+    # each project.
+    "plotnine$": ":class:`plotnine.ggplot`",
+}
 
 # -- Options for sphinx.ext.extlinks ---------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -159,11 +159,11 @@ intersphinx_mapping = {
     "message_doc": ("https://docs.messageix.org/projects/global/en/latest/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pint": ("https://pint.readthedocs.io/en/stable/", None),
-    "plotnine": ("https://plotnine.readthedocs.io/en/stable", None),
+    "plotnine": ("https://plotnine.org", None),
     "pyam": ("https://pyam-iamc.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
-    "xarray": ("https://xarray.pydata.org/en/stable/", None),
+    "xarray": ("https://docs.xarray.dev/en/stable", None),
 }
 
 # -- Options for sphinx.ext.linkcode / ixmp.util.sphinx_linkcode_github ----------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,13 +4,9 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import re
 from importlib.metadata import version as get_version
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
-
-if TYPE_CHECKING:
-    import sphinx
+from typing import Optional
 
 # -- Project information ---------------------------------------------------------------
 
@@ -69,28 +65,7 @@ rst_prolog = r"""
 .. |IIASA| raw:: html
 
    <abbr title="International Institute for Applied Systems Analysis">IIASA</abbr>
-
-.. |KeyLike| replace:: :obj:`~genno.core.key.KeyLike`
 """  # noqa: E501
-
-
-def setup(app: "sphinx.application.Sphinx") -> None:
-    """Sphinx setup hook."""
-
-    expr = re.compile("docstring of (ixmp|genno)")
-
-    def warn_missing_reference(app: "sphinx.application.Sphinx", domain, node) -> bool:
-        """Silently discard unresolved references internal to upstream code.
-
-        When base classes in upstream (genno, ixmp) packages are inherited in
-        message_ix, Sphinx cannot properly resolve relative references within docstrings
-        of methods of the former.
-        """
-        # Return True without doing anything to silently discard the warning. Anything
-        # else, return False to allow other Sphinx hook implementations to handle.
-        return expr.search(node.source or "") is not None
-
-    app.connect("warn-missing-reference", warn_missing_reference)
 
 
 # -- Options for HTML output -----------------------------------------------------------
@@ -121,16 +96,40 @@ latex_engine = "lualatex"
 
 # -- Options for genno.compat.sphinx.rewrite_refs --------------------------------------
 
+# When base classes in upstream (genno, ixmp) packages are inherited in message_ix,
+# Sphinx will not properly resolve relative references within docstrings of methods of
+# the former. Some of these aliases are to allow Sphinx to locate the correct targets.
 reference_aliases = {
+    # genno
     "AnyQuantity": ":data:`genno.core.quantity.AnyQuantity`",
+    "Computer": "genno.Computer",
+    "Graph": "genno.core.graph.Graph",
+    "Operator": "genno.Operator",
+    "KeyLike": ":data:`genno.core.key.KeyLike`",
+    "iter_keys": "genno.core.key.iter_keys",
+    "single_key": "genno.core.key.single_key",
     r"(genno\.|)Key(?=Seq|[^\w]|$)": "genno.core.key.Key",
     r"(genno\.|)Quantity": "genno.core.attrseries.AttrSeries",
+    # ixmp
+    "ItemType": "ixmp.backend.ItemType",
+    "Platform": "ixmp.Platform",
+    "TimeSeries": "ixmp.TimeSeries",
     #
     # Many projects (including Sphinx itself!) do not have a py:module target in for the
     # top-level module in objects.inv. Resolve these using :doc:`index` or similar for
     # each project.
+    "dask$": ":std:doc:`dask:index`",
     "plotnine$": ":class:`plotnine.ggplot`",
 }
+
+# -- Options for ixmp.util.sphinx_linkcode_github / sphinx.ext.linkcode ----------------
+
+linkcode_github_repo_slug = "iiasa/message_ix"
+
+# -- Options for message_ix.util.sphinx_gams -------------------------------------------
+
+gams_source_dir = Path(__file__).parents[1].joinpath("message_ix", "model")
+gams_target_dir = "model"
 
 # -- Options for sphinx.ext.extlinks ---------------------------------------------------
 
@@ -182,10 +181,6 @@ intersphinx_mapping = {
     "xarray": ("https://docs.xarray.dev/en/stable", None),
 }
 
-# -- Options for sphinx.ext.linkcode / ixmp.util.sphinx_linkcode_github ----------------
-
-linkcode_github_repo_slug = "iiasa/message_ix"
-
 # -- Options for sphinx.ext.mathjax ----------------------------------------------------
 
 # See https://github.com/iiasa/message_ix/pull/721#pullrequestreview-1497907368:
@@ -231,8 +226,3 @@ todo_include_todos = True
 # -- Options for sphinxcontrib.bibtex --------------------------------------------------
 
 bibtex_bibfiles = ["references.bib"]
-
-# -- Options for message_ix.util.sphinx_gams -------------------------------------------
-
-gams_source_dir = Path(__file__).parents[1].joinpath("message_ix", "model")
-gams_target_dir = "model"

--- a/doc/contrib/tutorial.rst
+++ b/doc/contrib/tutorial.rst
@@ -4,7 +4,7 @@ Developing tutorials
 Developers *and users* of the |MESSAGEix| framework are welcome to contribute **tutorials**, according to the following guidelines.
 Per the license and CLA, tutorials will become part of the message_ix test suite and will be publicly available.
 
-Developers **must** ensure new features (including :mod:`message_ix.tools` submodules) are fully documented.
+Developers **must** ensure new features (including :py:`message_ix.tools` submodules) are fully documented.
 This can be done via the API documentation (this site) and, optionally, a tutorial.
 These have complementary purposes:
 

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -2,7 +2,7 @@ import logging
 import os
 from functools import lru_cache, partial
 from itertools import chain, product, zip_longest
-from typing import Iterable, List, Mapping, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 from warnings import warn
 
 import ixmp
@@ -231,6 +231,34 @@ class Scenario(ixmp.Scenario):
                 self._backend("cat_get_elements", name, cat),
             )
         )
+
+    def add_par(
+        self,
+        name: str,
+        key_or_data: Optional[
+            Union[int, str, Sequence[Union[int, str]], Dict, pd.DataFrame]
+        ] = None,
+        value=None,
+        unit: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> None:
+        # ixmp.Scenario.add_par() is typed as accepting only str, but this method also
+        # accepts int for "year"-like dimensions. Proxy the call to avoid type check
+        # failures.
+        # TODO Move this upstream, to ixmp
+        super().add_par(name, key_or_data, value, unit, comment)  # type: ignore [arg-type]
+
+    def add_set(
+        self,
+        name: str,
+        key: Union[int, str, Sequence[Union[str, int]], Dict, pd.DataFrame],
+        comment: Union[str, Sequence[str], None] = None,
+    ) -> None:
+        # ixmp.Scenario.add_par() is typed as accepting only str, but this method also
+        # accepts int for "year"-like dimensions. Proxy the call to avoid type check
+        # failures.
+        # TODO Move this upstream, to ixmp
+        super().add_set(name, key, comment)  # type: ignore [arg-type]
 
     def add_spatial_sets(self, data):
         """Add sets related to spatial dimensions of the model.

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -248,6 +248,8 @@ class Scenario(ixmp.Scenario):
         # TODO Move this upstream, to ixmp
         super().add_par(name, key_or_data, value, unit, comment)  # type: ignore [arg-type]
 
+    add_par.__doc__ = ixmp.Scenario.add_par.__doc__
+
     def add_set(
         self,
         name: str,
@@ -259,6 +261,8 @@ class Scenario(ixmp.Scenario):
         # failures.
         # TODO Move this upstream, to ixmp
         super().add_set(name, key, comment)  # type: ignore [arg-type]
+
+    add_set.__doc__ = ixmp.Scenario.add_set.__doc__
 
     def add_spatial_sets(self, data):
         """Add sets related to spatial dimensions of the model.

--- a/message_ix/macro.py
+++ b/message_ix/macro.py
@@ -158,13 +158,13 @@ def add_structure(
         scenario.add_set("cat_node", ["economy", n])
 
     # Add sectoral set structure
-    scenario.add_set("sector", s.sector)
+    scenario.add_set("sector", sorted(s.sector))
     scenario.add_set("mapping_macro_sector", mapping_macro_sector)
 
 
 def bconst(
     demand_ref: "DataFrame", gdp0: "Series", price_ref: "DataFrame", rho: "Series"
-) -> "Series":
+) -> "DataFrame":
     """Calculate production function coefficient.
 
     This is the MACRO GAMS parameter ``prfconst``.
@@ -450,7 +450,7 @@ def validate_transform(
         for col in cols:
             if df[col].dropna().empty:
                 raise ValueError(f"Config data for {col!r} is empty")
-        return
+        return pd.Series()
 
     # Validate this parameter and retrieve the index columns/dimensions
     idx = _validate_data(name, df, s)

--- a/message_ix/report/operator.py
+++ b/message_ix/report/operator.py
@@ -1,9 +1,11 @@
-from typing import List, Mapping, Union
+from typing import TYPE_CHECKING, List, Mapping, Tuple, Union
 
 import pandas as pd
-from ixmp.report import Quantity
 
 from message_ix.util import make_df
+
+if TYPE_CHECKING:
+    from genno.types import AnyQuantity
 
 __all__ = [
     "as_message_df",
@@ -14,7 +16,11 @@ __all__ = [
 
 
 def as_message_df(
-    qty: Quantity, name: str, dims: Mapping, common: Mapping, wrap: bool = True
+    qty: "AnyQuantity",
+    name: str,
+    dims: Mapping,
+    common: Mapping,
+    wrap: bool = True,
 ) -> Union[pd.DataFrame, dict]:
     """Convert `qty` to an :meth:`.add_par`-ready data frame using :func:`.make_df`.
 
@@ -70,7 +76,7 @@ def model_periods(y: List[int], cat_year: pd.DataFrame) -> List[int]:
     )
 
 
-def plot_cumulative(x, y, labels):
+def plot_cumulative(x: "AnyQuantity", y: "AnyQuantity", labels: Tuple[str, str, str]):
     """Plot a supply curve.
 
     - `x` and `y` must share the first two dimensions.
@@ -92,25 +98,25 @@ def plot_cumulative(x, y, labels):
     d0, d1, d2 = y.dims
 
     assert (
-        (d0, d1) == x.dims
-    ), f"dimensions of x {repr(x.dims)} != first dimensions of y {repr((d0, d1))}"
+        d0,
+        d1,
+    ) == x.dims, f"dimensions of x {x.dims!r} != first dimensions of y {(d0, d1)!r}"
 
     # Check that all data have the same value in the first dimension
     d0_labels = set(x.coords[d0].values) | set(y.coords[d0].values)
-    assert (
-        len(d0_labels) == 1
-    ), f"non-unique values {repr(d0_labels)} for dimension {repr(d0)}"
+    assert len(d0_labels) == 1, f"non-unique values {d0_labels!r} for dimension {d0!r}"
+    d0_label = d0_labels.pop()
 
     axes_properties = dict(
-        title=f"{d0_labels.pop()} {labels[0].title()}",
+        title=f"{d0_label} {labels[0].title()}",
         xlabel=f"{labels[1]} [{x.attrs['_unit']:~}]",
         ylabel=f"{labels[2]} [{y.attrs['_unit']:~}]",
     )
 
     # Reshape data
-    x_series = x.drop(d0).to_series()
+    x_series = x.sel({d0: d0_label}, drop=True).to_series()
     # NB groupby().mean() here will compute a mean price across d2, e.g. year
-    y_series = y.drop(d0).to_series().groupby(d1).mean()
+    y_series = y.sel({d0: d0_label}, drop=True).to_series().groupby(d1).mean()
 
     fig, ax = pyplot.subplots()
 
@@ -130,7 +136,14 @@ def plot_cumulative(x, y, labels):
     return ax
 
 
-def stacked_bar(qty, dims=["nl", "t", "ya"], units="", title="", cf=1.0, stacked=True):
+def stacked_bar(
+    qty: "AnyQuantity",
+    dims: Tuple[str, str, str] = ("nl", "t", "ya"),
+    units: str = "",
+    title: str = "",
+    cf: float = 1.0,
+    stacked: bool = True,
+):
     """Plot `qty` as a stacked bar chart.
 
     Parameters

--- a/message_ix/report/operator.py
+++ b/message_ix/report/operator.py
@@ -96,6 +96,7 @@ def plot_cumulative(x: "AnyQuantity", y: "AnyQuantity", labels: Tuple[str, str, 
 
     # Unpack the dimensions of `y`, typically "n" (node), "g" (grade), "y" (year)
     d0, d1, d2 = y.dims
+    assert isinstance(d1, str)
 
     assert (
         d0,

--- a/message_ix/report/pyam.py
+++ b/message_ix/report/pyam.py
@@ -1,11 +1,15 @@
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Optional
 
-import pandas as pd
+if TYPE_CHECKING:
+    import pandas
 
 
 def collapse_message_cols(
-    df: pd.DataFrame, var: Optional[str] = None, kind: Optional[str] = None, var_cols=[]
-) -> Callable:
+    df: "pandas.DataFrame",
+    var: Optional[str] = None,
+    kind: Optional[str] = None,
+    var_cols=[],
+) -> "pandas.DataFrame":
     """:mod:`genno.compat.pyam` `collapse=...` callback for MESSAGEix quantities.
 
     Wraps :func:`~genno.compat.pyam.util.collapse` with arguments particular to

--- a/message_ix/report/pyam.py
+++ b/message_ix/report/pyam.py
@@ -1,7 +1,6 @@
 from typing import Callable, Optional
 
 import pandas as pd
-from genno.compat.pyam import util
 
 
 def collapse_message_cols(
@@ -27,6 +26,8 @@ def collapse_message_cols(
         - 'emi': 'variable' is ``'<var>|<emission>|<technology>|<mode>'``.
         - Otherwise: 'variable' is ``'<var>|<technology>'``.
     """
+    from genno.compat.pyam import util
+
     columns = dict(variable=[var] if var else [])
 
     if kind == "ene":

--- a/message_ix/tests/test_feature_duration_time.py
+++ b/message_ix/tests/test_feature_duration_time.py
@@ -13,7 +13,8 @@ from message_ix import Scenario
 
 
 # A function for generating a simple model with sub-annual time slices
-def model_generator(
+# FIXME reduce complexity 14 → ≤13
+def model_generator(  # noqa: C901
     test_mp,
     comment,
     tec_time,

--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -86,7 +86,7 @@ def unit_uniform(df):
 # %% III) The main function
 
 
-# FIXME reduce complexity from 17 to <=14
+# FIXME reduce complexity 17 → ≤13
 def add_year(  # noqa: C901
     sc_ref,
     sc_new,
@@ -266,7 +266,8 @@ def add_year(  # noqa: C901
 
 # %% Submodules needed for running the main function
 #   IV) Adding new years to sets
-def add_year_set(
+# FIXME reduce complexity 13 → ≤13
+def add_year_set(  # noqa: C901
     sc_ref,
     sc_new,
     years_new,
@@ -537,7 +538,7 @@ def add_year_par(
 # %% VI) Required functions
 
 
-# FIXME reduce complexity from 19 to <=14
+# FIXME reduce complexity 19 → ≤13
 def interpolate_1d(  # noqa: C901
     df,
     yrs_new,
@@ -692,7 +693,7 @@ def interpolate_1d(  # noqa: C901
 # %% VI.B) Interpolating parameters with two dimensions related to time
 
 
-# FIXME reduce complexity from 38 to <=14
+# FIXME reduce complexity 38 → ≤13
 def interpolate_2d(  # noqa: C901
     df,
     yrs_new,

--- a/message_ix/util/__init__.py
+++ b/message_ix/util/__init__.py
@@ -94,8 +94,8 @@ def make_df(name, **data):
     """Return a data frame for parameter or indexed set `name` filled with `data`.
 
     :func:`make_df` always returns a data frame with the columns required by either:
-    - :meth:`.add_par`: the dimensions of the parameter `name`, plus 'value' and
-      'unit'.
+
+    - :meth:`.add_par`: the dimensions of the parameter `name`, plus 'value' and 'unit'.
     - :meth:`.add_set`: the dimensions of the indexed set `name`.
 
     Columns not listed in `data` are left empty.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,12 +92,9 @@ exclude = ["doc/"]
 [[tool.mypy.overrides]]
 # Packages/modules for which no type hints are available.
 module = [
-  "matplotlib.*",
-  "pandas.*",
   "pyam",
   "scipy.*",
   # Indirectly via ixmp; this should be a subset of the list in ixmp's pyproject.toml
-  "dask.*",
   "jpype",
   "memory_profiler",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ exclude_also = [
 
 [tool.coverage.run]
 omit = [
-  "message_ix/model/*",
   "message_ix/tests/test_nightly.py",
   "message_ix/testing/nightly.py",
 ]
@@ -115,13 +114,14 @@ markers = [
 
 [tool.ruff.lint]
 select = ["C9", "E", "F", "I", "W"]
-# Exceptions:
-# - message_ix/core.py:716:5: C901 'Scenario.rename' is too complex (18)
-# - message_ix/tools/add_year/__init__.py:86:1: C901 'add_year' is too complex (17)
-# - message_ix/tools/add_year/__init__.py:533:1: C901 'interpolate_1d' is too complex (19)
-# - message_ix/tools/add_year/__init__.py:687:1: C901 'interpolate_2d' is too complex (38)
-# - message_ix/testing/__init__.py:91:1: C901 'make_austria' is too complex (18)
-mccabe.max-complexity = 14
+# FIXME the following exceed this limit
+# - .testing.make_austria(): 18
+# - .tests.test_feature_duration_time.model_generator(): 14
+# - .tools.add_year.add_year_set(): 14
+# - .tools.add_year.add_year(): 17
+# - .tools.add_year.interpolate_1d(): 19
+# - .tools.add_year.interpolate_2d(): 38
+mccabe.max-complexity = 13
 
 [tool.setuptools.packages]
 find = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ documentation = "https://docs.messageix.org"
 
 [project.optional-dependencies]
 docs = [
+  "genno >= 1.26",  # For sphinx extensions; see doc/conf.py
   "GitPython",
   "message_ix[report]",
   "numpydoc",


### PR DESCRIPTION
- Adapt typing to genno 1.25.
- Defer import of pyam until needed; speeds up import of message_ix.
- Improve documentation cross-references using sphinx extensions provided by genno 1.26.
- Adjust code to pass type checks with pandas-stubs.
- Reduce max-complexity 15 → 13.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- ~Update release notes.~ No change in functionality.