### PR TITLE
Bump Python version for tutorials

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -171,7 +171,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
         cache: pip
         cache-dependency-path: "**/pyproject.toml"
 
@@ -251,7 +251,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:  # Same as the "Latest version supported by message_ix", above
-        python-version: "3.12"
+        python-version: "3.13"
 
     - name: Force recreation of pre-commit virtual environment for mypy
       if: github.event_name == 'schedule'  # Comment this line to run on a PR

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - types-requests
     args: ["."]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.9
+  rev: v0.8.4
   hooks:
   - id: ruff
   - id: ruff-format

--- a/message_ix/tests/test_report.py
+++ b/message_ix/tests/test_report.py
@@ -204,30 +204,34 @@ def test_reporter_as_pyam(caplog, tmp_path, dantzig_reporter):
     assert not any(c in df2.columns for c in ["h", "m", "t"])
 
     # Variable names were formatted by the callback
-    reg_var = pd.DataFrame(
-        [
-            ["seattle", "Activity|canning_plant|production"],
-            ["seattle", "Activity|transport_from_seattle|to_new-york"],
-            ["seattle", "Activity|transport_from_seattle|to_chicago"],
-            ["seattle", "Activity|transport_from_seattle|to_topeka"],
-            ["san-diego", "Activity|canning_plant|production"],
-            ["san-diego", "Activity|transport_from_san-diego|to_new-york"],
-            ["san-diego", "Activity|transport_from_san-diego|to_chicago"],
-            ["san-diego", "Activity|transport_from_san-diego|to_topeka"],
-        ],
-        columns=["region", "variable"],
-    ) if sys.version_info >= (3, 10) else pd.DataFrame(
-        [
-            ["san-diego", "Activity|canning_plant|production"],
-            ["san-diego", "Activity|transport_from_san-diego|to_chicago"],
-            ["san-diego", "Activity|transport_from_san-diego|to_new-york"],
-            ["san-diego", "Activity|transport_from_san-diego|to_topeka"],
-            ["seattle", "Activity|canning_plant|production"],
-            ["seattle", "Activity|transport_from_seattle|to_chicago"],
-            ["seattle", "Activity|transport_from_seattle|to_new-york"],
-            ["seattle", "Activity|transport_from_seattle|to_topeka"],
-        ],
-        columns=["region", "variable"],
+    reg_var = (
+        pd.DataFrame(
+            [
+                ["seattle", "Activity|canning_plant|production"],
+                ["seattle", "Activity|transport_from_seattle|to_new-york"],
+                ["seattle", "Activity|transport_from_seattle|to_chicago"],
+                ["seattle", "Activity|transport_from_seattle|to_topeka"],
+                ["san-diego", "Activity|canning_plant|production"],
+                ["san-diego", "Activity|transport_from_san-diego|to_new-york"],
+                ["san-diego", "Activity|transport_from_san-diego|to_chicago"],
+                ["san-diego", "Activity|transport_from_san-diego|to_topeka"],
+            ],
+            columns=["region", "variable"],
+        )
+        if sys.version_info >= (3, 10)
+        else pd.DataFrame(
+            [
+                ["san-diego", "Activity|canning_plant|production"],
+                ["san-diego", "Activity|transport_from_san-diego|to_chicago"],
+                ["san-diego", "Activity|transport_from_san-diego|to_new-york"],
+                ["san-diego", "Activity|transport_from_san-diego|to_topeka"],
+                ["seattle", "Activity|canning_plant|production"],
+                ["seattle", "Activity|transport_from_seattle|to_chicago"],
+                ["seattle", "Activity|transport_from_seattle|to_new-york"],
+                ["seattle", "Activity|transport_from_seattle|to_topeka"],
+            ],
+            columns=["region", "variable"],
+        )
     )
     assert_frame_equal(df2[["region", "variable"]], reg_var)
 

--- a/message_ix/tests/test_report.py
+++ b/message_ix/tests/test_report.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import sys
 from functools import partial
 from pathlib import Path
 
@@ -204,6 +205,18 @@ def test_reporter_as_pyam(caplog, tmp_path, dantzig_reporter):
 
     # Variable names were formatted by the callback
     reg_var = pd.DataFrame(
+        [
+            ["seattle", "Activity|canning_plant|production"],
+            ["seattle", "Activity|transport_from_seattle|to_new-york"],
+            ["seattle", "Activity|transport_from_seattle|to_chicago"],
+            ["seattle", "Activity|transport_from_seattle|to_topeka"],
+            ["san-diego", "Activity|canning_plant|production"],
+            ["san-diego", "Activity|transport_from_san-diego|to_new-york"],
+            ["san-diego", "Activity|transport_from_san-diego|to_chicago"],
+            ["san-diego", "Activity|transport_from_san-diego|to_topeka"],
+        ],
+        columns=["region", "variable"],
+    ) if sys.version_info >= (3, 10) else pd.DataFrame(
         [
             ["san-diego", "Activity|canning_plant|production"],
             ["san-diego", "Activity|transport_from_san-diego|to_chicago"],


### PR DESCRIPTION
We're seeing the same error in our CI again as we did previously when GitHub runner-images first changed `ubuntu-latest` to Ubuntu 24.04. They are rolling out the same change again now. However, we have adopted Python 3.13 in the meantime and in the ixmp test suite, this seems to work, while Python 3.12 produces the same error with Ubuntu 24.04. 3.11 works with that image, too, so the error might be specific to Python 3.12. Thus, this PR bumps the Python version we use for the tutorial tests in hopes of enabling them to run again on `ubuntu-latest`.

If this works, we might be able to adjust the ixmp test suite to only use Ubuntu 22.04 with Python 3.12.

See https://github.com/IRkernel/IRkernel/issues/747 and https://github.com/r-lib/actions/issues/932 for the issues I opened about this back then.

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] Update test suite; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI bump.
- ~[ ] Update release notes.~ Just CI bump.

