### PR TITLE
Adjust to RTD's upcoming addon changes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,6 +4,7 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
 from importlib.metadata import version as get_version
 from pathlib import Path
 from typing import Optional
@@ -89,6 +90,15 @@ html_theme = "sphinx_rtd_theme"
 
 html_theme_options = {"logo_only": True}
 
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 # -- Options for LaTeX output ----------------------------------------------------------
 
 # The LaTeX engine to build the docs.
@@ -157,6 +167,7 @@ def local_inv(name: str, *parts: str) -> Optional[str]:
 
     if 0 == len(parts):
         parts = ("doc", "_build", "html")
+    assert spec.origin is not None
     return str(Path(spec.origin).parents[1].joinpath(*parts, "objects.inv"))
 
 


### PR DESCRIPTION
Starting on October 7, [RTD will switch to RTD Addons](https://about.readthedocs.com/blog/2024/07/addons-by-default/) for sphinx projects, too. They have identified that this is going to impact message_ix and suggest to change our configuration file in almost exactly the way this PR does. I have [enabled Addons temporarily on RTD](https://app.readthedocs.com/dashboard/iiasa-energy-program-message-ix/addons/edit/) and intend to use this PR to make any adjustments necessary to keep our docs building as expected. 

## How to review

- Read the diff and note that the CI checks all pass.
- Look at the docs built from this PR and confirm they are what we want/expect.


## PR checklist

- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Just docs-related.
- [x] Add, expand, or update documentation.
- ~[ ] Update release notes.~ Just docs-related.
