### PR TITLE
Fix "install from conda forge" CI after ixmp release v3.10.0

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -10,6 +10,10 @@ on:
   # pull_request:
   #   branches: [ main ]
 
+env:
+  # First version including a macOS arm64 distribution
+  GAMS_VERSION: 43.4.1
+
 jobs:
   conda:
     strategy:
@@ -55,6 +59,20 @@ jobs:
             f.write(f"init={init}\n")
             f.write(f"profile={profile}\n")
       shell: python
+
+    - name: Cache GAMS installer
+      uses: actions/cache@v4
+      with:
+        path: |
+          gams
+        key: ${{ matrix.os }}-gams${{ env.GAMS_VERSION }}
+        restore-keys: |
+          ${{ matrix.os }}-
+
+    - uses: iiasa/actions/setup-gams@main
+      with:
+        version: ${{ env.GAMS_VERSION }}
+        license: ${{ secrets.GAMS_LICENSE }}
 
     - name: Initialize shell for "conda activate"
       run: conda init ${{ steps.shell.outputs.init }}


### PR DESCRIPTION
Unfortunately, it looks like the release v3.10.0 of ixmp broke the "install from conda forge" CI here, but only the tests running on windows machines. 

Comparing ixmp 3.9 to 3.10, we see that the way we collect the GAMS information has changed. Not dramatically and on macos, everything still works fine, which makes me think I'm still missing something here. However, looking at the backtrace, we see this bit:

```python
   File "D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\ixmp\cli.py", line 59, in main
    mp = ixmp.Platform(name=platform)
  File "D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\ixmp\core\platform.py", line 95, in __init__
    self._backend = backend_class(**kwargs)
                    ~~~~~~~~~~~~~^^^^^^^^^^
  File "D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\ixmp\backend\jdbc.py", line 264, in __init__
    start_jvm(jvmargs)
    ~~~~~~~~~^^^^^^^^^
  File "D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\ixmp\backend\jdbc.py", line 1253, in start_jvm
    gams_info().java_api_dir,  # GAMS system directory
    ~~~~~~~~~^^
  File "D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\ixmp\model\gams.py", line 412, in gams_info
    _GAMS_INFO = GAMSInfo()
  File "D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\ixmp\model\gams.py", line 90, in __init__
    output = check_output(
        ["gams", "null.gms", "-LogOption=3"],
    ...<2 lines>...
        universal_newlines=True,
    )
```

Indicating that `gams` is now called whenever an instance of an `ixmp.Platform` is created. However, `gams` is never in the `PATH` or even installed in the `conda` workflow. `message-ix show-versions` always reports `'gams' executable not in PATH`, even for successful runs on windows in the past and with ixmp 3.10.0 on macos. This is another bit I don't quite understand: how could this possibly work? 
With earlier versions of ixmp, we possibly didn't execute `gams` whenever creating a `Platform`, but today's runs already use ixmp 3.10.0, so should come with that requirement. The only reason I can immediately see for a difference from the windows tests is that `check_output` gets a different value for `shell`:

```python
                output = check_output(
                    ["gams", "null.gms", "-LogOption=3"],
                    shell=os.name == "nt",
                    cwd=temp_dir,
                    universal_newlines=True,
                )
```

So possibly, modifying this argument would also do the trick.

For now, though, I copied the steps that install GAMS in other CI workflows to this one as it seems we should have it installed for ixmp to work properly.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update release notes.~ Just CI.
- [x] After approval, drop the "TEMPORARY" commit(s).

