### PR TITLE
Adjust links to MESSAGEix-GLOBIOM docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -182,7 +182,6 @@ intersphinx_mapping = {
         "https://docs.messageix.org/projects/models/en/latest/",
         None,
     ),
-    "message_doc": ("https://docs.messageix.org/projects/global/en/latest/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pint": ("https://pint.readthedocs.io/en/stable/", None),
     "plotly": ("https://plotly.com/python-api-reference", None),

--- a/doc/macro.rst
+++ b/doc/macro.rst
@@ -3,7 +3,7 @@ Calibrate and tune MESSAGE-MACRO
 
 “MESSAGE-MACRO” refers to an iterative algorithm that links MESSAGE and MACRO :cite:`Messner-Schrattenholzer-2000`.
 This algorithm allows to model demand elasticity: MESSAGE solution data on energy prices and total system costs are provided to MACRO, and MACRO solution data on (endogenous) demand and GDP are provided to MESSAGE.
-This process continues until a convergence criterion or “equilibrium” is reached—briefly, that the MACRO demand output varies minimally between two iterations (:cite:`Johnson-2016`, further details can be found :ref:`here <message_doc:macro>`).
+This process continues until a convergence criterion or “equilibrium” is reached—briefly, that the MACRO demand output varies minimally between two iterations (:cite:`Johnson-2016`, further details can be found :doc:`here <message-ix-models:global/macro>`).
 
 The linked models can be activated by calling :meth:`.Scenario.solve` with the argument `model='MESSAGE-MACRO'`, or using the GAMS :file:`MESSAGE-MACRO_run.gms` script directly (see :ref:`running` for details about these two methods).
 


### PR DESCRIPTION
- Remove intersphinx config for unmaintained iiasa/message_doc.
- Link to location within iiasa/message-ix-models docs.

## How to review

- View the diff.
- View the MACRO page in the RTD preview build.
- Ensure the edited intersphinx link goes to the right place.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- ~Update release notes.~