### PR TITLE
Avoid `RunLockRequired` error by using backend functions

### DIFF
--- a/message_ix/util/ixmp4.py
+++ b/message_ix/util/ixmp4.py
@@ -1,5 +1,4 @@
 import ixmp
-import ixmp.backend
 from ixmp.util.ixmp4 import is_ixmp4backend
 
 


### PR DESCRIPTION
Closes #975, superseded #976. The former PR was an attempt to pin the ixmp4 version, which doesn't work as explained there. Instead, as @khaeru suggested, we should bump the minimum supported version of ixmp4 in ixmp to v0.12. This PR adjusts the code we have in message_ix that runs into `RunLockRequired` errors by calling ixmp4-backend functions directly.

Please note that this is not an attempt to integrate the `Run.transact()` or other ixmp4 rollback features.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist


- [ ] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just internal function calls.
- ~[ ] Update release notes.~ Just internal function calls.

