### PR TITLE
Fix aggregation of subannual demand in the MESSAGE-MACRO iteration

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -22,7 +22,7 @@ Adjust any imports like the following:
 All changes
 -----------
 
-- Correct MESSAGE-MACRO aggregation of subannual demand (:pull:`NNNN`).
+- Correct MESSAGE-MACRO aggregation of subannual demand (:pull:`1027`).
 
 - :mod:`message_ix` is tested and compatible with `Python 3.14 <https://www.python.org/downloads/release/python-3140/>`__ (:pull:`985`).
 - Support for Python 3.9 is dropped (:pull:`985`), as it has reached end-of-life.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -22,6 +22,8 @@ Adjust any imports like the following:
 All changes
 -----------
 
+- Correct MESSAGE-MACRO aggregation of subannual demand (:pull:`NNNN`).
+
 - :mod:`message_ix` is tested and compatible with `Python 3.14 <https://www.python.org/downloads/release/python-3140/>`__ (:pull:`985`).
 - Support for Python 3.9 is dropped (:pull:`985`), as it has reached end-of-life.
 - :mod:`message_ix` is tested and compatible with `Pandas 3.0.0 <https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html>`_,

--- a/message_ix/model/MESSAGE-MACRO_run.gms
+++ b/message_ix/model/MESSAGE-MACRO_run.gms
@@ -146,14 +146,16 @@ year(year_all)$( model_horizon(year_all) ) = yes ;
 year(year_all)$( macro_base_period(year_all) ) = yes ;
 
 * useful energy/service demand levels from MESSAGE get mapped onto MACRO sector structure
+* (DEMAND and demand_fixed are slice-cumulative quantities, so the annual total is a plain sum over `time`)
 enestart(node_macro,sector,year) = SUM((commodity, level, time) $ mapping_macro_sector(sector, commodity, level),
-                                 DEMAND.L(node_macro,commodity,level,year,time) * duration_time(time) ) / 1000
+                                 DEMAND.L(node_macro,commodity,level,year,time) ) / 1000
 ;
 
 demand_init(node_macro,sector,year) = SUM((commodity, level, time)$mapping_macro_sector(sector, commodity, level),
     demand_fixed(node_macro,commodity,level,year,time) ) ;
 
 * useful energy/service demand prices from MESSAGE get mapped onto MACRO sector structure
+* (PRICE_COMMODITY is a per-unit price, so the annual price is its duration_time-weighted mean over `time`)
 
 * Replace EPS values with 0
 PRICE_COMMODITY.L(node_macro,commodity,level,year,time)$(
@@ -202,10 +204,11 @@ demand_diff_rel(iteration,node_macro,sector,year) $(NOT macro_base_period(year))
     demand_diff_abs(iteration,node_macro,sector,year) / demand_init(node_macro,sector,year) ;
 
 * compute the relative difference between the previous demand and the updated demand from MACRO
+* (plain sum over `time`, following the slice-cumulative convention of demand_fixed)
 demand_scale(node_macro,sector,year)$(NOT macro_base_period(year)) =
     demand_new(node_macro,sector,year)
         / SUM((commodity, level, time) $ mapping_macro_sector(sector, commodity, level),
-            demand_fixed(node_macro,commodity,level,year,time) * duration_time(time) ) ;
+            demand_fixed(node_macro,commodity,level,year,time) ) ;
 
 * limit MACRO demand scaling to relative the maximum adjustment level (defined using SETGLOBAL from command line)
 demand_scale(node_macro,sector,year)$(NOT macro_base_period(year)) =

--- a/message_ix/tests/test_macro.py
+++ b/message_ix/tests/test_macro.py
@@ -434,3 +434,81 @@ def test_sector_map(westeros_solved: Scenario, w_data: dict[str, pd.DataFrame]) 
         w_data[table] = w_data[table].replace({"sector": {"light": "FOO"}})
 
     westeros_solved.add_macro(w_data, check_convergence=True)
