### PR TITLE
Fix failures in "nightly" CI workflow

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -26,7 +26,7 @@ All changes
 - Support for Python 3.9 is dropped (:pull:`985`), as it has reached end-of-life.
 - :mod:`message_ix` is tested and compatible with `Pandas 3.0.0 <https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html>`_,
   released 2026-01-21 (:pull:`1001`).
-- Add representation of commodity flows associated with construction and retirement of technology capacity (:pull:`451`).
+- Add representation of commodity flows associated with construction and retirement of technology capacity (:pull:`451`, :pull:`1003`).
 
   - New parameters
     |input_cap|,

--- a/doc/requirements.in
+++ b/doc/requirements.in
@@ -7,4 +7,4 @@ numpydoc==1.8.0
 pandas==2.2.3
 sphinx==8.2.3
 sphinx-rtd-theme==3.0.2
-sphinxcontrib-bibtex==2.6.3
+sphinxcontrib-bibtex==2.6.5

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -85,7 +85,7 @@ platformdirs==4.3.8
     #   pint
 pyarrow==21.0.0
     # via pandas
-pybtex==0.24.0
+pybtex==0.25.1
     # via
     #   pybtex-docutils
     #   sphinxcontrib-bibtex
@@ -110,7 +110,6 @@ roman-numerals-py==3.1.0
 six==1.16.0
     # via
     #   latexcodec
-    #   pybtex
     #   python-dateutil
 smmap==5.0.0
     # via gitdb
@@ -128,7 +127,7 @@ sphinx-rtd-theme==3.0.2
     # via -r requirements.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-bibtex==2.6.3
+sphinxcontrib-bibtex==2.6.5
     # via -r requirements.in
 sphinxcontrib-devhelp==2.0.0
     # via sphinx

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -155,17 +155,32 @@ demand_init(node_macro,sector,year) = SUM((commodity, level, time)$mapping_macro
 
 * useful energy/service demand prices from MESSAGE get mapped onto MACRO sector structure
 
-eneprice(node_macro,sector,year) $(NOT macro_base_period(year)) = SUM((commodity, level, time) $ mapping_macro_sector(sector, commodity, level),
-                                 PRICE_COMMODITY.L(node_macro,commodity,level,year,time) * duration_time(time) )
-;
+* Replace EPS values with 0
+PRICE_COMMODITY.L(node_macro,commodity,level,year,time)$(
+    mapVal(PRICE_COMMODITY.L(node_macro,commodity,level,year,time)) = 8
+) = 0;
 
-price_diff_abs(iteration,node_macro,sector,year)$( price_init(node_macro,sector,year) ) =
-    eneprice(node_macro,sector,year) - price_init(node_macro,sector,year) ;
-price_diff_rel(iteration,node_macro,sector,year)$( price_init(node_macro,sector,year) ) =
-    price_diff_abs(iteration,node_macro,sector,year) / price_init(node_macro,sector,year) ;
+eneprice(node_macro,sector,year)$(NOT macro_base_period(year)) = SUM(
+    (commodity,level,time)$mapping_macro_sector(sector,commodity,level),
+    PRICE_COMMODITY.L(node_macro,commodity,level,year,time) * duration_time(time)
+);
 
-price_init(node_macro,sector,year) = SUM((commodity, level, time) $ mapping_macro_sector(sector, commodity, level),
-                                        PRICE_COMMODITY.l(node_macro,commodity,level,year,time) ) ;
+* Absolute difference in prices
+price_diff_abs(iteration,node_macro,sector,year)$price_init(node_macro,sector,year) = (
+    eneprice(node_macro,sector,year)
+    - price_init(node_macro,sector,year)
+);
+
+* Relative difference in prices
+price_diff_rel(iteration,node_macro,sector,year)$price_init(node_macro,sector,year) = (
+    price_diff_abs(iteration,node_macro,sector,year)
+    / price_init(node_macro,sector,year)
+);
+
+price_init(node_macro,sector,year) = SUM(
+  (commodity,level,time)$mapping_macro_sector(sector,commodity,level),
+  PRICE_COMMODITY.L(node_macro,commodity,level,year,time)
+);
 
 DISPLAY enestart, eneprice, total_cost ;
 


### PR DESCRIPTION
Since about 2025-08-12 / after commit iiasa/message_ix@9fb0b978 (see commit hash in [this succeeding run](https://github.com/iiasa/message_ix/actions/runs/16899458541)), the "nightly" CI workflow has had one failure, e.g. [here](https://github.com/iiasa/message_ix/actions/runs/23422943812/job/68131757688#step:8:2237):
```
=================================== FAILURES ===================================
__ test_solve_and_check[scenario_info1-md5:ae17c294c9479a2af14a9d3157f49257] ___

…

--- Reading solution for model MESSAGE_LP
--- Executing after solve: elapsed 0:01:22.973
--- MESSAGE-MACRO_run.gms(5662) 755 Mb
*** Error at line 5893: division by eps
--- MESSAGE-MACRO_run.gms(5662) 755 Mb 1 Error
*** SOLVE not executed
```

The particular "line 5893" is the one that calculates price_diff_rel = price_diff_abs / price_init:
https://github.com/iiasa/message_ix/blob/621690f788734a781600d9a0b36c8ec52e7ec825/message_ix/model/MESSAGE-MACRO_run.gms#L164-L165

The errors occur because `eneprice` has exactly one EPS entry:

```
----   5891 PARAMETER eneprice  Shadow prices of energy services from MESSAGE model run

                         2010        2020        2030        2040        2050        2060
[...]
R11_EEU.rc_therm      248.770     283.161     410.613     370.907     424.376     407.898
R11_EEU.transport     232.390     206.319     325.135     400.463     452.543     530.404
R11_FSU.i_feed        125.070     115.702     219.082     324.498     483.760     523.904
R11_FSU.i_spec        498.760     554.890     775.132     828.470     882.616     889.580
R11_FSU.i_therm       208.590     177.434     317.329     351.830     372.610     412.852
R11_FSU.rc_spec       615.330     745.076    1029.884    1047.595    1006.199    1012.247
R11_FSU.rc_therm      236.280     229.053         EPS     364.862     382.863     392.681
```
With the older code that passes the test, this entry is instead zero:
```
----   5575 PARAMETER eneprice  Shadow prices of energy services from MESSAGE model run

                         2010        2020        2030        2040        2050        2060

R11_EEU.rc_therm      248.770     283.161     410.613     370.906     424.376     407.901
R11_EEU.transport     232.390     206.319     325.135     400.463     452.543     530.404
R11_FSU.i_feed        125.070     115.702     219.082     324.498     483.760     523.904
R11_FSU.i_spec        498.760     554.890     775.132     828.470     882.616     889.580
R11_FSU.i_therm       208.590     177.434     317.329     351.830     372.610     412.852
R11_FSU.rc_spec       615.330     745.076    1029.884    1047.596    1006.199    1012.247
R11_FSU.rc_therm      236.280     229.053                 364.862     382.863     392.681
```
These EPS/0 entries in turn appear to come from PRICE_COMMODITY.L, so they probably started with #451, which changed the way this was calculated.

The PR fixes by ensuring EPS is replaced with zero 0.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~
- [x] Update release notes.
