### PR TITLE
Annotate `cat_list()`

### DIFF
--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -184,13 +184,17 @@ class Scenario(ixmp.Scenario):
         """
         return self._year_as_int(name, super().var(name, filters))
 
-    def cat_list(self, name):
+    def cat_list(self, name: str) -> list[str]:
         """Return a list of all categories for a mapping set.
 
         Parameters
         ----------
         name : str
             Name of the set.
+
+        Returns
+        -------
+        list of str
         """
         return self._backend("cat_list", name)
 


### PR DESCRIPTION
This PR comes from me wanting to showcase a small, completely typed function in the UBA presentation on Tuesday as an example for how to use docstrings. I didn't want to spend too much time looking, `cat_list()` seems fine, but is missing some annotation. This PR provides them.

## How to review

No need to merge this (quickly), I'm mainly interested in the docs built from this PR. But of course, this is a small improvement we can bring in anytime :)


- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
- ~[ ] Add or expand tests;~ coverage checks both ✅ Just adding annotations.
- [x] Add, expand, or update documentation.
- ~[ ] Update release notes.~ Just adding annotations.
