### PR TITLE
Adjust for pandas-stubs v2.3.3.251219

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.17.0
+  rev: v1.19.1
   hooks:
   - id: mypy
     pass_filenames: false
@@ -15,7 +15,7 @@ repos:
     - types-PyYAML
     - types-requests
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.4
+  rev: v0.14.11
   hooks:
   - id: ruff-check
   - id: ruff-format

--- a/message_ix/tools/add_year/__init__.py
+++ b/message_ix/tools/add_year/__init__.py
@@ -829,7 +829,7 @@ def interpolate_2d(  # noqa: C901
                 d_n = slice_df(df_yrs, idx, year_ref, [yr_nn], yr)
             d_n = d_n.loc[d_n.index.isin(d.index), :]
             d = d.loc[d.index.isin(d_n.index), :]
-            d[d.isnull() & d_n.notnull()] = d_n  # type: ignore [call-overload]
+            d[d.isnull() & d_n.notnull()] = d_n  # type: ignore [index]
             df2.loc[df2.index.isin(d.index), :] = d
 
         cond1 = df_dur.index <= yr_diff_new[0]
@@ -915,10 +915,10 @@ def interpolate_2d(  # noqa: C901
                 df_pre, df_pp.shift(+1, axis=1), year_pre, year_pp, yr
             )  # type: ignore
             df_yr.loc[pd.isna(df_yr[yr])] = df_to_fill_nans.shift(+1, axis=1)
-            df_yr[pd.isna(df_yr)] = df_pre  # type: ignore [call-overload]
+            df_yr[pd.isna(df_yr)] = df_pre  # type: ignore [index]
 
             if extrapol_neg:
-                df_yr[(df_yr < 0) & (df_pre >= 0)] = df_pre * extrapol_neg  # type: ignore [call-overload]
+                df_yr[(df_yr < 0) & (df_pre >= 0)] = df_pre * extrapol_neg  # type: ignore [index]
             df_yr.loc[:, df_yr.columns < str(yr)] = np.nan
 
         # c) Otherwise, do intrapolation


### PR DESCRIPTION
Same as iiasa/ixmp#625. See [here](https://github.com/iiasa/message_ix/actions/runs/20389538340/job/58596617580#step:5:46) for the first failing job, on 2025-12-20.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A; CI changes only.
- ~Update release notes.~