### PR TITLE
Support mypy 1.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     language: python
     entry: bash -c ". ${PRE_COMMIT_MYPY_VENV:-/dev/null}/bin/activate 2>/dev/null; mypy $0 $@"
     additional_dependencies:
-    - mypy >= 1.9.0
+    - mypy >= 1.12.0
     - asyncssh
     - git+https://github.com/iiasa/ixmp.git@main
     - importlib_resources
@@ -22,7 +22,7 @@ repos:
     - types-requests
     args: ["."]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.4
+  rev: v0.6.9
   hooks:
   - id: ruff
   - id: ruff-format

--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -218,9 +218,9 @@ def add_year(
     cat_year_new: pd.DataFrame = sc_new.set("cat_year")
     firstmodelyear_new = cat_year_new.query("type_year == 'firstmodelyear'")
     firstyr_new: int = (
-        min(cat_year_new["year"])
+        int(min(cat_year_new["year"]))
         if firstmodelyear_new.empty
-        else firstmodelyear_new["year"]
+        else int(firstmodelyear_new["year"].item())
     )  # type: ignore
     # assert isinstance(firstyear_new, int)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ omit = [
 
 [tool.mypy]
 exclude = ["doc/"]
+# TODO Remove this once it has become default with mypy 2.0:
+local_partial_types = true
 
 [[tool.mypy.overrides]]
 # Packages/modules for which no type hints are available.

--- a/tutorial/westeros/westeros_report.ipynb
+++ b/tutorial/westeros/westeros_report.ipynb
@@ -118,9 +118,11 @@
     "rep.add(\"A\", 1)\n",
     "rep.add(\"B\", 2)\n",
     "\n",
+    "\n",
     "# Add one node and two edges\n",
     "def add(*inputs):\n",
     "    return sum(inputs)\n",
+    "\n",
     "\n",
     "rep.add(\"C\", add, \"A\", \"B\")"
    ]
@@ -283,6 +285,7 @@
     "\n",
     "def ratio(a, b):\n",
     "    return a / b\n",
+    "\n",
     "\n",
     "# Add your code here:"
    ]


### PR DESCRIPTION
Our CI failed today because of the [release of mypy 1.12](https://mypy.readthedocs.io/en/stable/changelog.html).
This PR collects changes to adjust. It also includes a suggested change, namely to activate `local_partial_type = true` since this is planned to become the default with mypy 2.0. However, this setting does not seem to affect this repository too much :)

This PR is likely a prerequisite for other PRs as they won't be able to clear the code quality check before being rebased on this one.

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Just adjusting to dependency.
- ~[ ] Add, expand, or update documentation.~ Just adjusting to dependency.
- ~[ ] Update release notes.~ Just adjusting to dependency.
