### PR TITLE
Remove Python 3.8 compat in .macro.extrapolate()

### DIFF
--- a/message_ix/macro.py
+++ b/message_ix/macro.py
@@ -262,8 +262,6 @@ def extrapolate(
         The index does *not* have a ``year`` dimension; the data are implicitly for
         `ym1`.
     """
-    from sys import version_info
-
     from scipy.optimize import curve_fit
 
     def f(x, b, m):
@@ -278,11 +276,8 @@ def extrapolate(
 
     # Apply fitted_intercept to grouped data
     groupby_cols = set(model_data.columns) - {"year", "value"}
-    apply_kwargs = {"include_groups": False} if version_info.minor > 8 else {}
     result = (
-        model_data.groupby(list(groupby_cols))
-        .apply(fitted_intercept, **apply_kwargs)
-        .rename("value")
+        model_data.groupby(list(groupby_cols)).apply(fitted_intercept).rename("value")
     )
 
     # Convert "commodity" and "level" to "sector"


### PR DESCRIPTION
pandas-stubs version 2.3.0 was released 2025-07-02 (lagging about a month behind pandas itself). This caused mypy errors [here](https://github.com/iiasa/message_ix/actions/runs/16042038021/job/45265360347#step:5:44):
```
message_ix/macro.py:283: error: No overload variant of "apply" of "DataFrameGroupBy" matches argument types "Callable[[DataFrame], float]", "dict[str, bool]"  [call-overload]
message_ix/macro.py:283: note: Possible overload variants:
message_ix/macro.py:283: note:     def [P`17067] apply(self, DFCallable1[P], /, *args: P.args, **kwargs: P.kwargs) -> Series[Any]
message_ix/macro.py:283: note:     def [P`17068] apply(self, DFCallable2[P], /, *args: P.args, **kwargs: P.kwargs) -> DataFrame
message_ix/macro.py:283: note:     def [P`17069] apply(self, DFCallable3[P], /, *args: P.args, **kwargs: P.kwargs) -> DataFrame
```

The offending code was for compatibility with Python 3.8 and earlier, or at least with versions of pandas that would be installed for Python 3.8. Since this Python version is no longer supported, this PR drops the work-around, which makes the error disappear.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, type checking only
- ~Update release notes.~ Ditto.