### PR TITLE
Allow moderated secrets usage on PRs from forks

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,6 +6,9 @@ on:
   # 05:00 UTC = 06:00 CET = 07:00 CEST
   schedule:
   - cron: "0 5 * * *"
+  workflow_run:
+    workflows: [ "Receive pull request" ]
+    types: [ completed ]
 
 # Cancel previous runs that have not completed
 concurrency:
@@ -23,6 +26,10 @@ env:
 
 jobs:
   pytest:
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+
     strategy:
       matrix:
         os:
@@ -62,9 +69,18 @@ jobs:
 
     steps:
     - name: Check out message_ix
+      if: github.event_name != 'workflow_run'
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.depth }}
+
+    - name: Check out message_ix (workflow_run)
+      if: github.event_name == 'workflow_run'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: ${{ env.depth }}
+        repository: ${{ github.event.workflow_run.repository }}
+        ref: ${{ github.event.workflow_run.head_branch }}
 
     - name: Fetch tags (for setuptools-scm)
       run: git fetch --tags --depth=${{ env.depth }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -139,6 +139,10 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   tutorials:
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+
     strategy:
       matrix:
         os:
@@ -153,9 +157,17 @@ jobs:
 
     steps:
     - name: Check out message_ix
+      if: github.event_name != 'workflow_run'
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.depth }}
+
+    - name: Check out message_ix (workflow_run)
+      if: github.event_name == 'workflow_run'
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.workflow_run.repository }}
+        ref: ${{ github.event.workflow_run.head_branch }}
 
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/receive.yaml
+++ b/.github/workflows/receive.yaml
@@ -1,0 +1,21 @@
+name: Receive pull request
+
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+  label: "safe to test"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Ensure first-party branch or valid label
+      if: >
+        github.repository != github.event.pull_request.head.repo.full_name &&
+        ! contains(github.event.pull_request.labels.*.name, env.label)
+      run: |
+        echo "Will not run \`pytest\` workflow for branch in fork without label \`${{ env.label }}\`." >>$GITHUB_STEP_SUMMARY
+        exit 1


### PR DESCRIPTION
This PR implements the approach recommended by [this article](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) from Github's ‘Security Lab’ to allow the usage of secrets on PRs from forks of the `message_ix` repository.

- Add a "receive" CI workflow.
  - Run on all PRs into `main`.
  - Fail if (a) the PR is from a fork and (b) it does not have a certain label, currently "safe to test".
- Adjust the "pytest" CI workflow:
  - Add a `workflow_run:` event trigger. Invoke this trigger every time the "receive" workflow completes (success or failure).
  - Skip the main `pytest` and `tutorials` jobs if the "receive" workflow failed.
  - Invoke actions/checkout with the right options to use the fork PR branch.

With this merged, it would be up to some user with ‘write’ permissions on the current repo to give a first look-over of any PR from and then add the "safe to test" label. (The label could also be removed again at any time.)

## How to review

[Per the documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run):

> This [workflow_run] event will only trigger a workflow run if the workflow file is on the default branch.

This means we will need to:
- Merge this PR.
- Create or update another PR (#770 was suggested).
- Confirm that the `pytest` workflow is invoked and runs successfully; if not, open a follow-up PR to adjust the workflow(s).

## PR checklist

- [x] Continuous integration checks all ✅
- ~Add or expand tests; coverage checks both ✅~ N/A; CI changes only
- ~Add, expand, or update documentation.~
- ~Update release notes.~
