### PR TITLE
Pin ixmp4 version temporarily to enable CI success

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -67,6 +67,9 @@ jobs:
           "ixmp[tests] @ git+https://github.com/iiasa/ixmp.git@main" \
           .[tests]
 
+    - name: TEMPORARY workaround https://github.com/iiasa/message_ix/issues/975
+      run: uv pip install "ixmp4==0.11.1"
+
     - name: Run test suite using pytest
       env:
         MESSAGE_IX_ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -2,11 +2,11 @@ name: Tests
 
 on:
   # Uncomment this entry only to debug the workflow
-  # pull_request:
-  #   branches: [ main ]
-  pull_request_target:
+  pull_request:
     branches: [ main ]
-    types: [ labeled, opened, reopened, synchronize ]
+  # pull_request_target:
+  #   branches: [ main ]
+  #   types: [ labeled, opened, reopened, synchronize ]
   # 05:00 UTC = 06:00 CET = 07:00 CEST
   schedule:
   - cron: "0 5 * * *"

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -134,6 +134,9 @@ jobs:
     - name: Install the package and dependencies
       run: uv pip install --upgrade ${{ env.upstream-versions }} .[tests]
 
+    - name: TEMPORARY workaround https://github.com/iiasa/message_ix/issues/975
+      run: uv pip install "ixmp4==0.11.1"
+
     - name: Run test suite using pytest
       env:
         # For test_cli.test_dl; see code in message_ix.cli.dl
@@ -213,6 +216,9 @@ jobs:
 
     - name: Install the package and dependencies
       run: uv pip install --upgrade ${{ env.upstream-versions }} .[tests]
+
+    - name: TEMPORARY workaround https://github.com/iiasa/message_ix/issues/975
+      run: uv pip install "ixmp4==0.11.1"
 
     - name: Install R dependencies and tutorial requirements
       run: |


### PR DESCRIPTION
As announced in #975, this PR is a temporary workaround for that issue which aims to get our CI passing again. 
I hope to have more time toward the end of the week to figure out a proper solution to the underlying issue.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [ ] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update release notes.~ Just CI.
