### PR TITLE
CI fixes for 2026-W32

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -1,5 +1,4 @@
 # Verify that installation from conda-forge works as intended
-
 name: Install from conda-forge
 
 on:
@@ -19,46 +18,24 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        conda:
-        - {installer: anaconda, version: 2024.06-1}
-        - {installer: miniconda, version: py312_24.7.1-0}
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}-${{ matrix.conda.installer }}
+    name: ${{ matrix.os }}
+
+    # As suggested by conda-incubator/setup-miniconda
+    defaults:
+      run:
+        shell: bash -el {0}
 
     steps:
-    - name: Cache Anaconda installer, conda packages
-      uses: actions/cache@v6
-      with:
-        path: |
-          $CONDA/pkgs
-          ~/.conda/pkgs
-          ~/anaconda3/pkgs
-          ~/appdata/local/conda/conda/pkgs
-          ${{ github.workspace }}/Anaconda*.exe
-        key: ${{ matrix.os }}-${{ matrix.conda.installer }}
-
     - name: Setup Anaconda or miniconda
-      uses: iiasa/actions/setup-conda@main
+      uses: conda-incubator/setup-miniconda@v4
       with:
-        installer: ${{ matrix.conda.installer }}
-        version: ${{ matrix.conda.version }}
-
-    # TODO move the following 2 steps into the above action
-    - name: Determine shell on current OS
-      id: shell
-      run: |
-        import os
-        init, profile = {
-            "macos": ("bash", "source ~/.bash_profile"),
-            "windows": ("powershell", ""),
-        }.get("${{ matrix.os }}".split("-")[0])
-
-        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-            f.write(f"init={init}\n")
-            f.write(f"profile={profile}\n")
-      shell: python
+        activate-environment: testenv
+        channel-priority: strict
+        channels: conda-forge
+        python-version: "3.14"
 
     - name: Cache GAMS installer
       uses: actions/cache@v6
@@ -74,39 +51,18 @@ jobs:
         version: ${{ env.GAMS_VERSION }}
         license: ${{ secrets.GAMS_LICENSE }}
 
-    - name: Initialize shell for "conda activate"
-      run: conda init ${{ steps.shell.outputs.init }}
-
-    - name: Configure conda channels, update, create environment, and install message-ix
+    - name: Install message-ix into 'testenv' conda environment
+      # Also install pytest and packages required for testing. pip and related
+      # tools support this via message_ix[testing], but conda does not.
       run: |
-        conda install -n base conda-libmamba-solver
-        conda config --set solver libmamba
-        conda config --prepend channels conda-forge
-        conda config --set channel_priority strict
-        conda update -n base -c defaults conda
-
-        # Also install pytest and packages required for testing. pip/PyPI
-        # supports this via message_ix[testing], but conda does not.
-        # Pin Python version to enable pyam versions relied on by the sankey tool;
-        # remove once pyam supports the latest Python
-        conda create --quiet --name testenv message-ix pytest asyncssh sphinx python=3.12
-        conda list --name testenv
-
-    - name: Check CLI commands and run test
-      run: |
-        # Source profile. On non-windows OSes, GHA invokes bash with
-        # "--noprofile", so the file written by "conda init bash" above is not
-        # read automatically
-        ${{ steps.shell.outputs.profile }}
-
-        # Activate the test environment
-        conda activate testenv
+        conda install message-ix pytest asyncssh sphinx
+        conda list
         conda info
 
-        # Check CLI tools
+    - name: Check message-ix and ixmp CLIs
+      run: |
         message-ix show-versions
         ixmp --platform default list || true
 
-        # Run a single test from the test suite to touch JDBCBackend Java code,
-        # via JPype
-        pytest --pyargs message_ix -p ixmp.testing -p message_ix.testing -p no:faulthandler -k "test_add_cat" --verbose -rA --color=yes
+    - name: Run a test from the test suite to touch JDBCBackend/Java via JPype
+      run: pytest --pyargs message_ix -p ixmp.testing -p message_ix.testing -p no:faulthandler -k "test_add_cat" --verbose -rA --color=yes

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -12,7 +12,7 @@ on:
 
 env:
   # Oldest version that can reliably be downloaded
