### PR TITLE
Fix Code Quality test after pandas-stubs v2.2.3.250308

### DIFF
--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -76,12 +76,16 @@ def slice_df(
     return df.set_index(idx)
 
 
-def mask_df(df: pd.DataFrame, index: str, count: int, value) -> None:
+def mask_df(
+    df: pd.DataFrame, index: tuple[Union[int, str], ...], count: int, value
+) -> None:
     """Create a mask for removing extra values from *df*."""
     df.loc[
         index,
         df.columns
-        > (df.loc[[index]].notnull().cumsum(axis=1) == count).idxmax(axis=1).values[0],
+        > (df.loc[[index], :].notnull().cumsum(axis=1) == count)
+        .idxmax(axis=1)
+        .values[0],
     ] = value
 
 


### PR DESCRIPTION
v2.2.3.250308 of pandas-stubs broke our Code Quality CI check with an error about indexing a `pandas.DataFrame`. This PR makes the check pass again.

## Details

The error we received was

```python
message_ix/tools/add_year/__init__.py:84: error: Invalid index type "list[str]" for "_LocIndexerFrame[DataFrame]"; expected type "slice[Any, Any, Any] | ndarray[Any, dtype[integer[Any]]] | Index[Any] | list[int] | Series[int] | <6 more items>"  [index]
```

and the code in question was

```python
def mask_df(df: pd.DataFrame, index: str, count: int, value) -> None:
    """Create a mask for removing extra values from *df*."""
    df.loc[
        index,
        df.columns
        > (df.loc[[index]].notnull().cumsum(axis=1) == count).idxmax(axis=1).values[0],
    ] = value
```

I think I put in the type hint of `index: str` as I understood it, but this is not correct. All usage of `mask_df()` within our code calls the function with `index` being one element of an iteration over `year_df.index`, which is a `MultiIndex`, so `index` is actually a `tuple`. I have confirmed as much through running

```python
    print(index)
    print(type(index))
    reveal_type(index)
```

immediately before the `df.loc[...]` call. So first I tried changing the type hint to `index: tuple`, which yields the same error but with `index type "list[tuple[Any, ...]]"`. Through looking at the `print(index)` for our tests, it seems that the types of the tuple entries can only be `int` or `str`, so I tried specifying that. 
Unfortunately, this yields the same error, and now even the pylance extension in my code editor can't tell me what `.notnull()` etc are, but the code is working fine. In fact, making the second appearance of `index` just `index` (instead of `[index]`), results in an error.

So I tried to specify the type correctly as best I can and the code is working as it is, but mypy is not happy. I assume this is because pandas-stubs is not allowing our `index` type, even though that seems to be working fine. So for now, it seems like adding a `type: ignore` is the best way to handle this. I should also open an issue with pandas-stubs, though I don't know if I can set up a minimal example to reproduce this.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update release notes.~ Just CI.
