### PR TITLE
Document duration_period_sum and its use

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -39,6 +39,7 @@ All changes
   In :mod:`message_ix` v3.7.0 to v3.10.0, changes in |duration_period| between subsequent periods
   would result in upper bounds applied to ``CAP_NEW``
   that were artificially low (if period duration increased) or high (if period duration decreased).
+- Improve documentation of |duration_period_sum| (:pull:`926`, :issue:`925`).
 
 .. _v3.10.0:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -79,7 +79,7 @@ rst_prolog = r"""
 for name in (
     "duration_period",
     "duration_period_sum",
-    "growth_new_capacity",
+    "growth_new_capacity_up",
     "historical_new_capacity",
     "map_tec_lifetime",
     "remaining_capacity",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,12 +69,22 @@ rst_prolog = r"""
 
 .. |yA| replace:: :math:`y^A`
 .. |yV| replace:: :math:`y^V`
+"""
 
-.. |duration_period| replace:: :ref:`duration_period <duration_period>`
-.. |growth_new_capacity_up| replace:: :ref:`growth_new_capacity_up <growth_new_capacity_up>`
-.. |historical_new_capacity| replace:: :ref:`historical_new_capacity <historical_new_capacity>`
-.. |map_tec_lifetime| replace:: :ref:`map_tec_lifetime <map_tec_lifetime>`
-"""  # noqa: E501
+# Add reST replacements for references to particular MESSAGE/MACRO model items. These
+# are of the form ".. |foo| replace:: :ref:`foo <foo>`", such that |foo| in reST links
+# to the hyperlink target #foo with the text 'foo'. The explicit text is needed because
+# sometimes multiple targets appear above a single heading, and that heading text would
+# be automatically used for the link text.
+for name in (
+    "duration_period",
+    "duration_period_sum",
+    "growth_new_capacity",
+    "historical_new_capacity",
+    "map_tec_lifetime",
+    "remaining_capacity",
+):
+    rst_prolog += f"\n.. |{name}| replace:: :ref:`{name} <{name}>`"
 
 
 # -- Options for HTML output -----------------------------------------------------------

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -66,6 +66,26 @@
 *    See :doc:`/time`.
 *
 * .. [#df_auto] These parameters are computed during the GAMS execution.
+*
+* .. _duration_period_sum:
+*
+* duration_period_sum (dimensions :math:`y_a, y_b`)
+*    This parameter measures the total time from the **start** of period :math:`y_a`
+*    until the **start** of any following period :math:`y_b`
+*    (equivalently: until the **end** of the period immediately preceding :math:`y_b`).
+*
+*    For example, with periods labelled '1000', '1010', '1015', and '1020':
+*
+*    - The period '1000' ends on and includes the day 1000-12-31.
+*    - The period '1010' starts on 1001-01-01 and ends on 1010-12-31.
+*    - The period '1020' starts on 1016-01-01.
+*    - Thus ``duration_period_sum(1010, 1020)`` measures the total time from 1001-01-01 to 1016-01-01,
+*      which is 15 years.
+*    - This is the same as ``duration_period(1010) + duration_period(1015)``.
+*
+*    This parameter is used,
+*    *inter alia*,
+*    to populate |map_tec_lifetime| and compute |remaining_capacity|.
 ***
 
 Parameters
@@ -556,6 +576,7 @@ Parameters
 
 ***
 * .. _section_parameter_investment:
+* .. _remaining_capacity:
 *
 * Auxiliary investment cost parameters and multipliers
 * ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR ~implements a fix for a bug in the `duration_period_sum` set documented in #925.~

- Adds documentation of duration_period_sum to clarify its meaning/interpretation/use.
- Adds in-line comments where it is used in MACRO/model_solve.gms.

See #925 and the discussion below for more details.

## How to review

- Look at the added "What's new" entry and the docs that it links to.
- Read the diff, especially the added inline comments in the GAMS code.
- Note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.