### PR TITLE
Add foresight keyword and fix prior-period var fixing in recursive dynamic

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -22,6 +22,7 @@ Adjust any imports like the following:
 All changes
 -----------
 
+- Add a ``foresight`` keyword to :meth:`.Scenario.solve` for recursive-dynamic (myopic / rolling-horizon) mode, and correct how prior-period variables are fixed between iterations (:pull:`1016`).
 - :mod:`message_ix` is tested and compatible with `Python 3.14 <https://www.python.org/downloads/release/python-3140/>`__ (:pull:`985`).
 - Support for Python 3.9 is dropped (:pull:`985`), as it has reached end-of-life.
 - :mod:`message_ix` is tested and compatible with `Pandas 3.0.0 <https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html>`_,

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -22,7 +22,7 @@ Adjust any imports like the following:
 All changes
 -----------
 
-- Add a ``foresight`` keyword to :meth:`.Scenario.solve` for recursive-dynamic (myopic / rolling-horizon) mode, and correct how prior-period variables are fixed between iterations (:pull:`1016`).
+- Add a ``foresight`` keyword to :meth:`.Scenario.solve` for recursive-dynamic (myopic / rolling-horizon) mode, and correct how prior-period variables are fixed between iterations (:pull:`1017`).
 - :mod:`message_ix` is tested and compatible with `Python 3.14 <https://www.python.org/downloads/release/python-3140/>`__ (:pull:`985`).
 - Support for Python 3.9 is dropped (:pull:`985`), as it has reached end-of-life.
 - :mod:`message_ix` is tested and compatible with `Pandas 3.0.0 <https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html>`_,

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -270,6 +270,13 @@ Model classes
      .. note:: For some models, this can significantly increase the linear program (LP) size
         and thus the solve time.
 
+   - **foresight** (:class:`int`):
+     Number of years of foresight for the solution algorithm.
+     :py:`0` (the default) selects perfect foresight, in which the entire model horizon is optimized simultaneously.
+     :py:`1` selects myopic (recursive-dynamic) optimization: each period is solved in turn with the decision variables of earlier periods held fixed.
+     A value :py:`> 1` selects a rolling horizon that looks ahead that many years in each step.
+     This corresponds to the GAMS compile-time variable ``foresight``.
+
    .. autoattribute:: items
       :no-value:
 

--- a/doc/framework.rst
+++ b/doc/framework.rst
@@ -65,6 +65,11 @@ There are three ways to run a |MESSAGEix| model:
    :mod:`message_ix`, calling :meth:`message_ix.Scenario.solve`. (See the
    :doc:`tutorials`.)
 
+   The solution algorithm is selected with the :py:`foresight` keyword:
+   :py:`solve(foresight=0)` (the default) is perfect foresight, :py:`foresight=1` is
+   myopic, and :py:`foresight=N` for :py:`N > 1` is a rolling horizon with ``N`` years
+   of look-ahead. See :doc:`api` for details.
+
 2. Using the file ``MESSAGE_master.gms``, where the scenario name (i.e., the
    gdx input file), the optimization horizon (perfect foresight or myopic/
    rolling-horizon version), and other options can be defined explicitly.

--- a/message_ix/message.py
+++ b/message_ix/message.py
@@ -68,7 +68,10 @@ class MESSAGE(GAMSModel):
     #: All equations, parameters, sets, and variables in the MESSAGE formulation.
     items: MutableMapping[str, Item] = dict()
 
-    keyword_to_solve_arg = [("cap_comm", _boollike, "MESSAGE_CAP_COMM")]
+    keyword_to_solve_arg = [
+        ("cap_comm", _boollike, "MESSAGE_CAP_COMM"),
+        ("foresight", int, "foresight"),
+    ]
 
     @staticmethod
     def enforce(scenario: "ixmp.Scenario") -> None:

--- a/message_ix/model/MESSAGE/model_solve.gms
+++ b/message_ix/model/MESSAGE/model_solve.gms
@@ -125,7 +125,8 @@ else
 * fix all variables of the current iteration period 'year_all' to the optimal levels
         EXT.fx(node,commodity,grade,year_all) =  EXT.l(node,commodity,grade,year_all) ;
         CAP_NEW.fx(node,tec,year_all) = CAP_NEW.l(node,tec,year_all) ;
-        CAP.fx(node,tec,year_all2,year_all)$( map_period(year_all2,year_all) ) = CAP.l(node,tec,year_all,year_all2) ;
+* NB CAP is indexed (year_vtg, year_act); both sides must use that order (cf. ACT below)
+        CAP.fx(node,tec,year_all2,year_all)$( map_period(year_all2,year_all) ) = CAP.l(node,tec,year_all2,year_all) ;
         ACT.fx(node,tec,year_all2,year_all,mode,time)$( map_period(year_all2,year_all) )
             = ACT.l(node,tec,year_all2,year_all,mode,time) ;
         CAP_NEW_UP.fx(node,tec,year_all) = CAP_NEW_UP.l(node,tec,year_all) ;

