### PR TITLE
Make usage of `vintage_and_active_years()` in the tutorials consistent

### DIFF
--- a/tutorial/westeros/westeros_firm_capacity.ipynb
+++ b/tutorial/westeros/westeros_firm_capacity.ipynb
@@ -70,8 +70,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "year_df = scen.vintage_and_active_years()\n",
-    "vintage_years, act_years = year_df[\"year_vtg\"], year_df[\"year_act\"]\n",
     "model_horizon = scen.set(\"year\")\n",
     "country = \"Westeros\""
    ]
@@ -387,7 +385,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "message_ix",
+   "display_name": "mix312",
    "language": "python",
    "name": "python3"
   },
@@ -402,11 +400,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.3"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "29605b568787f5559ca1ba05da75d155c3dcfa15a1a63b1885b057c5465ade2e"
-   }
   }
  },
  "nbformat": 4,

--- a/tutorial/westeros/westeros_fossil_resource.ipynb
+++ b/tutorial/westeros/westeros_fossil_resource.ipynb
@@ -128,11 +128,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "country = \"Westeros\"\n",
+    "\n",
     "# Retrieving model period information\n",
-    "year_df = scen.vintage_and_active_years()\n",
+    "year_df = scen.vintage_and_active_years((country, \"coal_ppl\"), in_horizon=False)\n",
     "vintage_years, act_years = year_df[\"year_vtg\"], year_df[\"year_act\"]\n",
-    "model_horizon = scen.set(\"year\")\n",
-    "country = \"Westeros\""
+    "model_horizon = scen.set(\"year\")"
    ]
   },
   {
@@ -491,7 +492,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "message_ix",
+   "display_name": "mix312",
    "language": "python",
    "name": "python3"
   },
@@ -506,11 +507,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.3"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "29605b568787f5559ca1ba05da75d155c3dcfa15a1a63b1885b057c5465ade2e"
-   }
   }
  },
  "nbformat": 4,

--- a/tutorial/westeros/westeros_historical_new_capacity.ipynb
+++ b/tutorial/westeros/westeros_historical_new_capacity.ipynb
@@ -225,7 +225,7 @@
    "outputs": [],
    "source": [
     "df = scenario.par(\"demand\")\n",
-    "df[\"value\"] = float(df[df[\"year\"] == 700][\"value\"])\n",
+    "df[\"value\"] = float(df.loc[df[\"year\"] == 700, \"value\"].iloc[0])\n",
     "scenario.add_par(\"demand\", df)\n",
     "df"
    ]
@@ -1106,7 +1106,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mix312",
    "language": "python",
    "name": "python3"
   },

--- a/tutorial/westeros/westeros_renewable_resource.ipynb
+++ b/tutorial/westeros/westeros_renewable_resource.ipynb
@@ -76,10 +76,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "year_df = scen.vintage_and_active_years()\n",
+    "country = \"Westeros\"\n",
+    "year_df = scen.vintage_and_active_years((country, \"wind_ppl\"), in_horizon=False)\n",
     "vintage_years, act_years = year_df[\"year_vtg\"], year_df[\"year_act\"]\n",
-    "model_horizon = scen.set(\"year\")\n",
-    "country = \"Westeros\""
+    "model_horizon = scen.set(\"year\")"
    ]
   },
   {
@@ -517,7 +517,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "message_ix",
+   "display_name": "mix312",
    "language": "python",
    "name": "python3"
   },
@@ -532,11 +532,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.3"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "29605b568787f5559ca1ba05da75d155c3dcfa15a1a63b1885b057c5465ade2e"
-   }
   }
  },
  "nbformat": 4,

--- a/tutorial/westeros/westeros_share_constraint.ipynb
+++ b/tutorial/westeros/westeros_share_constraint.ipynb
@@ -81,9 +81,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "year_df = scen.vintage_and_active_years()\n",
-    "vintage_years, act_years = year_df[\"year_vtg\"], year_df[\"year_act\"]\n",
-    "model_horizon = scen.set(\"year\")\n",
     "country = \"Westeros\""
    ]
   },
@@ -472,7 +469,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mix312",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Closes #897 and #899:

- For some tutorials, remove `year_df` entirely because it is unused. For others, make its usage consistent with `westeros_baseline`. 
- Address a `FutureWarning` from pandas.


## How to review


- Read the diff and note that the CI checks all pass.


## PR checklist

- [ ] Continuous integration checks all ✅
- [ ] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just fixing tutorials.
- ~[ ] Update release notes.~ Just fixing tutorials.

