### PR TITLE
Address CI failures due to flexcache

### DIFF
--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -25,6 +25,16 @@ GHA = "GITHUB_ACTIONS" in os.environ
 # Pytest hooks
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    """Force iam-units to use a distinct cache for each worker.
+
+    Work around for https://github.com/hgrecco/flexcache/issues/6 /
+    https://github.com/IAMconsortium/units/issues/54.
+    """
+    name = f"iam-units-{os.environ.get('PYTEST_XDIST_WORKER', '')}".rstrip("-")
+    os.environ["IAM_UNITS_CACHE"] = str(config.cache.mkdir(name))
+
+
 def pytest_report_header(config: pytest.Config, start_path: Path) -> str:
     """Add the message_ix import path to the pytest report header."""
     import message_ix


### PR DESCRIPTION
This mirrors changes made in khaeru/genno#179 to address hgrecco/flexcache#6 / IAMconsortium/units#54. The `IAM_UNITS_CACHE` environment variable (available since iam-units 2025.10.13) is set to a different directory for each pytest-xdist worker. This prevents collisions.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A; CI changes only.
- ~Update release notes.~