### PR TITLE
Use message_ix.testing plugin in "conda" workflow

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -109,4 +109,4 @@ jobs:
 
         # Run a single test from the test suite to touch JDBCBackend Java code,
         # via JPype
-        pytest --pyargs message_ix -p ixmp.testing -p no:faulthandler -k "test_add_cat" --verbose -rA --color=yes
+        pytest --pyargs message_ix -p ixmp.testing -p message_ix.testing -p no:faulthandler -k "test_add_cat" --verbose -rA --color=yes


### PR DESCRIPTION
This is to address failures in the "conda" CI workflow, e.g. [here](https://github.com/iiasa/message_ix/actions/runs/15339556552/job/43163031831#step:9:197):
```
_______________________ ERROR at setup of test_add_cat ________________________
file D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\message_ix\tests\test_core.py, line 376
  def test_add_cat(dantzig_message_scenario: Scenario) -> None:
file D:\a\_actions\iiasa\actions\main\setup-conda\Anaconda3\envs\testenv\Lib\site-packages\message_ix\tests\test_core.py, line 21
  @pytest.fixture
  def dantzig_message_scenario(
E       fixture 'message_test_mp' not found
```

The fixture in question is in message_ix.testing. When running from source, this plugin is specified by conftest.py, but when installed from PyPI or conda-forge the file is not present and the plugins must be specified directly. (This could possibly be avoided by moving the file to message_ix/tests/conftest.py; we haven't tried this.)

## How to review

The "conda" workflow is temporarily enabled for the PR branch.

- Note that the "conda" workflow run passes.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A; CI changes only
- ~Update release notes.~
- [ ] (After approval) Remove the TEMPORARY commit.