### PR TITLE
Ensure compatibility with pandas CoW

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- Ensure compatibility with pandas upcoming 3.0 Copy-on-Write behaviour (:pull:`842`).
 - Update tutorial Westeros multinode to include code-based hints for in-depth questions (:pull:`798`).
 - :func:`.make_df` can now create partly-filled :class:`DataFrames <pandas.DataFrame>` for indexed sets; not only parameters (:pull:`784`).
 - New function :func:`.util.copy_model` that exposes the behaviour of the :program:`message-ix copy-model` CLI command to other Python code (:pull:`784`).

--- a/message_ix/macro.py
+++ b/message_ix/macro.py
@@ -287,7 +287,9 @@ def extrapolate(
     # Apply fitted_intercept to grouped data
     groupby_cols = set(model_data.columns) - {"year", "value"}
     result = (
-        model_data.groupby(list(groupby_cols)).apply(fitted_intercept).rename("value")
+        model_data.groupby(list(groupby_cols))
+        .apply(fitted_intercept, include_groups=False)
+        .rename("value")
     )
 
     # Convert "commodity" and "level" to "sector"

--- a/message_ix/macro.py
+++ b/message_ix/macro.py
@@ -272,6 +272,8 @@ def extrapolate(
         The index does *not* have a ``year`` dimension; the data are implicitly for
         `ym1`.
     """
+    from sys import version_info
+
     from scipy.optimize import curve_fit
 
     def f(x, b, m):
@@ -286,9 +288,10 @@ def extrapolate(
 
     # Apply fitted_intercept to grouped data
     groupby_cols = set(model_data.columns) - {"year", "value"}
+    apply_kwargs = {"include_groups": False} if version_info.minor > 8 else {}
     result = (
         model_data.groupby(list(groupby_cols))
-        .apply(fitted_intercept, include_groups=False)
+        .apply(fitted_intercept, **apply_kwargs)
         .rename("value")
     )
 

--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -430,16 +430,8 @@ def add_year_par(
         )
         sc_new.commit("New parameter initiated!")
 
-    par_old = (
-        sc_ref.par(parname, {node_col[0]: reg_list})
-        if node_col
-        else sc_ref.par(parname)
-    )
-    par_new = (
-        sc_new.par(parname, {node_col[0]: reg_list})
-        if node_col
-        else sc_new.par(parname)
-    )
+    par_old = sc_ref.par(parname, filters={node_col[0]: reg_list} if node_col else None)
+    par_new = sc_new.par(parname, filters={node_col[0]: reg_list} if node_col else None)
     sort_order = (
         [
             node_col[0],


### PR DESCRIPTION
Closes #804.
This PR temporarily enables the pandas Copy-on-Write behaviour that will become standard with pandas 3.0. With this, I ran all tests locally to study the warnings we would get from this: only two files were affected, `add_year/__init__` and `macro`. Then, I fixed all of these warnings [as suggested in the migration guide](https://pandas.pydata.org/docs/user_guide/copy_on_write.html#copy-on-write), so we might be good with this repo (and all underlying ixmp functions called from the test suite here) :)

## How to review

- Read the diff and note that the CI checks all pass.
- Study CI output to see if any pandas Warnings wrt CoW came up that were skipped locally.
- Fix new Warnings (if any).
- Remove the `TEMPORARY` commit to avoid enabling pandas CoW for all users already.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~
- ~[ ] Add, expand, or update documentation.~
- [x] Update release notes.

