### PR TITLE
Add modelinstance support 

### DIFF
--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -760,6 +760,36 @@ class Scenario(ixmp.Scenario):
         """
         super().solve(model=model, solve_options=solve_options, **kwargs)
 
+    def create_model_instance(self, model="MESSAGE", **model_options):
+        """Create a persistent GAMS model instance for efficient resolving.
+
+        This is a thin wrapper around :meth:`ixmp.Scenario.create_model_instance`
+        that defaults to the MESSAGE model.
+
+        Parameters
+        ----------
+        model : str, optional
+            Model to compile. Default is "MESSAGE".
+        model_options :
+            Additional keyword arguments passed to the model.
+
+        Returns
+        -------
+        tuple of (GamsModelInstance, GamsWorkspace)
+            The model instance and workspace that can be used for efficient resolving.
+
+        Examples
+        --------
+        >>> mi, ws = scen.create_model_instance()
+        >>> mi.solve()
+        >>> obj_value = mi.sync_db["OBJ"].first_record().level
+
+        See Also
+        --------
+        ixmp.Scenario.create_model_instance
+        """
+        return super().create_model_instance(model=model, **model_options)
+
     def add_macro(
         self,
         data: Union[Mapping, os.PathLike],

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -808,6 +808,7 @@ class Scenario(ixmp.Scenario):
         self,
         model="MESSAGE",
         modifiable_pars=None,
+        fixable_vars=None,
         use_defaults=True,
         **model_options,
     ):
@@ -823,6 +824,8 @@ class Scenario(ixmp.Scenario):
         modifiable_pars : list of str, optional
             List of parameter names that can be modified between solves.
             If None and use_defaults=True, uses DEFAULT_MODIFIABLE_PARS.
+        fixable_vars : list of str, optional
+            List of variable names that can be fixed between solves.
         use_defaults : bool, optional
             If True and modifiable_pars is None, uses DEFAULT_MODIFIABLE_PARS.
             Set to False to create instance with no modifiable parameters.
@@ -859,7 +862,10 @@ class Scenario(ixmp.Scenario):
             modifiable_pars = DEFAULT_MODIFIABLE_PARS
 
         return super().create_model_instance(
-            model=model, modifiable_pars=modifiable_pars, **model_options
+            model=model,
+            modifiable_pars=modifiable_pars,
+            fixable_vars=fixable_vars,
+            **model_options,
         )
 
     def add_macro(

--- a/message_ix/core.py
+++ b/message_ix/core.py
@@ -18,6 +18,50 @@ from ixmp.util.ixmp4 import is_ixmp4backend
 
 log = logging.getLogger(__name__)
 
+#: Parameters that can be made modifiable in GamsModelInstance
+#: These are NOT used in conditional expressions ($) in GAMS code
+DEFAULT_MODIFIABLE_PARS = [
+    # Cost parameters
+    "inv_cost",
+    "fix_cost",
+    "var_cost",
+    "resource_cost",
+    # Technical coefficients
+    "input",
+    "output",
+    "technical_lifetime",
+    "construction_time",
+    # Bounds
+    "bound_activity_up",
+    "bound_activity_lo",
+    "bound_new_capacity_up",
+    "bound_new_capacity_lo",
+    "bound_total_capacity_up",
+    "bound_total_capacity_lo",
+    "initial_activity_up",
+    "initial_activity_lo",
+    "initial_new_capacity_up",
+    "initial_new_capacity_lo",
+    # Resource parameters
+    "resource_volume",
+    "resource_remaining",
+    # Demand and stocks
+    "demand",
+    "stock",
+    # Emissions
+    "emission_factor",
+    "emission_scaling",
+    # Storage
+    "storage_initial",
+    "storage_self_discharge",
+    # Relations
+    "relation_upper",
+    "relation_lower",
+    "relation_activity",
+    "relation_new_capacity",
+    "relation_total_capacity",
+]
+
 # Also print warnings to stderr
 _sh = logging.StreamHandler()
 _sh.setLevel(level=logging.WARNING)
@@ -760,16 +804,28 @@ class Scenario(ixmp.Scenario):
         """
         super().solve(model=model, solve_options=solve_options, **kwargs)
 