--- a/message_ix/model/MESSAGE/model_solve.gms
+++ b/message_ix/model/MESSAGE/model_solve.gms
@@ -6,6 +6,9 @@
 * including the required accounting of investment costs beyond the model horizon.
 ***
 
+* Tolerance for the band used to lock prior-period variables in recursive-dynamic mode
+$setglobal rd_fix_tol 1E-6
+
 if (%foresight% = 0,
 ***
 * Perfect-foresight model
@@ -122,17 +125,30 @@ else
             ABORT "MESSAGEix did not solve to optimality!"
         ) ;
 
-* fix all variables of the current iteration period 'year_all' to the optimal levels
-        EXT.fx(node,commodity,grade,year_all) =  EXT.l(node,commodity,grade,year_all) ;
-        CAP_NEW.fx(node,tec,year_all) = CAP_NEW.l(node,tec,year_all) ;
-* NB CAP is indexed (year_vtg, year_act); both sides must use that order (cf. ACT below)
-        CAP.fx(node,tec,year_all2,year_all)$( map_period(year_all2,year_all) ) = CAP.l(node,tec,year_all2,year_all) ;
-        ACT.fx(node,tec,year_all2,year_all,mode,time)$( map_period(year_all2,year_all) )
-            = ACT.l(node,tec,year_all2,year_all,mode,time) ;
-        CAP_NEW_UP.fx(node,tec,year_all) = CAP_NEW_UP.l(node,tec,year_all) ;
-        CAP_NEW_LO.fx(node,tec,year_all) = CAP_NEW_LO.l(node,tec,year_all) ;
-        ACT_UP.fx(node,tec,year_all,time) = ACT_UP.l(node,tec,year_all,time) ;
-        ACT_LO.fx(node,tec,year_all,time) = ACT_LO.l(node,tec,year_all,time) ;
+* Lock the current iteration period's variables for subsequent iterations. A narrow
+* tolerance band (.l +/- rd_fix_tol) is used instead of a hard .fx: pinning a variable
+* to the solver's bit-exact level can leave an equation violated by rounding (~1e-15),
+* which GAMS rejects as "infeasible due to rhs value" once every variable in it is
+* fixed. The band keeps a free variable in each equation while holding the decision
+* sunk to within rd_fix_tol.
+* NB CAP and ACT are indexed (year_vtg, year_act); the .l on the right must use the
+* same index order as the left.
+        EXT.up(node,commodity,grade,year_all) = EXT.l(node,commodity,grade,year_all) + %rd_fix_tol% ;
+        EXT.lo(node,commodity,grade,year_all) = max(0, EXT.l(node,commodity,grade,year_all) - %rd_fix_tol%) ;
+        CAP_NEW.up(node,tec,year_all) = CAP_NEW.l(node,tec,year_all) + %rd_fix_tol% ;
+        CAP_NEW.lo(node,tec,year_all) = max(0, CAP_NEW.l(node,tec,year_all) - %rd_fix_tol%) ;
+        CAP.up(node,tec,year_all2,year_all)$( map_period(year_all2,year_all) ) = CAP.l(node,tec,year_all2,year_all) + %rd_fix_tol% ;
+        CAP.lo(node,tec,year_all2,year_all)$( map_period(year_all2,year_all) ) = max(0, CAP.l(node,tec,year_all2,year_all) - %rd_fix_tol%) ;
+        ACT.up(node,tec,year_all2,year_all,mode,time)$( map_period(year_all2,year_all) ) = ACT.l(node,tec,year_all2,year_all,mode,time) + %rd_fix_tol% ;
+        ACT.lo(node,tec,year_all2,year_all,mode,time)$( map_period(year_all2,year_all) ) = max(0, ACT.l(node,tec,year_all2,year_all,mode,time) - %rd_fix_tol%) ;
+        CAP_NEW_UP.up(node,tec,year_all) = CAP_NEW_UP.l(node,tec,year_all) + %rd_fix_tol% ;
+        CAP_NEW_UP.lo(node,tec,year_all) = max(0, CAP_NEW_UP.l(node,tec,year_all) - %rd_fix_tol%) ;
+        CAP_NEW_LO.up(node,tec,year_all) = CAP_NEW_LO.l(node,tec,year_all) + %rd_fix_tol% ;
+        CAP_NEW_LO.lo(node,tec,year_all) = max(0, CAP_NEW_LO.l(node,tec,year_all) - %rd_fix_tol%) ;
+        ACT_UP.up(node,tec,year_all,time) = ACT_UP.l(node,tec,year_all,time) + %rd_fix_tol% ;
+        ACT_UP.lo(node,tec,year_all,time) = max(0, ACT_UP.l(node,tec,year_all,time) - %rd_fix_tol%) ;
+        ACT_LO.up(node,tec,year_all,time) = ACT_LO.l(node,tec,year_all,time) + %rd_fix_tol% ;
+        ACT_LO.lo(node,tec,year_all,time) = max(0, ACT_LO.l(node,tec,year_all,time) - %rd_fix_tol%) ;
 
     ) ; # end of the recursive-dynamic loop
 

