### PR TITLE
Fix quoting in "pytest" GitHub Actions workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -78,7 +78,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.depth }}
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event_name != 'pull_request_target' && github.ref || github.event.pull_request.head.sha }}
 
     - name: Fetch tags (for setuptools-scm)
       run: git fetch --tags --depth=${{ env.depth }}
@@ -152,7 +152,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.depth }}
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ github.event_name != 'pull_request_target' && github.ref || github.event.pull_request.head.sha }}
 
     - name: Set up uv, Python
       uses: astral-sh/setup-uv@v5
@@ -221,6 +221,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name != 'pull_request_target' && github.ref || github.event.pull_request.head.sha }}
     - uses: astral-sh/setup-uv@v5
       with: { cache-dependency-glob: "**/pyproject.toml" }
     - uses: actions/cache@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,6 +1,9 @@
 name: Tests
 
 on:
+  # Uncomment this entry only to debug the workflow
+  # pull_request:
+  #   branches: [ main ]
   pull_request_target:
     branches: [ main ]
     types: [ labeled, opened, reopened, synchronize ]

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - if: >
         !(
-          github.event_name == "schedule"
+          github.event_name == 'schedule'
           || github.repository == github.event.pull_request.head.repo.full_name
           || contains(github.event.pull_request.labels.*.name, env.label)
         )

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -700,14 +700,12 @@ equ("ACTIVITY_RATING_TOTAL", "", "Equivalence of `ACT_RATING` to `ACT`")
 equ(
     "ACTIVITY_SOFT_CONSTRAINT_LO",
     "",
-    "Bound on relaxation of the dynamic constraint on market penetration"
-    " (lower bound)",
+    "Bound on relaxation of the dynamic constraint on market penetration (lower bound)",
 )
 equ(
     "ACTIVITY_SOFT_CONSTRAINT_UP",
     "",
-    "Bound on relaxation of the dynamic constraint on market penetration"
-    " (upper bound)",
+    "Bound on relaxation of the dynamic constraint on market penetration (upper bound)",
 )
 equ("ADDON_ACTIVITY_LO", "", "Addon technology activity lower constraint")
 equ("ADDON_ACTIVITY_UP", "", "Addon-technology activity upper constraint")
