### PR TITLE
Fix workflow runs from forks

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -79,7 +79,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.depth }}
-        repository: ${{ github.event.workflow_run.repository }}
+        repository: ${{ github.event.workflow_run.repository.fullname }}
         ref: ${{ github.event.workflow_run.head_branch }}
 
     - name: Fetch tags (for setuptools-scm)
@@ -166,7 +166,7 @@ jobs:
       if: github.event_name == 'workflow_run'
       uses: actions/checkout@v4
       with:
-        repository: ${{ github.event.workflow_run.repository }}
+        repository: ${{ github.event.workflow_run.repository.fullname }}
         ref: ${{ github.event.workflow_run.head_branch }}
 
     - uses: actions/setup-python@v5

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,8 +1,6 @@
 name: Test
 
 on:
-  pull_request:
-    branches: [ main ]
   # 05:00 UTC = 06:00 CET = 07:00 CEST
   schedule:
   - cron: "0 5 * * *"


### PR DESCRIPTION
As discovered in https://github.com/iiasa/message_ix/pull/904#issuecomment-2577300711, it seems we need to bring to `main` a version of the "Pytest" workflow that doesn't run on all PRs to `main` and that uses the correct data for the checkout action when being dispatched from the "Receive PR" workflow. This PR cherry-picks the two commits from #904 that achieve this. 

## How to review

- ~Read the diff and note that the CI checks all pass.~
- Note that this PR should trigger the "Pytest" workflow only once, after successfully completing the "Receive PR" workflow.

## PR checklist


- ~Continuous integration checks all ✅~ These fail because of the underlying issue. Merging the changes will address the issue.
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update release notes.~ Just CI.

