### PR TITLE
Use Java 21 on Windows GHA runners

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -110,6 +110,13 @@ jobs:
       # Work around ts-graphviz/setup-graphviz#630
       if: matrix.os != 'macos-13'
 
+    - name: Set Java version on Windows
+      if: startsWith(matrix.os, 'windows-')
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
+
     - name: Cache GAMS installer
       uses: actions/cache@v4
       with:
@@ -171,6 +178,13 @@ jobs:
         activate-environment: true
         enable-cache: true
         python-version: ${{ env.python-version }}
+
+    - name: Set Java version on Windows
+      if: startsWith(matrix.os, 'windows-')
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: '21'
 
     - name: Set RETICULATE_PYTHON
       # Retrieve the Python executable set up above

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,8 +1,10 @@
-.. Next release
-.. ============
+Next release
+============
 
-.. All changes
-.. -----------
+All changes
+-----------
+
+- Document the :ref:`minimum version of Java <install-java>` required for :class:`ixmp.JDBCBackend <ixmp.backend.jdbc.JDBCBackend>` (:pull:`962`).
 
 .. _v3.11.1:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -197,6 +197,7 @@ intersphinx_mapping = {
         "https://docs.messageix.org/projects/ixmp/en/latest/",
         (local_inv("ixmp"), None),
     ),
+    "jpype": ("https://jpype.readthedocs.io/en/stable", None),
     "message-ix-models": (
         "https://docs.messageix.org/projects/models/en/latest/",
         None,

--- a/doc/install-adv.rst
+++ b/doc/install-adv.rst
@@ -57,16 +57,26 @@ of which the most popular is OpenJDK.
   - `Zulu <https://www.azul.com/downloads/?package=jre#zulu>`_.
   - `Corretto <https://aws.amazon.com/corretto/>`_.
 
-.. caution::
+  .. caution::
 
-   Oracle provides releases branded simply “Java” at https://www.java.com,
-   as well as `Oracle OpenJDK builds <https://jdk.java.net/>`_.
-   Not all of these are free to use;
-   for instance, use by several people in the same organization may require a paid license.
-   `This news article <https://www.theregister.com/2025/05/09/users_advised_to_review_oracle_java_use/>`__ and other coverage
-   explain how license fee demands may come as a surprise to users.
+     Oracle provides releases branded simply “Java” at https://www.java.com,
+     as well as `Oracle OpenJDK builds <https://jdk.java.net/>`_.
+     Not all of these are free to use;
+     for instance, use by several people in the same organization may require a paid license.
+     `This news article <https://www.theregister.com/2025/05/09/users_advised_to_review_oracle_java_use/>`__ and other coverage
+     explain how license fee demands may come as a surprise to users.
 
-   We recommend one of the above, non-Oracle alternatives, which do not use paid licensing.
+     We recommend one of the above, non-Oracle alternatives, which do not use paid licensing.
+
+- JDBCBackend uses the :mod:`jpype` package (`‘JPype1’`_ on PyPI) to interact with the JRE.
+
+  From JPype version 1.6.0 (released 2025-07-07),
+  :ref:`its requirements <jpype:userguide:key requirements>` include **JRE version 11 or greater**.
+  You **should** use such a JRE version;
+  in general it is good practice to use the *latest* available version.
+
+  If it is only possible to use JRE version 8,
+  then install JPype version 1.5.2 or earlier.
 
 If using Anaconda or Miniconda, installing a JDK/JRE manually is *not required*.
 This is because the ``message-ix`` conda-forge package depends on the `openjdk <https://anaconda.org/conda-forge/openjdk>`_ package,
@@ -481,6 +491,7 @@ See the `Git documentation`_ for more details.
 .. _`Graphviz`: https://www.graphviz.org/
 .. _`its conda-forge package`: https://anaconda.org/conda-forge/graphviz
 .. _`Graphviz download page`: https://www.graphviz.org/download/
+.. _`‘JPype1’`: https://pypi.org/project/jpype1
 .. _`conda`: https://docs.conda.io/projects/conda/en/stable/
 .. _`IIASA YouTube channel`: https://www.youtube.com/user/IIASALive
 .. _`Miniconda`: https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html


### PR DESCRIPTION
Parallel to iiasa/ixmp#586, use a version of Java compatible with JPype1 v1.6.0. This version of JPype was released 2025-07-07 and triggered failures of the `windows-latest-py3.1[123]` and `windows-latest tutorials` scheduled testing jobs, for instance [here](https://github.com/iiasa/message_ix/actions/runs/16134446053).

- I initially tried the settings:
  ```yaml
  distribution: 'temurin'
  java-version: 11
  ```
- This caused ([here](https://github.com/iiasa/message_ix/actions/runs/16253568336/job/45887494779?pr=962)) all the Windows jobs to fail with `java.lang.OutOfMemoryError: Java heap space`.
- I imagine this is due to different memory usage characteristics of (a) the underlying Java version, (b) JPype, (c) ixmp_source, or (d) some interaction of the first three, such that more memory is used.
- The PR now uses the _latest_ Java version, 21, that is in the tool cache on Windows runners.
- This is sufficient for CI, i.e. the jobs will again pass. The idea of using Java 11 follows the principle of “ensure that the claimed oldest supported version(s) do, in fact, work”—using older versions also serves a ‘canary’ purpose so we can notice when (a) things stop working or (b) we add new code that is not compatible with versions we claim to support. Time does not allow to diagnose or adjust for the heap space issues with Java 11.

## How to review

Note that the CI checks all pass on the jobs labeled "(pull_request)" (not pull_request_target) → [run #2855](https://github.com/iiasa/message_ix/actions/runs/16260807967/job/45907820472?pr=962).

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
- [x] (after approval, before merge) Drop the TEMPORARY commit(s).