+
+
+@pytest.mark.parametrize("shares", [(0.5, 0.5), (0.3, 0.7)])
+def test_solve_subannual(
+    westeros_solved: Scenario, w_data_path: Path, shares: tuple[float, float]
+) -> None:
+    """MESSAGE-MACRO on a subannual scenario reproduces its annual equivalent.
+
+    The MESSAGE-MACRO iteration aggregates the ``time`` dimension of MESSAGE
+    quantities with two distinct conventions: ``DEMAND`` and ``demand_fixed``
+    are slice-cumulative, so their annual total is a plain sum over ``time``,
+    whereas ``PRICE_COMMODITY`` is a per-unit price, so its annual value is a
+    ``duration_time``-weighted mean. To check both, an annual scenario is
+    compared with a clone whose ``light`` demand is split into two time slices
+    such that the resulting LP is exactly equivalent to the annual one: GDP,
+    annually-summed demand, and annualized prices must match.
+    """
+    annual = westeros_solved.add_macro(w_data_path, check_convergence=False)
+    subannual = annual.clone(
+        scenario=f"{annual.scenario} subannual", keep_solution=False
+    )
+
+    with subannual.transact("Split light demand into two time slices"):
+        subannual.add_set("lvl_temporal", "season")
+
+        demand = subannual.par("demand", filters={"commodity": "light"})
+        subannual.remove_par("demand", demand)
+        output = subannual.par("output", filters={"technology": "bulb"})
+        subannual.remove_par("output", output)
+
+        # Each slice receives demand proportional to its duration, served
+        # through `output` of the (still annual) `bulb` activity scaled by the
+        # same share, so every slice constraint is the annual constraint
+        # rescaled and the subannual LP has the same solution as the annual
+        # one.
+        for time, share in zip(("h1", "h2"), shares):
+            subannual.add_set("time", time)
+            subannual.add_set("map_temporal_hierarchy", ["season", time, "year"])
+            subannual.add_par("duration_time", [time], share, "-")
+            subannual.add_par(
+                "demand", demand.assign(time=time, value=demand["value"] * share)
+            )
+            subannual.add_par(
+                "output",
+                output.assign(time_dest=time, value=output["value"] * share),
+            )
+
+    solve_args: dict[str, Any] = dict(model="MESSAGE-MACRO", quiet=True)
+    annual.solve(**solve_args)
+    subannual.solve(**solve_args)
+
+    npt.assert_allclose(
+        annual.var("GDP")["lvl"].values,
+        subannual.var("GDP")["lvl"].values,
+        rtol=1e-6,
+    )
+
+    def annual_light_demand(scenario: Scenario) -> np.ndarray:
+        demand = scenario.var("DEMAND", filters={"commodity": "light"})
+        return demand.groupby("year")["lvl"].sum().to_numpy()
+
+    npt.assert_allclose(
+        annual_light_demand(annual),
+        annual_light_demand(subannual),
+        rtol=1e-6,
+    )
+
+    def annual_light_price(scenario: Scenario) -> np.ndarray:
+        price = scenario.var("PRICE_COMMODITY", filters={"commodity": "light"})
+        duration = scenario.par("duration_time").set_index("time")["value"]
+        weighted = price["lvl"] * price["time"].map(duration)
+        return weighted.groupby(price["year"]).sum().to_numpy()
+
+    npt.assert_allclose(
+        annual_light_price(annual),
+        annual_light_price(subannual),
+        rtol=1e-6,
+    )


### PR DESCRIPTION
Remove the spurious `duration_time` weighting from the two annual aggregations of subannual demand in the MESSAGE-MACRO iteration, which made coupled runs diverge on any scenario with subannual `time` resolution in a MACRO-mapped commodity.

`DEMAND.L` and `demand_fixed` are slice-cumulative quantities: the annual total is the plain sum over `time`, as `demand_init` already computes. Weighting them by `duration_time` in `enestart` and in the `demand_scale` denominator under-counted every subannual MACRO-mapped sector by its slice duration, so MACRO scaled those sectors up against the `MAX_ADJUSTMENT` cap each iteration and the coupled run diverged. Annual scenarios are unaffected (`duration_time('year') = 1`). The price aggregation `eneprice` is correct as-is, since `PRICE_COMMODITY` is a per-unit price; comments documenting both conventions are added.

## How to review

- Check the two changed aggregations now match the convention `demand_init` already uses, and that the duration-weighted `eneprice` is untouched.
- Run `pytest message_ix/tests/test_macro.py::test_solve_subannual`: it compares an annual Westeros MESSAGE-MACRO scenario with an LP-equivalent subannual clone over uniform and non-uniform slice durations, asserting GDP, annual demand, and annual prices match. Both parametrizations fail without the GAMS change.

## PR checklist

- [ ] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
