### PR TITLE
Clean up CI & miscellaneous updates for 3.10

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -24,8 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - if: >
-        github.repository != github.event.pull_request.head.repo.full_name &&
-        ! contains(github.event.pull_request.labels.*.name, env.label)
+        !(
+          github.event_name == "schedule"
+          || github.repository == github.event.pull_request.head.repo.full_name
+          || contains(github.event.pull_request.labels.*.name, env.label)
+        )
       run: |
         echo "Pytest workflow will not run for branch in fork without label \`${{ env.label }}\`." >>$GITHUB_STEP_SUMMARY
         exit 1

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -14,14 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Version used until 2024-11-20; disabled
-  # GAMS_VERSION: 29.1.0
-  # First version including a macOS arm64 distribution
-  GAMS_VERSION: 43.4.1
-
-  # See description in lint.yml
-  depth: 100
-
+  GAMS_VERSION: 43.4.1   # First version including a macOS arm64 distribution
+  depth: 100  # Must be large enough to include the most recent release
   label: "safe to test"
 
 jobs:
@@ -86,17 +80,17 @@ jobs:
     - name: Fetch tags (for setuptools-scm)
       run: git fetch --tags --depth=${{ env.depth }}
 
-    - uses: actions/setup-python@v5
+    - name: Set up uv, Python
+      uses: astral-sh/setup-uv@v5
       with:
+        cache-dependency-glob: "**/pyproject.toml"
         python-version: ${{ matrix.python-version }}
-        cache: pip
-        cache-dependency-path: "**/pyproject.toml"
 
     - uses: ts-graphviz/setup-graphviz@v2
-      # TEMPORARY Work around ts-graphviz/setup-graphviz#630
-      if: ${{ ! startswith(matrix.os, 'macos-') }}
+      # Work around ts-graphviz/setup-graphviz#630
+      if: matrix.os != 'macos-13'
 
-    - name: Cache GAMS installer and R packages
+    - name: Cache GAMS installer
       uses: actions/cache@v4
       with:
         path: |
@@ -110,17 +104,13 @@ jobs:
         version: ${{ env.GAMS_VERSION }}
         license: ${{ secrets.GAMS_LICENSE }}
 
-    - name: Install Python package and dependencies
+    - name: Install the package and dependencies
       # By default, the below installs ixmp from the main branch. To run against
       # other code, e.g. other branches for open PRs), temporarily edit as
       # appropriate. DO NOT merge such changes to `main`.
       run: |
-        pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
-        pip install .[tests]
-
-        # TEMPORARY With Python 3.13 pyam-iamc resolves to 1.3.1, which in turn
-        # limits pint < 0.17. Override.
-        pip install --upgrade pint
+        uv pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
+        uv pip install .[tests]
 
     - name: Run test suite using pytest
       env:
@@ -129,7 +119,7 @@ jobs:
       run: |
         pytest message_ix \
           -m "not nightly and not tutorial" \
-          -rA --verbose --color=yes --durations=20 \
+          --color=yes --durations=20 -rA --verbose \
           --cov-report=xml \
           --numprocesses=auto --dist=loadgroup
       shell: bash
@@ -140,9 +130,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   tutorials:
-    if: >
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
+    needs: [ check ]
 
     strategy:
       matrix:
@@ -158,32 +146,21 @@ jobs:
 
     steps:
     - name: Check out message_ix
-      if: github.event_name != 'workflow_run'
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.depth }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Check out message_ix (workflow_run)
-      if: github.event_name == 'workflow_run'
-      uses: actions/checkout@v4
+    - name: Set up uv, Python
+      uses: astral-sh/setup-uv@v5
       with:
-        repository: ${{ github.event.workflow_run.repository.fullname }}
-        ref: ${{ github.event.workflow_run.head_branch }}
-
-    - uses: actions/setup-python@v5
-      with:
+        cache-dependency-glob: "**/pyproject.toml"
         python-version: "3.13"
-        cache: pip
-        cache-dependency-path: "**/pyproject.toml"
 
     - name: Set RETICULATE_PYTHON
-      # Use the environment variable set by the setup-python action, above.
-      run: echo "RETICULATE_PYTHON=$pythonLocation" >> "$GITHUB_ENV"
+      # Retrieve the Python executable set up above
+      run: echo "RETICULATE_PYTHON=$(uv python find)" >> "$GITHUB_ENV"
       shell: bash
