### PR TITLE
Adjust CI for Numpy 2.0, Graphviz

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -66,6 +66,10 @@ jobs:
         (cd ixmp; pip install .[tests])
         (cd message_ix; pip install .[tests])
 
+        # TEMPORARY Work around unionai-oss/pandera#1685;
+        # see https://github.com/khaeru/genno/issues/140
+        pip install "numpy < 2"
+
     - name: Run test suite using pytest
       env:
         MESSAGE_IX_CI_USER: ${{ secrets.ENE_DATA_USER }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -86,6 +86,10 @@ jobs:
         pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
         pip install .[tests]
 
+        # TEMPORARY Work around unionai-oss/pandera#1685;
+        # see https://github.com/khaeru/genno/issues/140
+        pip install "numpy < 2"
+
     - name: Run test suite using pytest
       env:
         # For test_cli.test_dl; see code in message_ix.cli.dl
@@ -165,6 +169,10 @@ jobs:
       run: |
         pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
         pip install .[tests]
+
+        # TEMPORARY Work around unionai-oss/pandera#1685;
+        # see https://github.com/khaeru/genno/issues/140
+        pip install "numpy < 2"
 
     - name: Install R dependencies and tutorial requirements
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -61,8 +61,8 @@ jobs:
         cache-dependency-path: "**/pyproject.toml"
 
     - uses: ts-graphviz/setup-graphviz@v2
-      with:
-        macos-skip-brew-update: true
+      # TEMPORARY Work around ts-graphviz/setup-graphviz#630
+      if: ${{ ! startswith(matrix.os, 'macos-') }}
 
     - name: Cache GAMS installer and R packages
       uses: actions/cache@v4
@@ -138,8 +138,8 @@ jobs:
       shell: bash
 
     - uses: ts-graphviz/setup-graphviz@v2
-      with:
-        macos-skip-brew-update: true
+      # TEMPORARY Work around ts-graphviz/setup-graphviz#630
+      if: ${{ ! startswith(matrix.os, 'macos-') }}
 
     - uses: r-lib/actions/setup-r@v2
       id: setup-r


### PR DESCRIPTION
This PR updates the "pytest" CI workflow to address two causes of failures:

- With NumPy 2.0.0 we run into unionai-oss/pandera#1685, which is a dependency via `message_ix.report` → `pyam-iamc` → `ixmp4`. We apply the mitigation discussed at khaeru/genno#140.
- ts-graphviz/setup-graphviz#630. This mirrors changes made in iiasa/ixmp#535.

Both of these are temporary work-arounds, are marked accordingly, and should be removed when the respective upstream packages are fixed.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅ CI changes only.
- ~Add, expand, or update documentation.~
- ~Update release notes.~