### PR TITLE
Fix "install from conda forge" CI  broken by release 3.10.0

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -87,7 +87,9 @@ jobs:
 
         # Also install pytest and packages required for testing. pip/PyPI
         # supports this via message_ix[testing], but conda does not.
-        conda create --quiet --name testenv message-ix pytest asyncssh sphinx
+        # Pin Python version to enable pyam versions relied on by the sankey tool;
+        # remove once pyam supports the latest Python
+        conda create --quiet --name testenv message-ix pytest asyncssh sphinx python=3.12
         conda list --name testenv
 
     - name: Check CLI commands and run test


### PR DESCRIPTION
Unfortunately, our release 3.10.0 broke our own "install from conda forge" CI _again_. This PR will eventually fix that.

We see this error upon test collection in the CI run:
```python
 ImportError while importing test module 'D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\message_ix\tests\tools\test_sankey.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\message_ix\tools\sankey.py:5: in <module>
    from pyam.str import get_variable_components
E   ModuleNotFoundError: No module named 'pyam.str'

During handling of the above exception, another exception occurred:
D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\importlib\__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\message_ix\tests\tools\test_sankey.py:7: in <module>
    from message_ix.tools.sankey import map_for_sankey
D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\message_ix\tools\sankey.py:7: in <module>
    from pyam.utils import get_variable_components
E   ImportError: cannot import name 'get_variable_components' from 'pyam.utils' (D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\pyam\utils.py)
```

We introduced the sankey tool in this release and it already includes a clause that tries to handle older versions of pyam (that adjusted the location from which to import `get_variable_components`. However, the CI run currently installs pyam 0.7.0, which was released more than 4.5 years ago, for some reason. 

Unfortunately, conda doesn't seem to offer any option to explain its dependency resolution process. I didn't find any reason when [comparing version 0.7.0 and 0.8.0 of pyam](https://github.com/IAMconsortium/pyam/compare/v0.7.0...v0.8.0): the pytest dependency received a pin, but that didn't make it to the conda-force build recipe. In fact, the [current recipe](https://github.com/conda-forge/pyam-feedstock/blob/main/recipe/meta.yaml) only contains a pin of numpy to < 2.0, which I would not expect to effect anything from four years ago. 

I'll keep on looking for a reason, but in the meantime, this PR attempts to install pyam 3.0.0 explicitly in the hopes that this will either work or yield some details on why not.

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI
- ~[ ] Update release notes.~ Just CI.
- [x] Rebase removing "TEMPORARY" commits.