-
-    - uses: ts-graphviz/setup-graphviz@v2
-      # TEMPORARY Work around ts-graphviz/setup-graphviz#630
-      if: ${{ ! startswith(matrix.os, 'macos-') }}
 
     - uses: r-lib/actions/setup-r@v2
       id: setup-r
@@ -206,26 +183,17 @@ jobs:
         version: ${{ env.GAMS_VERSION }}
         license: ${{ secrets.GAMS_LICENSE }}
 
-    - name: Install Python package and dependencies
+    - name: Install the package and dependencies
       # By default, the below installs ixmp from the main branch. To run against
       # other code, e.g. other branches for open PRs), temporarily edit as
       # appropriate. DO NOT merge such changes to `main`.
       run: |
-        pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
-        pip install .[tests]
-
-        # TEMPORARY With Python 3.13 pyam-iamc resolves to 1.3.1, which in turn
-        # limits pint < 0.17. Override.
-        pip install --upgrade pint
+        uv pip install --upgrade "ixmp @ git+https://github.com/iiasa/ixmp.git@main"
+        uv pip install .[tests]
 
     - name: Install R dependencies and tutorial requirements
       run: |
-        install.packages("remotes")
-        remotes::install_cran(
-          c("dplyr", "IRkernel", "reticulate"),
-          dependencies = TRUE,
-          # force = TRUE,
-        )
+        install.packages(c("dplyr", "IRkernel", "reticulate"))
         IRkernel::installspec()
       shell: Rscript {0}
 
@@ -233,7 +201,7 @@ jobs:
       run: |
         pytest message_ix \
           -m "tutorial" \
-          -rA --verbose --color=yes --durations=20 \
+          --color=yes --durations=20 -rA --verbose \
           --cov-report=xml \
           --numprocesses=auto --dist=loadgroup
       shell: bash
@@ -250,13 +218,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:  # Same as the "Latest version supported by message_ix", above
-        python-version: "3.13"
-
-    - name: Force recreation of pre-commit virtual environment for mypy
-      if: github.event_name == 'schedule'  # Comment this line to run on a PR
-      run: gh cache list -L 999 | cut -f2 | grep pre-commit | xargs -I{} gh cache delete "{}" || true
-      env: { GH_TOKEN: "${{ github.token }}" }
-
-    - uses: pre-commit/action@v3.0.1
+    - uses: astral-sh/setup-uv@v5
+      with: { cache-dependency-glob: "**/pyproject.toml" }
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.UV_PYTHON }}|${{ hashFiles('.pre-commit-config.yaml') }}
+        lookup-only: ${{ github.event_name == 'schedule' }}  # Set 'true' to recreate cache
+    - run: uvx pre-commit run --all-files --color=always --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,10 @@
 repos:
-- repo: local
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.14.1
   hooks:
   - id: mypy
-    name: mypy
-    always_run: true
-    require_serial: true
     pass_filenames: false
-
-    language: python
-    entry: bash -c ". ${PRE_COMMIT_MYPY_VENV:-/dev/null}/bin/activate 2>/dev/null; mypy $0 $@"
     additional_dependencies:
-    - mypy >= 1.12.0
     - asyncssh
     - git+https://github.com/iiasa/ixmp.git@main
     - importlib_resources
@@ -20,9 +14,8 @@ repos:
     - Sphinx
     - types-PyYAML
     - types-requests
