### PR TITLE
Replace resolved numpy workaround with dask workaround

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -170,9 +170,9 @@ jobs:
         pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
         pip install .[tests]
 
-        # TEMPORARY Work around unionai-oss/pandera#1685;
-        # see https://github.com/khaeru/genno/issues/140
-        pip install "numpy < 2"
+        # TEMPORARY Work around dask v2024.11.0;
+        # see https://github.com/khaeru/genno/issues/149
+        pip install "dask != 2024.11.0"
 
     - name: Install R dependencies and tutorial requirements
       run: |


### PR DESCRIPTION
This PR tries to resolve the CI test failures by not using version 2024.11.0 of dask, which is causing [issues with genno](https://github.com/khaeru/genno/issues/149). 

The most preferable solution would be to adapt genno to this dask version, but it is unclear how much effort this would be and how long this would take. So for now, I'm simply imposing that we don't use that particular version (note: 2024.11.1 would be allowed, hoping that this might resolve the incompatibilities).
If this workaround is successful and we agree we want to employ it for now, we should also adopt it in the nightly workflow.

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
- [x] Update CI tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update release notes.~ Just CI.
