### PR TITLE
Bump GAMS version in CI workflows to adjust for ixmp changes

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ on:
   - cron: "0 5 * * *"
 
 env:
-  GAMS_VERSION: 25.1.1
+  GAMS_VERSION: 43.4.1
   # See description in lint.yml
   depth: 100
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GAMS_VERSION: 25.1.1
+  GAMS_VERSION: 43.4.1
   # See description in lint.yml
   depth: 100
 


### PR DESCRIPTION
https://github.com/iiasa/ixmp/pull/532 deleted some libraries that were used to run GAMS, which should now be read directly from a GAMS subdirectory. This PR adjusts the version of GAMS used in CI to check if this newer version enables finding the libraries.


## How to review


- Read the diff and note that the CI checks all pass.


## PR checklist

- [ ] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Just internal CI.
- ~[ ] Add, expand, or update documentation.~ Just internal CI.
- ~[ ] Update release notes.~ Just internal CI.