-    args: ["."]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.4
+  rev: v0.9.1
   hooks:
   - id: ruff
   - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Documentation build](https://readthedocs.com/projects/iiasa-energy-program-message-ix/badge/?version=stable)](https://docs.messageix.org/en/stable/)
 [![Build status](https://github.com/iiasa/message_ix/actions/workflows/pytest.yaml/badge.svg)](https://github.com/iiasa/message_ix/actions/workflows/pytest.yaml)
 [![Test coverage](https://codecov.io/gh/iiasa/message_ix/branch/main/graph/badge.svg)](https://codecov.io/gh/iiasa/message_ix)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md) 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 
 MESSAGEix is a versatile, dynamic, model framework for energy-engineering-economy-environment (E4) systems research.
@@ -55,7 +55,7 @@ Other forms of documentation:
 
 ## License
 
-Copyright © 2018–2024 IIASA Energy, Climate, and Environment (ECE) Program
+Copyright © 2018–2025 IIASA Energy, Climate, and Environment (ECE) Program
 
 The MESSAGEix framework is licensed under the Apache License, Version 2.0 (the "License"); you may not use the files in this repository except in compliance with the License. You may obtain a copy of the License in [`LICENSE`](LICENSE) or at <http://www.apache.org/licenses/LICENSE-2.0>.
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ The `message_ix` Python package—also fully usable from R—includes:
 - Application programming interfaces (APIs) and tools for model building and scientific programming,
 - Extensive documentation and a complete test suite.
 
-The framework is built on IIASA's [*ix* modeling platform (`ixmp`)](https://github.com/iiasa/ixmp), which provides data warehouse features for high-powered numerical scenario analysis.
+The framework is built on IIASA's [*ix* modeling platform (`ixmp`)](https://github.com/iiasa/ixmp), which provides data warehouse features for numerical scenario analysis.
 
 ## Documentation
 
-Complete documentation of the framework is avaiable at **https://docs.messageix.org/**.
+Complete documentation of the framework is available at **https://docs.messageix.org**.
 This includes:
 
 - **Installation** and recommended pre-requisite learning.
@@ -39,7 +39,7 @@ This includes:
 Other forms of documentation:
 
 - The online documentation is built automatically from the contents of the
-[`message_ix` GitHub repository](https://github.com/iiasa/messag_ix).
+[`message_ix` GitHub repository](https://github.com/iiasa/message_ix).
 - Documentation for the ‘latest’ or ‘stable’ release is shown by default.
 - Use the chooser to access the [‘latest’ version](https://docs.messageix.org/en/latest/), corresponding to the ``main`` branch and including the latest development code; or to access docs for a specific release, e.g. `v3.2.0`.
 - For offline use, the documentation can be built from the source code.
@@ -47,11 +47,19 @@ Other forms of documentation:
 
 ## Commitment to our Community
 
-- We aim to create a community that is welcoming to everyone. Please respect our [Code of Conduct](CODE_OF_CONDUCT.md) at all times when interacting with `message_ix` and the community.
+- We aim to create a community that is welcoming to everyone.
+  Please respect our [Code of Conduct](CODE_OF_CONDUCT.md) at all times when interacting with `message_ix` and the community.
 - We warmly welcome all contributions to our community. Please take a look at our [guidelines for contributing to development](https://docs.messageix.org/en/latest/contributing.html).
 - If you are looking to understand how the `message_ix` team operates and how we decide what to do with your contributions, please read our [governance guidelines](GOVERNANCE.md).
-- We highly value code security. To learn more about our security practice and advice, please visit our [security policy](.github/SECURITY.md).
-- We strive to entertain a welcoming and inclusive community. If you struggle to use `message_ix`, please check our [guidelines for getting support](SUPPORT.md).
+- We highly value code security.
+  To learn more about our security practice and advice, please visit our [security policy](.github/SECURITY.md).
+- We strive to entertain a welcoming and inclusive community.
+  If you struggle to use `message_ix`, please check our [guidelines for getting support](SUPPORT.md).
+- We also:
+  - Host an annual [MESSAGEix Community Meeting](https://iiasa.ac.at/search?search_api_fulltext=MESSAGEix+Community+Meeting).
+  - Publish, at least once per year, a community newsletter.
+    You are cordially invited to subscribe by filling [this form](https://iiasa.ac.at/signup) and ticking the box for “MESSAGEix Community”.
+
 
 ## License
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,7 +4,7 @@ Next release
 GitHub community guidelines
 ---------------------------
 
-Add community guidelines for interaction on GitHub (:pull:`871`).
+Add community guidelines for interaction on GitHub (:pull:`871`, :pull:`911`).
 Please familiarize yourself with these to foster an open and welcoming community!
 
 All changes

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,7 @@ from typing import Optional
 # -- Project information ---------------------------------------------------------------
 
 project = "MESSAGEix"
-copyright = "2018–2024, IIASA Energy, Climate, and Environment (ECE) Program"
+copyright = "2018–%Y, IIASA Energy, Climate, and Environment (ECE) Program"
 author = "MESSAGEix Developers"
 
 # The major project version, used as the replacement for |version|.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,7 +4,7 @@ The |MESSAGEix| framework
 |MESSAGEix| is a versatile, dynamic systems-optimization modelling framework developed by the |IIASA| Energy, Climate, and Environment (ECE) Program [#rename]_ since the 1980s.
 
 This is the documentation for :mod:`message_ix`, a Python package that ties together all components of the framework.
-:mod:`message_ix` and :mod:`ixmp` are free and open source, licensed under the `APACHE 2.0 open-source license`_.
+:mod:`message_ix` and :mod:`ixmp` are free and open source software, licensed under the `APACHE 2.0 license`_.
 
 - For the scientific reference of the framework, see Huppmann et al. (2019) :cite:`Huppmann-2018`.
 - For an overview and recent publications related to the specific |MESSAGEix|-GLOBIOM global model instance used at the IIASA ECE Program, see the `MESSAGEix-GLOBIOM documentation`_.
@@ -41,7 +41,7 @@ Then, continue with the:
    framework
    install
    tutorials
-   Publications, Projects, and Tools <usage>
+   Publications, projects, and tools <usage>
 
 .. figure:: _static/ix_features.svg
    :width: 360px
@@ -55,8 +55,7 @@ Then, continue with the:
 Mathematical specification
 ==========================
 
-These pages provide comprehensive description of the variables and equations in
-the core MESSAGEix mathematical implementation.
+These pages provide comprehensive description of the variables and equations in the core MESSAGEix mathematical implementation.
 
 - :doc:`model/MESSAGE/sets_maps_def`
 - :doc:`time`
@@ -69,7 +68,7 @@ the core MESSAGEix mathematical implementation.
 
 .. toctree::
    :hidden:
-   :caption: Mathematical Specification
+   :caption: Mathematical specification
 
    model/MESSAGE/sets_maps_def
    time
@@ -86,7 +85,8 @@ the core MESSAGEix mathematical implementation.
 Developing |MESSAGEix| models
 =============================
 
-Developing a valid, scientific |MESSAGEix| model requires careful use of the framework features.
+Everyone is encouraged to use |MESSAGEix| to develop energy system and integrated assessment models!
+Developing a valid, scientific model requires careful use of the framework features.
 This section provides guidelines for how to make some common model design choices.
 
 - :doc:`efficiency`
@@ -94,6 +94,8 @@ This section provides guidelines for how to make some common model design choice
 - :doc:`reporting`
 - :doc:`debugging`
 - :doc:`macro`
+- :doc:`notice` describes how to cite the framework and software in published research.
+- :doc:`sharing` explains how to add your |MESSAGEix| applications to the :doc:`Usage <usage>` page in these docs.
 
 .. toctree::
    :hidden:
@@ -105,60 +107,58 @@ This section provides guidelines for how to make some common model design choice
    reporting
    debugging
    macro
+   notice
+   sharing
 
-
-Using, getting help, and contributing
-=====================================
-
-Everyone is encouraged to use the framework to develop energy system and integrated assessment models!
-
-Everyone is required to please follow our Code of Conduct, which you can find `on GitHub <https://github.com/iiasa/message_ix/blob/main/CODE_OF_CONDUCT.md>`__ or in :file:`CODE_OF_CONDUCT.md` included with the source code.
+Reference and development
+=========================
 
 - :doc:`api`
 - :doc:`rmessageix`
 - :doc:`whatsnew` —release history and migration/upgrade notes.
-- :doc:`notice` —including how to properly cite the framework and software in scientific research.
-
 - :doc:`contributing` —we welcome enhancements to the framework itself that enable new features across all models.
-- You can learn more about how we handle your contributions `on GitHub <https://github.com/iiasa/message_ix/blob/main/GOVERNANCE.md>`__ or in :file:`GOVERNANCE.md` included with the source code.
-- :doc:`sharing`—we invite the sharing of the usage of the |MESSAGEix| framework.
-- See our Security Policy `on GitHub <https://github.com/iiasa/message_ix/blob/main/.github/SECURITY.md>`__ or in :file:`.github/SECURITY.md` included with the source code.
-- :doc:`faq`
+  You can learn more about how we handle these contributions in :file:`GOVERNANCE.md` (`on GitHub <https://github.com/iiasa/message_ix/blob/main/GOVERNANCE.md>`__ or included with the source code)  [#osguides]_
 - :doc:`bibliography`
 
 .. toctree::
    :hidden:
-   :caption: Help & reference
+   :caption: Reference & development
 
    api
    rmessageix
    whatsnew
-   notice
    contributing
-   governance
-   sharing
-   security policy
-   faq
    bibliography
 
 .. _help:
 
+Community and support
+=====================
 
-For further information and to get involved with the MESSAGEix user/developer community:
+We aim to maintain a healthy community for developers and users of MESSAGEix; thus we expect everyone to follow our **Code of Conduct**, which you can find in :file:`CODE_OF_CONDUCT.md` (`on GitHub <https://github.com/iiasa/message_ix?tab=coc-ov-file>`__  or included with the source code). [#osguides]_
 
-- Check on GitHub:
-
-  - Join an existing `discussion <https://github.com/iiasa/message_ix/discussions>`_ or start a new one with your MESSAGEix usage question.
-  - Search `current issues <https://github.com/iiasa/message_ix/issues?q=is:issue>`_, or open a new one to report a bug in the code.
-
-- See the less frequently updated :doc:`faq` and message_ix Google Group, either `online <https://groups.google.com/d/forum/message_ix>`_ or via e-mail at <message_ix@googlegroups.com>.
+You can also:
 
 .. _newsletter:
 
-- We cordially invite you to subscribe to the **MESSAGEix Community Newsletter** by filling `this form <https://iiasa.ac.at/signup>`__ and ticking the box for "MESSAGEix-Community".
-  At least once a year, we update all subscribers on the latest research and ongoing projects regarding MESSAGEix and invite you to our annual `Community Meeting <https://iiasa.ac.at/search?search_api_fulltext=MESSAGEix+Community+Meeting`__.
+- Read or join existing `discussions <https://github.com/iiasa/message_ix/discussions>`_ on GitHub, or start a new one with your MESSAGEix usage question.
+- Search `current issues <https://github.com/iiasa/message_ix/issues?q=is:issue>`_, or open a new one to report a bug in the code.
+- Subscribe to the **MESSAGEix Community Newsletter** by filling `this form <https://iiasa.ac.at/signup>`__ and ticking the box for "MESSAGEix-Community".
+  At least once a year, we update all subscribers on the latest research and ongoing projects regarding MESSAGEix and invite you to our annual `Community Meeting <https://iiasa.ac.at/search?search_api_fulltext=MESSAGEix+Community+Meeting>`__.
+- See our security policy in :file:`SECURITY.md` (`on GitHub <https://github.com/iiasa/message_ix?tab=security-ov-file>`_ or included with the source code). [#osguides]_
+- Read answers to some not-so-:doc:`‘frequently’ asked questions <faq>`.
+- Check the older message_ix Google Group, either `online <https://groups.google.com/d/forum/message_ix>`_ or via e-mail at <message_ix@googlegroups.com>.
+
+.. toctree::
+   :hidden:
+   :caption: Community & support
+
+   Code of conduct <https://github.com/iiasa/message_ix?tab=coc-ov-file#readme>
+   Discussions <https://github.com/iiasa/message_ix/discussions>
+   faq
 
 .. _`MESSAGEix-GLOBIOM documentation`: http://data.ene.iiasa.ac.at/message-globiom/
 .. _`APACHE 2.0 open-source license`: https://github.com/iiasa/message_ix/blob/main/LICENSE
 
 .. [#rename] Known as the “Energy Program” until 2020-12-31.
+.. [#osguides] `Our usage <https://github.com/iiasa/message_ix/community>`_ of files like CODE_OF_CONDUCT, GOVERNANCE, SECURITY, and SUPPORT follows the `Open Source Guides <https://opensource.guide/>`_ recommendations.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -143,15 +143,20 @@ Everyone is required to please follow our Code of Conduct, which you can find `o
 
 .. _help:
 
-Have a question? Check…
 
-- …on GitHub:
+For further information and to get involved with the MESSAGEix user/developer community:
 
-  - Join an existing `discussion <https://github.com/iiasa/message_ix/discussions>`_ or start a new one with your question.
+- Check on GitHub:
+
+  - Join an existing `discussion <https://github.com/iiasa/message_ix/discussions>`_ or start a new one with your MESSAGEix usage question.
   - Search `current issues <https://github.com/iiasa/message_ix/issues?q=is:issue>`_, or open a new one to report a bug in the code.
 
-- …the :doc:`faq`.
-- …the message_ix Google Group, either `online <https://groups.google.com/d/forum/message_ix>`_ or via e-mail at <message_ix@googlegroups.com>.
+- See the less frequently updated :doc:`faq` and message_ix Google Group, either `online <https://groups.google.com/d/forum/message_ix>`_ or via e-mail at <message_ix@googlegroups.com>.
+
+.. _newsletter:
+
+- We cordially invite you to subscribe to the **MESSAGEix Community Newsletter** by filling `this form <https://iiasa.ac.at/signup>`__ and ticking the box for "MESSAGEix-Community".
+  At least once a year, we update all subscribers on the latest research and ongoing projects regarding MESSAGEix and invite you to our annual `Community Meeting <https://iiasa.ac.at/search?search_api_fulltext=MESSAGEix+Community+Meeting`__.
 
 .. _`MESSAGEix-GLOBIOM documentation`: http://data.ene.iiasa.ac.at/message-globiom/
 .. _`APACHE 2.0 open-source license`: https://github.com/iiasa/message_ix/blob/main/LICENSE

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -2,7 +2,7 @@ $TITLE The MESSAGEix-MACRO Integrated Assessment Model
 $ONDOLLAR
 $ONTEXT
 
-   Copyright 2017–2021 IIASA Energy, Climate, and Environment (ECE) Program
+   Copyright 2017–2022 IIASA Energy, Climate, and Environment (ECE) Program
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -1,41 +1,6 @@
 $TITLE The MESSAGEix-MACRO Integrated Assessment Model
 $ONDOLLAR
-$ONTEXT
-
-   Copyright 2017–2022 IIASA Energy, Climate, and Environment (ECE) Program
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-This is the GAMS implementation of the integrated assessment and system optimization model MESSAGEix
-For the most recent version of the framework, please visit `github.com/iiasa/message_ix`.
-For a comprehensive documentation of the latest release of the MESSAGEix framework
-and the ix modeling platform, please visit `MESSAGEix.iiasa.ac.at/`.
-
-When using the MESSAGEix framework, please cite as:
-
-   Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
-   Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
-   Keywan Riahi, and Volker Krey.
-   "The |MESSAGEix| Integrated Assessment Model and the ix modeling platform".
-   Environmental Modelling & Software 112:143-156, 2019.
-   doi: 10.1016/j.envsoft.2018.11.012
-   electronic pre-print available at pure.iiasa.ac.at/15157/
-
-Please review the NOTICE at `MESSAGEix.iiasa.ac.at/notice.html`
-and included in the GitHub repository for further user guidelines.
-The community forum and mailing list is hosted at `groups.google.com/d/forum/message_ix`.
-
-$OFFTEXT
+$INCLUDE includes/copyright.gms
 
 ***
 * Run script for |MESSAGEix| and MACRO

--- a/message_ix/model/MESSAGE_master.gms
+++ b/message_ix/model/MESSAGE_master.gms
@@ -1,41 +1,6 @@
 $TITLE The MESSAGEix Integrated Assessment Model
 $ONDOLLAR
-$ONTEXT
-
-   Copyright 2018 IIASA Energy Program
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-This is the GAMS implementation of the integrated assessment and system optimization model MESSAGEix
-For the most recent version of the framework, please visit `github.com/iiasa/message_ix`.
-For a comprehensive documentation of the latest release of the MESSAGEix framework
-and the ix modeling platform, please visit `MESSAGEix.iiasa.ac.at/`.
-
-When using the MESSAGEix framework, please cite as:
-
-   Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
-   Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
-   Keywan Riahi, and Volker Krey.
-   "The |MESSAGEix| Integrated Assessment Model and the ix modeling platform".
-   Environmental Modelling & Software 112:143-156, 2019.
-   doi: 10.1016/j.envsoft.2018.11.012
-   electronic pre-print available at pure.iiasa.ac.at/15157/
-
-Please review the NOTICE at `MESSAGEix.iiasa.ac.at/notice.html`
-and included in the GitHub repository for further user guidelines.
-The community forum and mailing list is hosted at `groups.google.com/d/forum/message_ix`.
-
-$OFFTEXT
+$INCLUDE includes/copyright.gms
 
 * activate dollar commands on a global level
 $ONGLOBAL

--- a/message_ix/model/MESSAGE_run.gms
+++ b/message_ix/model/MESSAGE_run.gms
@@ -1,41 +1,6 @@
 $TITLE The MESSAGEix Integrated Assessment Model
 $ONDOLLAR
-$ONTEXT
-
-   Copyright 2017–2021 IIASA Energy, Climate, and Environment (ECE) Program
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-This is the GAMS implementation of the integrated assessment and system optimization model MESSAGEix
-For the most recent version of the framework, please visit `github.com/iiasa/message_ix`.
-For a comprehensive documentation of the latest release of the MESSAGEix framework
-and the ix modeling platform, please visit `MESSAGEix.iiasa.ac.at/`.
-
-When using the MESSAGEix framework, please cite as:
-
-   Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer,
-   Michael Pimmer, Nikolay Kushin, Adriano Vinca, Alessio Mastrucci,
-   Keywan Riahi, and Volker Krey.
-   "The |MESSAGEix| Integrated Assessment Model and the ix modeling platform".
-   Environmental Modelling & Software 112:143-156, 2019.
-   doi: 10.1016/j.envsoft.2018.11.012
-   electronic pre-print available at pure.iiasa.ac.at/15157/
-
-Please review the NOTICE at `MESSAGEix.iiasa.ac.at/notice.html`
-and included in the GitHub repository for further user guidelines.
-The community forum and mailing list is hosted at `groups.google.com/d/forum/message_ix`.
-
-$OFFTEXT
+$INCLUDE includes/copyright.gms
 
 ***
 * Run script for |MESSAGEix| (stand-alone)

--- a/message_ix/model/includes/copyright.gms
+++ b/message_ix/model/includes/copyright.gms
@@ -1,0 +1,29 @@
+$HIDDEN Text is displayed in the listing when this file is included.
+$ONTEXT
+
+Copyright 2018–2025 IIASA Energy Program
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+
+This is the GAMS implementation of the integrated assessment and system optimization model MESSAGE. For the most recent
+version of the code, please visit `https://github.com/iiasa/message_ix`. For comprehensive documentation of the overall
+MESSAGEix framework and ix modeling platform, as well as links to support resources, see `https://docs.messageix.org`.
+
+When using the MESSAGEix framework, please review `https://docs.messageix.org/en/latest/notice.html` or the file NOTICE
+included with the source code. These include a request to cite:
+
+   Daniel Huppmann, Matthew Gidden, Oliver Fricko, Peter Kolp, Clara Orthofer, Michael Pimmer, Nikolay Kushin, Adriano
+   Vinca, Alessio Mastrucci, Keywan Riahi, and Volker Krey.
+   "The |MESSAGEix| Integrated Assessment Model and the ix modeling platform".
+   Environmental Modelling & Software 112:143-156, 2019.
+   doi: 10.1016/j.envsoft.2018.11.012
+   electronic pre-print available at pure.iiasa.ac.at/15157/
+
+$OFFTEXT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,9 @@ omit = [
 ]
 
 [tool.mypy]
-exclude = [
-  "build/",
-  "doc/",
+files = [
+  "doc",
+  "message_ix",
 ]
 # TODO Remove this once it has become default with mypy 2.0:
 local_partial_types = true


### PR DESCRIPTION
Parallel to iiasa/ixmp#555, plus:

- Adjust 'tutorial' jobs in 'pytest' CLI workflow to align with #909, #910.
- Bump copyright year.
- …items below.

## How to review

- View the [revised docs](https://iiasa-energy-program-message-ix--911.com.readthedocs.build/en/911/), in particular:
  - Mention of the newsletter on the index page.
  - Organization of the index page and navigation pane.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
  - [x] Mention newsletter sign-up.
  - [x] Correct outdated links embedded in GAMS code.
- [x] Update release notes.