### PR TITLE
Validate CI workflows

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -38,7 +38,6 @@ jobs:
 
   pytest:
     needs: [ check ]
-    name: run
 
     strategy:
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,19 @@ repos:
   - id: ruff
   - id: ruff-format
     args: [ --check ]
+
+# GitHub Actions workflows
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: check-yaml
+    name: Validate GitHub Actions workflow YAML
+    files: '.github/workflows/.*\.ya?ml'
+- repo: local
+  hooks:
+  - id: validate-github-actions
+    name: Validate GitHub Actions workflow schema
+    language: rust
+    entry: action-validator
+    additional_dependencies: [ cli:action-validator:0.6.0 ]
+    files: '.github/workflows/.*\.ya?ml'


### PR DESCRIPTION
#909 introduced invalid GitHub Actions syntax 🤦🏾‍♂️. This PR:

- Fixes the error.
- Adds pre-commit configuration to check that the workflow files (a) are valid YAML and (b) conform to GitHub's published schemas.

## How to review

Read the diff.

## PR checklist

- ~Continuous integration checks all ✅~ As with #909, the required checks from the "pytest" workflow will not run; this time because of the syntax error.
- ~Add or expand tests; coverage checks both ✅~
- ~Add, expand, or update documentation.~ N/A, CI changes only
- ~Update release notes.~