### PR TITLE
Add `.models.shift_period()`

### DIFF
--- a/message_ix/message.py
+++ b/message_ix/message.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import MutableMapping
 from functools import partial
+from typing import TYPE_CHECKING
 from warnings import warn
 
 import ixmp.model.gams
@@ -17,6 +18,10 @@ from .common import (
     _filter_log_initialize_items,
     _item_shorthand,
 )
+
+if TYPE_CHECKING:
+    from message_ix.core import Scenario
+
 
 log = logging.getLogger(__name__)
 
@@ -865,3 +870,62 @@ equ(
 )
 equ("TOTAL_CAPACITY_BOUND_LO", "n inv_tec y", "Lower bound on total installed capacity")
 equ("TOTAL_CAPACITY_BOUND_UP", "n inv_tec y", "Upper bound on total installed capacity")
+
+
+def shift_period(scenario: "Scenario", y0: int) -> None:
+    """Shift the first period of the model horizon."""
+    from ixmp.backend.jdbc import JDBCBackend
+
+    # Retrieve existing cat_year information, including the current 'firstmodelyear'
+    cat_year = scenario.set("cat_year")
+    y0_pre = cat_year.query("type_year == 'firstmodelyear'")["year"].item()
+
+    if y0 == y0_pre:
+        log.info(f"First model period is already {y0!r}")
+        return
+    elif y0 < y0_pre:
+        raise NotImplementedError(
+            f"Shift first model period *earlier*, from {y0_pre!r} -> {y0}"
+        )
+
+    # Periods to be shifted from within to before the model horizon
+    periods = list(
+        filter(lambda y: y0_pre <= y < y0, map(int, sorted(cat_year["year"].unique())))
+    )
+    log.info(f"Shift data for period(s): {periods}")
+
+    # Handle historical_* parameters for which the dimensions are a subset of the
+    # corresponding variable's dimensions
+    data = {}
+    for var_name, par_name, filter_dim in (
+        ("ACT", "historical_activity", "year_act"),
+        ("CAP_NEW", "historical_new_capacity", "year_vtg"),
+        ("EXT", "historical_extraction", "year"),
+        ("GDP", "historical_gdp", "year"),
+        ("LAND", "historical_land", "year"),
+    ):
+        # - Filter data for `var_name` along the `filter_dim`, keeping only the periods
+        #   to be shifted.
+        # - Drop the marginal column; rename the level column to "value".
+        # - Group according to the dimensions of the target `par_name`.
+        # - Sum within groups.
+        # - Restore index columns.
+        data[par_name] = (
+            scenario.var(var_name, filters={filter_dim: periods})
+            .drop("mrg", axis=1)
+            .rename(columns={"lvl": "value"})
+            .groupby(list(MESSAGE.items[par_name].dims))
+            .sum()["value"]
+            .reset_index()
+        )
+
+    # TODO Handle "EMISS:n-e-type_tec-y" →
+    # "historical_emission:n-type_emission-type_tec-type_year", in which dimension names
+    # are changed
+
+    # TODO Adjust cat_year
+
+    if isinstance(scenario.platform._backend, JDBCBackend):
+        raise NotImplementedError("Cannot set variable values with JDBCBackend")
+
+    # TODO Store new data

--- a/message_ix/tests/test_models.py
+++ b/message_ix/tests/test_models.py
@@ -1,6 +1,13 @@
 from contextlib import nullcontext
+from typing import TYPE_CHECKING
 
 import pytest
+
+from message_ix.message import shift_period
+from message_ix.testing import make_dantzig
+
+if TYPE_CHECKING:
+    from ixmp import Platform
 
 
 @pytest.mark.parametrize(
@@ -27,3 +34,21 @@ def test_deprecated_import(name: str) -> None:
 
     with ctx:
         getattr(message_ix.models, name)
+
+
+@pytest.mark.parametrize(
+    "y0",
+    (
+        # Not implemented: shifting to an earlier period
+        pytest.param(1962, marks=pytest.mark.xfail(raises=NotImplementedError)),
+        # Does nothing
+        1963,
+        # Not implemented with ixmp.JDBCBackend
+        pytest.param(1964, marks=pytest.mark.xfail(raises=NotImplementedError)),
+        pytest.param(1965, marks=pytest.mark.xfail(raises=NotImplementedError)),
+    ),
+)
+def test_shift_period(test_mp: "Platform", y0: int) -> None:
+    s = make_dantzig(test_mp, solve=True, multi_year=True)
+
+    shift_period(s, y0)


### PR DESCRIPTION
This PR adds a function `shift_period()` that implements, purely in Python, the behaviour of `Scenario.clone(…, shift_first_model_year)`. Because the latter is currently implemented in the Java code underlying `ixmp.JDBCBackend`, it cannot be extended in parallel with changes to the implementation of MESSAGE in GAMS (or, in the future, other implementations).

- Partly addresses #254.
- Also due to limitations of `ixmp.JDBCBackend`, is it not supported to set values on model data items of type "variable" or "equation" directly. Thus, this PR can't be completed without iiasa/ixmp#552, iiasa/ixmp#400, or similar.
- cf. also iiasa/ixmp#424. While the behaviour is currently provided as an argument to the `clone()` command, the new function is distinct.
- This PR does not directly address, but will make it much easier to address:
  - #542
  - #543
  - #867
- The operation of shifting the first model period *forward* in time is *lossy*, because parameters like `historical_activity` have fewer dimensions than the corresponding variables (e.g. `ACT`). For the opposite operation—shifting the first model period *backwards* in time—essentially the scenario must be solved again to generate the corresponding solution data in e.g. `ACT`.

**More to be added**

## How to review

**To be added**

<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- Build the documentation and look at a certain page.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

- [ ] Complete the implementation
  - [ ] Invoke `shift_period()` from `message_ix.Scenario.clone(…)` if the corresponding argument is given.
- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.