### PR TITLE
Bump GAMS version in nightly CI worklow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,10 @@ on:
   - cron: "0 5 * * *"
 
 env:
-  GAMS_VERSION: 29.1.0
+  # Version used until 2024-11-20; disabled
+  # GAMS_VERSION: 29.1.0
+  # First version including a macOS arm64 distribution
+  GAMS_VERSION: 43.4.1
   # See description in lint.yml
   depth: 100
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,6 +14,8 @@ on:
       - '**.gms'
       - '**.gpr'
       - '**.gdx'
+    types:
+     - labeled
 
 env:
   # Version used until 2024-11-20; disabled

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,6 +9,11 @@ on:
   schedule:
   # 05:00 UTC = 06:00 CET = 07:00 CEST
   - cron: "0 5 * * *"
+  pull_request_target:
+    paths:
+      - '**.gms'
+      - '**.gpr'
+      - '**.gdx'
 
 env:
   # Version used until 2024-11-20; disabled

--- a/message_ix/tests/test_nightly.py
+++ b/message_ix/tests/test_nightly.py
@@ -1,5 +1,8 @@
 """Slow-running tests for nightly continuous integration."""
 
+
+from functools import partial  # noqa: F401, is used through `case["test"]` below
+
 import ixmp
 import pytest
 

--- a/message_ix/tests/test_nightly.py
+++ b/message_ix/tests/test_nightly.py
@@ -1,6 +1,5 @@
 """Slow-running tests for nightly continuous integration."""
 
-
 from functools import partial  # noqa: F401, is used through `case["test"]` below
 
 import ixmp

--- a/message_ix/tests/test_nightly.py
+++ b/message_ix/tests/test_nightly.py
@@ -3,6 +3,7 @@
 from functools import partial  # noqa: F401, is used through `case["test"]` below
 
 import ixmp
+import numpy as np  # noqa: F401, same as above
 import pytest
 
 import message_ix


### PR DESCRIPTION
Similar to https://github.com/iiasa/message-ix-models/pull/250#pullrequestreview-2450593364, I'm hoping today's nightly CI test failure also just arises from an incompatibility of using an older GAMS version but a newer GAMS license for this kind of run. This PR thus bumps the GAMS version in the nightly workflow and temporarily enables them to make sure the fix works.

## How to review


- Read the diff and note that the CI checks all pass.


## PR checklist


- [x] Continuous integration checks all ✅
- [x] Update tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation. ~ Just CI.
- ~[ ] Update release notes. ~ Just CI.