-    def create_model_instance(self, model="MESSAGE", **model_options):
+    def create_model_instance(
+        self,
+        model="MESSAGE",
+        modifiable_pars=None,
+        use_defaults=True,
+        **model_options,
+    ):
         """Create a persistent GAMS model instance for efficient resolving.
 
         This is a thin wrapper around :meth:`ixmp.Scenario.create_model_instance`
-        that defaults to the MESSAGE model.
+        that defaults to the MESSAGE model and provides default modifiable parameters.
 
         Parameters
         ----------
         model : str, optional
             Model to compile. Default is "MESSAGE".
+        modifiable_pars : list of str, optional
+            List of parameter names that can be modified between solves.
+            If None and use_defaults=True, uses DEFAULT_MODIFIABLE_PARS.
+        use_defaults : bool, optional
+            If True and modifiable_pars is None, uses DEFAULT_MODIFIABLE_PARS.
+            Set to False to create instance with no modifiable parameters.
         model_options :
             Additional keyword arguments passed to the model.
 
@@ -780,15 +836,31 @@ class Scenario(ixmp.Scenario):
 
         Examples
         --------
+        >>> # Use default modifiable parameters
         >>> mi, ws = scen.create_model_instance()
+        >>> # Modify inv_cost in sync_db
+        >>> inv_cost = mi.sync_db["inv_cost"]
+        >>> for rec in inv_cost:
+        ...     if rec.keys == ["node", "wind_ppl", "2020"]:
+        ...         rec.level = 1500
         >>> mi.solve()
-        >>> obj_value = mi.sync_db["OBJ"].first_record().level
+
+        >>> # Custom modifiable parameters
+        >>> mi, ws = scen.create_model_instance(
+        ...     modifiable_pars=["demand", "bound_activity_up"]
+        ... )
 
         See Also
         --------
         ixmp.Scenario.create_model_instance
+        DEFAULT_MODIFIABLE_PARS
         """
-        return super().create_model_instance(model=model, **model_options)
+        if modifiable_pars is None and use_defaults:
+            modifiable_pars = DEFAULT_MODIFIABLE_PARS
+
+        return super().create_model_instance(
+            model=model, modifiable_pars=modifiable_pars, **model_options
+        )
 
     def add_macro(
         self,


### PR DESCRIPTION
This is an experimental branch connected to [IXMP PR](https://github.com/iiasa/ixmp/pull/605) adds support for the [Gamsmodelinstance API](https://www.gams.com/50/docs/apis/python/classgams_1_1control_1_1execution_1_1GamsModelInstance.html)which provides a persistent model object for use.

Right now this is quite experimental, hence the code is not up to quality. The API for allowing user access is also not final. Putting it here for reference and feedback. For most models, model generation times dominate solving times. This means when a sequence of scenarios are to be evaluated in an ensemble a large fraction of the time is spent in the generation of the model matrix. Modelinstance provides a persistent object with an in-memory database for modifiable parameters via sync_db.

In theory this allows for gains = 1 + time_build/time_solving. For the baseline model time_build is ~500s and solve is 200s which yields a gain of 3.5X for large number of runs. Additionally the model instance passes the previous solution's basis to the next solution. In theory then a barrier followed by Simplex methods with advanced basis can approach even higher performance gains. But this requires dynamic solver parametrization maybe ML methods could help here.


## How to review

At this point feedback and usage would be appreciated 

<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- View the preview build of the documentation and look at a certain page.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist
Experimental so this will not apply till at least an early Alpha stage is reached. 
<!-- This item is always required. -->
~~- [ ] Continuous integration checks all ✅~~
<!--
The following items are *required* if the PR results in changes to user-facing
behaviour—such as new features, or fixes to existing behaviour.

They are *optional* if the changes are solely to documentation, test/CI
configuration, etc. In such cases, strike them out and add a short explanation,
for example:

- ~Add or expand tests.~ No change in behaviour, simply refactoring.
-->
~~- [ ] Add or expand tests; coverage checks both ✅~~
~~- [ ] Add, expand, or update documentation.~~
~~- [ ] Update release notes.~~