--- a/message_ix/tests/test_feature_recursive_dynamic.py
+++ b/message_ix/tests/test_feature_recursive_dynamic.py
@@ -1,0 +1,59 @@
+"""Tests for recursive-dynamic (myopic / rolling-horizon) solve mode.
+
+The mode is selected with the ``foresight`` keyword: ``0`` is perfect foresight,
+``1`` is myopic, and a value ``> 1`` is a rolling horizon with that many years of
+look-ahead.
+"""
+
+import numpy as np
+import pytest
+from ixmp import Platform
+
+from message_ix.testing import make_westeros
+
+pytestmark = pytest.mark.ixmp4_209
+
+
+@pytest.mark.parametrize("foresight", [1, 15, 30])
+def test_objective_vs_perfect_foresight(
+    request: pytest.FixtureRequest, test_mp: Platform, foresight: int
+) -> None:
+    """RD objective is bounded by perfect foresight; equal at full lookahead.
+
+    Because the active ``year`` set accumulates across iterations and ``OBJECTIVE``
+    sums over ``year``, the final ``OBJ`` is the full-horizon cost with earlier
+    periods at their fixed values. Limited foresight can never beat perfect
+    foresight, and when ``foresight`` spans the model horizon (> 20 years for
+    :func:`.make_westeros`) the first iteration solves the full intertemporal problem
+    so the two objectives match.
+    """
+    pf = make_westeros(test_mp, solve=True, request=request)
+
+    rolling = pf.clone(keep_solution=False)
+    rolling.solve(foresight=foresight, quiet=True)
+
+    obj_pf = pf.var("OBJ")["lvl"]
+    obj_rd = rolling.var("OBJ")["lvl"]
+
+    # Limited foresight cannot beat perfect foresight (prior decisions are pinned
+    # within the tolerance band).
+    assert obj_rd + 1e-6 * abs(obj_pf) >= obj_pf
+
+    # Foresight spanning the horizon reproduces perfect foresight exactly.
+    if foresight > 20:  # horizon span of make_westeros (firstmodelyear 700 .. 720)
+        assert np.isclose(obj_pf, obj_rd)
+
+
+def test_foresight_keyword_matches_gams_args(
+    request: pytest.FixtureRequest, test_mp: Platform
+) -> None:
+    """``solve(foresight=N)`` matches ``gams_args=["--foresight=N"]``."""
+    base = make_westeros(test_mp, request=request)
+
+    via_keyword = base.clone(keep_solution=False)
+    via_keyword.solve(foresight=20, quiet=True)
+
+    via_gams_args = base.clone(keep_solution=False)
+    via_gams_args.solve(gams_args=["--foresight=20"], quiet=True)
+
+    assert np.isclose(via_keyword.var("OBJ")["lvl"], via_gams_args.var("OBJ")["lvl"])


### PR DESCRIPTION
<!--

Delete each of these instruction comments as you complete it.

Title: use a short, declarative statement similar to a commit message,
e.g. “Change [thing X] to [fix solve bug|enable feature Y]”

-->

This PR partially addresses #1016 by adding a test for recursive dynamic mode, adding a QoL keyword `foresight` keyword to `Scenario.solve` for recursive-dynamic (myopic /
rolling-horizon) mode, and corrects two issues in how prior-period variables are fixed
between iterations of the GAMS solve loop.


This PR re-implements some of the changes made in https://github.com/iiasa/message_ix/tree/project/cdrs_genie-uptake-cdirect, such as prior period variable fixing.

Testing on a contemporary SSP2 baseline scenario reveals issues, for example the model exhausts resource bounds in early periods under recursive dynamic mode. To make it usable some form of anticipation rules need to be implemented for inter-temporal constraints.  

## How to review

Review changes `model_solve.gms`, all changes are in the `else` branch. 

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
  <!--
  The following items are all *required* if the PR results in changes to user-
  facing behaviour, e.g. new features or fixes to existing behaviour. They are
  *optional* if the changes are solely to documentation, CI configuration, etc.

  In ambiguous cases, strike them out and add a short explanation, e.g.

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