-  GAMS_VERSION: 48.6.1
+  GAMS_VERSION: 48.7.0
 
 jobs:
   conda:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ env:
   # Version used until 2024-11-20; disabled
   # gams-version: 29.1.0
   # Oldest version that can reliably be downloaded
-  gams-version: 48.6.1
+  gams-version: 48.7.0
   os: ubuntu-latest
   python-version: "3.14"
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -79,11 +79,14 @@ jobs:
 
         # - "3.15.0-alpha.1"  # Development version
 
-        include:
-        - os: ubuntu-latest
-          python-version: "3.14"
-          extra-deps: '"pandas >= 3"'
-          extra-name: "-pandas-3"
+        # Additional matrix jobs for particular cases
+        # include:
+        # Force pandas >= 3 if upstream dependencies exclude it
+        # commented (2026-08-04): Not currently needed
+        # - os: ubuntu-latest
+        #   python-version: "3.14"
+        #   extra-deps: '"pandas >= 3"'
+        #   extra-name: "-pandas-3"
 
       fail-fast: false
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,7 +21,7 @@ defaults:
     shell: bash
 
 env:
-  GAMS_VERSION: 48.6.1 # Oldest version of GAMS that can reliably be downloaded
+  GAMS_VERSION: 48.7.0 # Oldest version of GAMS that can reliably be downloaded
   depth: 100  # Must be large enough to include the most recent release
   label: "safe to test"  # Label that must be applied to run on PRs from forks
   python-version: "3.14"  # For non-matrixed jobs


### PR DESCRIPTION
This PR collects updates to CI workflows to address recent failures:

1. Bump GAMS from 48.6.1 to 48.7.0. Between 2026-07-26 ([here](https://github.com/iiasa/message_ix/actions/runs/30190340200/job/89762365753#step:8:93)) and 2026-07-27 ([here](https://github.com/iiasa/message_ix/actions/runs/30241795099/job/89900428500#step:8:84)) the former was unpublished. Version 48.7.0 is the same used in iiasa/ixmp#645.
2. Switch from [`iiasa/actions/setup-conda`](https://github.com/iiasa/actions/tree/main/setup-conda) to [`conda-incubator/setup-miniconda`](https://github.com/conda-incubator/setup-miniconda). The latter is actively maintained by a third party, has a larger feature set and better documentation, and allows to simplify the workflow.
   - This addresses failures in the "conda" workflow / `windows-latest-*` jobs, which began between 2026-06-18 ([here](https://github.com/iiasa/message_ix/actions/runs/27741270496/job/82068799524#step:8:1)) and 2026-06-19 ([here](https://github.com/iiasa/message_ix/actions/runs/27810017160/job/82297987774#step:8:19)) with the message:
     ```
     usage: conda-script.py [-h] [-v] [--no-plugins] [-V] COMMAND ...
     conda-script.py: error: argument COMMAND: invalid choice: '' (choose from 'activate', 'deactivate', 'clean', 'compare', 'config', 'create', 'env', 'export', 'info', 'init', 'install', 'list', 'notices', 'package', 'remove', 'uninstall', 'rename', 'run', 'search', 'update', 'upgrade', 'build', 'content-trust', 'convert', 'debug', 'develop', 'doctor', 'index', 'inspect', 'metapackage', 'render', 'repoquery', 'skeleton', 'server', 'repo', 'token', 'pack')
     Invoke-Expression: Cannot bind argument to parameter 'Command' because it is an empty string.
     ```
   - As part of this change, only the latest/current Miniconda and Python 3.14 is tested. Since our install instructions now recommend uv or pip over *conda, it is less critical to test these
   - [Here](https://github.com/iiasa/message_ix/actions/runs/30834787965/job/91757201675?pr=1030) is a successful workflow run with the changes on the PR branch.
3. Confirm that #969 is no longer occurring; see [here](https://github.com/iiasa/message_ix/actions/runs/30890846287/job/91932282144?pr=1030).
4. Partly revert #1001.

## How to review

Read the diff and note that the CI checks all pass in [this](https://github.com/iiasa/message_ix/actions/runs/30890846566) pytest workflow run.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update release notes.~ N/A