@@ -738,8 +736,7 @@ equ("COMMODITY_BALANCE_LT", "", "Commodity supply lower than or equal demand")
 equ(
     "COMMODITY_USE_LEVEL",
     "",
-    "Aggregate use of commodity by level as defined by total input into "
-    "technologies",
+    "Aggregate use of commodity by level as defined by total input into technologies",
 )
 equ("COST_ACCOUNTING_NODAL", "n y", "Cost accounting aggregated to the node")
 equ(
@@ -791,7 +788,7 @@ equ(
 equ(
     "MIN_UTILIZATION_CONSTRAINT",
     "",
-    "Constraint for minimum yearly operation (aggregated over the course of a " "year)",
+    "Constraint for minimum yearly operation (aggregated over the course of a year)",
 )
 equ("NEW_CAPACITY_BOUND_LO", "", "Lower bound on technology capacity investment")
 equ("NEW_CAPACITY_BOUND_UP", "", "Upper bound on technology capacity investment")
@@ -803,8 +800,7 @@ equ(
 equ(
     "NEW_CAPACITY_CONSTRAINT_UP",
     "",
-    "Dynamic constraint for capacity investment (learning and spillovers upper "
-    "bound)",
+    "Dynamic constraint for capacity investment (learning and spillovers upper bound)",
 )
 equ(
     "NEW_CAPACITY_SOFT_CONSTRAINT_LO",
@@ -839,8 +835,7 @@ equ("RENEWABLES_POTENTIAL_CONSTRAINT", "", "Constraint on renewable resource pot
 equ(
     "RESOURCE_CONSTRAINT",
     "",
-    "Constraint on resources remaining in each period (maximum extraction per "
-    "period)",
+    "Constraint on resources remaining in each period (maximum extraction per period)",
 )
 equ(
     "RESOURCE_HORIZON",

--- a/message_ix/tests/test_core.py
+++ b/message_ix/tests/test_core.py
@@ -502,7 +502,7 @@ def test_new_timeseries_long_name64(message_test_mp):
                 "India",
             ],
             "variable": [
-                ("Emissions|CO2|Energy|Demand|Transportation|Aviation|" "Domestic|Fre"),
+                ("Emissions|CO2|Energy|Demand|Transportation|Aviation|Domestic|Fre"),
             ],
             "unit": [
                 "Mt CO2/yr",

--- a/message_ix/tests/test_models.py
+++ b/message_ix/tests/test_models.py
@@ -36,7 +36,7 @@ def test_message_macro():
 
     # Constructor complains about an insufficient GAMS version
     with pytest.raises(
-        RuntimeError, match="MESSAGE-MACRO requires GAMS >= " "99.9.9; found "
+        RuntimeError, match="MESSAGE-MACRO requires GAMS >= 99.9.9; found "
     ):
         _MM()
 

--- a/message_ix/tools/lp_diag/__init__.py
+++ b/message_ix/tools/lp_diag/__init__.py
@@ -138,9 +138,9 @@ class LPdiag:
             # end of MPS reading
 
         # check, if the last required section ('ENDATA') was defined
-        assert (
-            n_section == 7
-        ), f'The "ENDATA" section is not declared; last section_id = {n_section}.'
+        assert n_section == 7, (
+            f'The "ENDATA" section is not declared; last section_id = {n_section}.'
+        )
 
         self.mps_sum()  # summarize the processed MPS content
 
@@ -156,8 +156,7 @@ class LPdiag:
             if words[0] == sections[n_exp]:  # required section found
                 if n_exp == 0:  # store the problem name
                     assert n_words > 1, (
-                        f"problem name undefined: line {n_line} has"
-                        f" {n_words} words."
+                        f"problem name undefined: line {n_line} has {n_words} words."
                     )
                     # print(f"\tProblem name line {words[1:]}.")
                     if n_words == 2:
@@ -246,16 +245,16 @@ class LPdiag:
 
         row_types = ["N", "E", "G", "L"]  # types of rows
         n_words = len(words)
-        assert (
-            n_words == 2
-        ), f"row declaration (line {n_line}) has {n_words} words instead of 2."
+        assert n_words == 2, (
+            f"row declaration (line {n_line}) has {n_words} words instead of 2."
+        )
         row_type = words[0]
         row_name = words[1]
         row_seq = len(self.row_name)
         assert row_type in row_types, f"unknown row type {row_type} (line {n_line})."
-        assert (
-            row_name not in self.row_name
-        ), f"duplicated row name: {row_name} (line {n_line})."
+        assert row_name not in self.row_name, (
+            f"duplicated row name: {row_name} (line {n_line})."
+        )
         if row_type == "N" and self.gf_seq == -1:
             self.gf_seq = row_seq
             print(
@@ -292,9 +291,9 @@ class LPdiag:
         ], f"matrix element (line {n_line}) has {n_words} words."
         col_name = words[0]
         if col_name != self.col_curr:  # new column
-            assert (
-                col_name not in self.col_name
-            ), f"duplicated column name: {col_name} (line {n_line})"
+            assert col_name not in self.col_name, (
+                f"duplicated column name: {col_name} (line {n_line})"
+            )
             col_seq = len(self.col_name)
             self.col_name.update({col_name: col_seq})
             self.seq_col.update({col_seq: [col_name, 0.0, self.infty]})
@@ -384,12 +383,11 @@ class LPdiag:
             pos_name = 0  # first row-name in words[pos_name]
 
         assert n_words in n_req_wrd, (
-            f"rhs line {n_line} has {n_words} words, expected" f" {n_req_wrd}."
+            f"rhs line {n_line} has {n_words} words, expected {n_req_wrd}."
         )
         if self.id_rhs:  # check id of the RHS entry, if it was defined
             assert words[0] == self.rhs_id, (
-                f"RHS id {words[0]}, line {n_line} differ from"
-                f"expected: {self.rhs_id}."
+                f"RHS id {words[0]}, line {n_line} differ from expected: {self.rhs_id}."
             )
         row_name = words[pos_name]
         row_seq = self.row_name.get(row_name)
@@ -407,9 +405,9 @@ class LPdiag:
         if n_words == n_req_wrd[1]:  # second pair of rhs defined
             row_name = words[pos_name + 2]
             row_seq = self.row_name.get(row_name)
-            assert (
-                row_seq is not None
-            ), f"unknown RHS row-name {row_name} (line {n_line})."
+            assert row_seq is not None, (
+                f"unknown RHS row-name {row_name} (line {n_line})."
+            )
             try:
                 val = float(words[pos_name + 3])
             except ValueError as e:
@@ -455,9 +453,9 @@ class LPdiag:
             n_req_wrd = [2, 4]
             pos_name = 0  # first row-name in words[pos_name]
 
-        assert (
-            n_words in n_req_wrd
-        ), f"ranges line {n_line} has {n_words} words, expected {n_req_wrd}."
+        assert n_words in n_req_wrd, (
+            f"ranges line {n_line} has {n_words} words, expected {n_req_wrd}."
+        )
         if self.id_range:  # check id of the ranges' entry, if it was defined
             assert words[0] == self.range_id, (
                 f"Ranges id {words[0]}, line {n_line} differ from"
@@ -465,9 +463,9 @@ class LPdiag:
             )
         row_name = words[pos_name]
         row_seq = self.row_name.get(row_name)
-        assert (
-            row_seq is not None
-        ), f"unknown range row-name {row_name} (line {n_line})."
+        assert row_seq is not None, (
+            f"unknown range row-name {row_name} (line {n_line})."
+        )
         try:
             val = float(words[pos_name + 1])
         except ValueError as e:
@@ -481,9 +479,9 @@ class LPdiag:
         if n_words == n_req_wrd[1]:  # second pair of ranges defined
             row_name = words[pos_name + 2]
             row_seq = self.row_name.get(row_name)
-            assert (
-                row_seq is not None
-            ), f"unknown ranges row-name {row_name} (line {n_line})."
+            assert row_seq is not None, (
+                f"unknown ranges row-name {row_name} (line {n_line})."
+            )
             try:
                 val = float(words[pos_name + 3])
             except ValueError as e:
@@ -543,9 +541,9 @@ class LPdiag:
             n_req_wrd = [3, 2]
             pos_name = 1  # col-name in words[pos_name]
 
-        assert (
-            n_words in n_req_wrd
-        ), f"bounds line {n_line} has {n_words} words, expected: {n_req_wrd}."
+        assert n_words in n_req_wrd, (
+            f"bounds line {n_line} has {n_words} words, expected: {n_req_wrd}."
+        )
         if self.id_bnd:  # check id of the BOUNDS line, if it was defined
             assert words[1] == self.bnd_id, (
                 f"BOUNDS id {words[1]}, line {n_line} differ from "
@@ -553,9 +551,9 @@ class LPdiag:
             )
         col_name = words[pos_name]
         col_seq = self.col_name.get(col_name)
-        assert (
-            col_seq is not None
-        ), f"unknown BOUNDS col-name {col_name} (line {n_line})."
+        assert col_seq is not None, (
+            f"unknown BOUNDS col-name {col_name} (line {n_line})."
+        )
         attr = self.seq_col.get(col_seq)  # [col_name, lo_bnd, up_bnd]
 
         typ = words[0]
@@ -581,8 +579,7 @@ class LPdiag:
                 attr[at_pos] = self.infty
         elif typ in bnd_type3:
             raise TypeError(
-                f"Bound type {typ} of integer var. (line {n_line}) not"
-                " processed yet."
+                f"Bound type {typ} of integer var. (line {n_line}) not processed yet."
             )
         else:
             raise TypeError(f"Unknown bound type {typ} (line {n_line}).")
@@ -631,9 +628,9 @@ class LPdiag:
             "L": [self.infty, 0.0],
             "N": [self.infty, self.infty],
         }
-        assert row_seq == self.row_name.get(
-            row_name
-        ), f"{row_seq=} should be equal to: {self.row_name.get(row_name)}."
+        assert row_seq == self.row_name.get(row_name), (
+            f"{row_seq=} should be equal to: {self.row_name.get(row_name)}."
+        )
         assert row_type in type2bnd, f"undefined row type {row_type=} for {row_name=}."
         if sec_name == "rows":  # initialize row attributes (used in ROW section)
             low_upp = type2bnd[row_type]
@@ -692,10 +689,10 @@ class LPdiag:
 
         # print(f'\nDistribution of non-zero values:\n{self.mat["val"].describe()}')
         print(
-            f'\nDistribution of abs(non-zero) values:\n{self.mat["abs_val"].describe()}'
+            f"\nDistribution of abs(non-zero) values:\n{self.mat['abs_val'].describe()}"
         )
         print(
-            f'\nDistribution of int(log10(abs(values))):\n{self.mat["log"].describe()}'
+            f"\nDistribution of int(log10(abs(values))):\n{self.mat['log'].describe()}"
         )
         min_logv = self.mat["log"].min()
         max_logv = self.mat["log"].max()
@@ -730,7 +727,7 @@ class LPdiag:
                 "\nDistribution of log10(values) in the requested low-tail (<="
                 f" {lo_tail}) of the distribution."
             )
-            print(f'{self.mat.loc[self.mat["log"] <= lo_tail].describe()}')
+            print(f"{self.mat.loc[self.mat['log'] <= lo_tail].describe()}")
             for val in [*range(min_logv, lo_tail + 1)]:
                 print(
                     f"Number of log10(values) == {val}:"
@@ -747,7 +744,7 @@ class LPdiag:
                 "\nDistribution of log10(values) in the requested upp-tail (>="
                 f" {up_tail}) of the distribution."
             )
-            print(f'{self.mat.loc[self.mat["log"] >= up_tail].describe()}')
+            print(f"{self.mat.loc[self.mat['log'] >= up_tail].describe()}")
             for val in [*range(up_tail, max_logv + 1)]:
                 print(
                     f"Number of log10(values) == {val}:"
@@ -775,13 +772,13 @@ class LPdiag:
         if small:  # sub-matrix composed of only small-value outliers
             df = self.mat.loc[self.mat["log"] <= thresh]
             print(
-                f'\nRow-wise locations of {df["log"].count()} outliers (coeff. with'
+                f"\nRow-wise locations of {df['log'].count()} outliers (coeff. with"
                 f" values of log10(values) <= {thresh})."
             )
         else:  # large-value outliers
             df = self.mat.loc[self.mat["log"] >= thresh]
             print(
-                f'\nRow-wise locations of {df["log"].count()} outliers (coeff. with'
+                f"\nRow-wise locations of {df['log'].count()} outliers (coeff. with"
                 f" values of log10(values) >= {thresh})."
             )
         df1 = df.sort_values(
@@ -790,9 +787,9 @@ class LPdiag:
         df1.reset_index()
         col_out = []  # col_seq of outliers' cols
         for n_rows, (_, row) in enumerate(df1.iterrows()):
-            assert (
-                n_rows < max_rec
-            ), "To process all requested coeffs modify the safety limit assertion."
+            assert n_rows < max_rec, (
+                "To process all requested coeffs modify the safety limit assertion."
+            )
             row_seq, row_name = self.get_entity_info(
                 row, True
             )  # row seq_id and name of the current coeff.
@@ -804,8 +801,8 @@ class LPdiag:
             else:
                 print(f"{col_seq = } already in another outlier row.")
             print(
-                f'Coeff. ({row_seq}, {col_seq}): val = {row["val"]:.4e}, log(val) ='
-                f' {row["log"]:n}'
+                f"Coeff. ({row_seq}, {col_seq}): val = {row['val']:.4e}, log(val) ="
+                f" {row['log']:n}"
             )
             df_row_out = df1.loc[df1["row"] == row_seq]  # df with only outlier elements
             df_row_all = self.mat.loc[

--- a/message_ix/util/sphinx_gams.py
+++ b/message_ix/util/sphinx_gams.py
@@ -35,7 +35,7 @@ def transcribe_docs(infp, outfp, source_filename):
     on = None
 
     note = (
-        ".. note:: This page is generated from inline documentation in " "``{}``.\n\n"
+        ".. note:: This page is generated from inline documentation in ``{}``.\n\n"
     ).format(source_filename)
 
     for line in infp:

--- a/tutorial/westeros/westeros_historical_new_capacity.ipynb
+++ b/tutorial/westeros/westeros_historical_new_capacity.ipynb
@@ -344,7 +344,7 @@
     ")\n",
     "print(\n",
     "    \"The `'historical_new_capacity'` for `coal_ppl` is set to \"\n",
-    "    f\"{round(historical_new_capacity, 2)} {df[\"unit\"].values}.\"\n",
+    "    f\"{round(historical_new_capacity, 2)} {df['unit'].values}.\"\n",
     ")\n",
     "scenario.add_par(\"historical_new_capacity\", df)"
    ]


### PR DESCRIPTION
#911 used double-quotes erroneously. This was not picked up by the actions-validator pre-commit hook, unfortunately. This causes errors like [this](https://github.com/iiasa/message_ix/actions/runs/12916949865).

Also:
- Check out the correct commit even on events other than pull_request_target.
- Apply ruff format to additional files.

## How to review

Read the diff.

## PR checklist

- ~Continuous integration checks all ✅~ Checks will not run because of the error.
- ~Add or expand tests; coverage checks both ✅~ ditto
- ~Add, expand, or update documentation.~ N/A; CI and formatting changes only
- ~Update release notes.~ ditto
