### PR TITLE
Adjust GAMS expression for type_tec_{share,total}

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -25,7 +25,7 @@ Users **should**:
 All changes
 -----------
 
-- Adjust use of :ref:`type_tec <mapping-sets>` in :ref:`equation_emission_equivalence` (:pull:`930`, :issue:`929`).
+- Adjust use of :ref:`type_tec <mapping-sets>` in :ref:`equation_emission_equivalence` (:pull:`930`, :issue:`929`, :pull:`935`).
 
   This change reduces the size of the ``EMISS`` variable,
   which can improve memory use performance for large scenarios

--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -86,14 +86,16 @@ storage_initial, storage_self_discharge, time_order
 *----------------------------------------------------------------------------------------------------------------------*
 
 * 'yes' for any type_tec that is a member of map_shares_commodity_share with any combination of other indices
-type_tec_share(type_tec) = SOR(
-    (shares, ns, n, m, commodity, l), map_shares_commodity_share(shares, ns, n, type_tec, m, commodity, l)
-);
+type_tec_share(type_tec)$SUM(
+  (shares, ns, n, m, commodity, l),
+  map_shares_commodity_share(shares, ns, n, type_tec, m, commodity, l)
+) = YES;
 
 * Same, except with map_shares_commodity_total
-type_tec_total(type_tec) = SOR(
-    (shares, ns, n, m, commodity, l), map_shares_commodity_total(shares, ns, n, type_tec, m, commodity, l)
-);
+type_tec_total(type_tec)$SUM(
+  (shares, ns, n, m, commodity, l),
+  map_shares_commodity_total(shares, ns, n, type_tec, m, commodity, l)
+) = YES;
 
 *----------------------------------------------------------------------------------------------------------------------*
 * ensure that each node is mapped to itself                                                                            *


### PR DESCRIPTION
As observed by both @ywpratama and I (in iiasa/message_data#605), from commit iiasa/message_ix@76eaa511c7d772bc3584bbbe5d64ea1fa424395a the GAMS code is very slow to execute for larger models. The difference is not noticeable within the message_ix test suite, and thus in #930, but becomes evident in larger (e.g. MESSAGEix-GLOBIOM) scenarios. For detailed symptoms see [Slack](https://iiasa-ece.slack.com/archives/CD0GBHHA4/p1745402028391619).

This one commit makes the following two changes to the implementation:
- Use SUM() instead of SOR().
- Use $-condition on left-hand side, instead of computing YES/NO on the RHS.

Although these have identical effects, the code executes much faster. It's not clear why: I searched for information about the performance of GAMS for these different constructs, but couldn't find anything.

## How to review

- Run any code or workflow involving MESSAGEix-GLOBIOM–sized scenarios, using this branch.
- Confirm that there is no noticeable slowdown compared to commit iiasa/message_ix@1d4564adde6bedbc0e5c2da77c0318ce86790d19 or earlier.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~
- [x] Update release notes.