### PR TITLE
Address failures of macOS tutorial CI jobs

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -227,7 +227,7 @@ jobs:
         IRkernel::installspec()
       shell: Rscript {0}
 
-    - name: Run test suite using pytest
+    - name: Run tutorial tests using pytest
       run: |
         pytest message_ix \
           -m "tutorial" \

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -218,6 +218,10 @@ jobs:
         version: ${{ env.GAMS_VERSION }}
         license: ${{ secrets.GAMS_LICENSE }}
 
+    - uses: ikalnytskyi/action-setup-postgres@v8
+      id: setup-postgres
+      with: { postgres-version: "16" }
+
     - name: Install the package and dependencies
       run: uv pip install --upgrade ${{ env.upstream-versions }} .[tests]
 
@@ -233,7 +237,8 @@ jobs:
           -m "tutorial" \
           --color=yes --durations=20 -rA --verbose \
           --cov-report=xml \
-          --numprocesses=auto --dist=loadgroup
+          --numprocesses=auto --dist=loadgroup \
+          --ixmp-postgres=${{ steps.setup-postgres.outputs.connection-uri }}
 
     - name: Upload test coverage to Codecov.io
       uses: codecov/codecov-action@v7

--- a/message_ix/testing/__init__.py
+++ b/message_ix/testing/__init__.py
@@ -1041,12 +1041,6 @@ def tmp_scenario(
 
 
 @pytest.fixture(scope="session")
-def tutorial_path(request: pytest.FixtureRequest) -> Path:
-    """Path to the directory containing the tutorials."""
-    return Path(__file__).parents[2] / "tutorial"
-
-
-@pytest.fixture(scope="session")
 def ureg() -> Iterator["UnitRegistry"]:
     """Session-scoped :class:`pint.UnitRegistry` with units needed by tests."""
     import pint

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -1,7 +1,8 @@
 import logging
 import os
 import sys
-from collections.abc import Generator
+from dataclasses import dataclass, field
+from importlib.resources import files
 from pathlib import Path
 from shutil import copyfile
 from typing import Any
@@ -17,23 +18,7 @@ from message_ix.tests.test_report import MISSING_IXMP4
 
 log = logging.getLogger(__name__)
 
-# Shorthands for tutorial directories/file names.
-AT = "Austrian_energy_system"
-W = "westeros"
-
-# Common marks for some test cases
-MARK = [
-    pytest.mark.skipif(  # 0
-        condition=GHA and sys.platform == "linux",
-        reason="IR kernel times out on GitHub Actions Ubuntu runners",
-    ),
-    pytest.mark.xfail(  # 1
-        condition=GHA and sys.platform == "darwin",
-        reason="Always fails on GitHub Action macOS runners",
-    ),
-]
-
-# Affects all tests in the file
+#: Marks for all tests in this module.
 pytestmark = [
     pytest.mark.tutorial,
     pytest.mark.flaky(
@@ -44,164 +29,172 @@ pytestmark = [
     ),
 ]
 
+#: Mapping from tutorial base name to data files to be copied into the temporary dir.
+DATA_FILES = {
+    "westeros_baseline_using_xlsx_import_part2.ipynb": (
+        "westeros_baseline_demand.xlsx",
+        "westeros_baseline_technology_basic.xlsx",
+        "westeros_baseline_technology_constraint.xlsx",
+        "westeros_baseline_technology_economic.xlsx",
+        "westeros_baseline_technology_historic.xlsx",
+    ),
+}
 
-# NOTE Pytest.param returns ParamSet, which is private and hard to type hint
-def _t(
-    group: str | None,
-    basename: str,
-    *,
-    check: list[tuple] | None = None,
-    marks: list[pytest.MarkDecorator] | None = None,
-) -> tuple:
-    """Shorthand for defining tutorial test cases.
+#: Path to the directory containing tutorials.
+TUTORIAL_DIR = Path(files(__name__.partition(".")[0])).with_name("tutorial")  # type: ignore[arg-type]
 
-    Parameters
-    ----------
-    basename : str
-       Base of the file name (without extension).
-    group : str, optional
-       Group ID. When pytest-xdist is used, tests in the same group are run in sequence
-       on the same worker. If one tutorial depends on contents in the temporary test
-       database produced by another tutorial, they should be in the same group.
-    check : list of tuple, optional
-       Each tuple consists of:
-
-       1. Name or index of cell whose output will contain a certain value, e.g. the
-          MESSAGE objective function value. This cell's output is retrieved and passed
-          as the first positional argument (`actual`) to
-          :func:`numpy.testing.assert_allclose`.
-       2. Further positional arguments to :func:`numpy.testing.assert_allclose`:
-          `desired`, `rtol`, `atol`, etc.
-    marks : list, optional
-       Any pytest marks applicable to the test.
-    """
-    # Determine the directory containing the notebook
-    dir_ = W if basename.startswith(f"{W}_") else AT
-
-    marks = marks or []
-    if group:
-        # Mark the test as belonging to an xdist group
-        marks.append(pytest.mark.xdist_group(name=group))
-
-    return pytest.param((dir_, basename), check or [], marks=marks)
+#: Parameters to :func:`test_tutorial`. This is populated using the shorthand functions
+#: below.
+TUTORIALS: list[tuple] = []
 
 
-#: Argument values to parametrize :func:`test_tutorial`.
-TUTORIALS: list[tuple] = [
-    # IPython kernel
-    _t("w0", f"{W}_baseline", check=[("solve-objective-value", 159025.82812)]),
-    # NB could also check objective function values in the following tutorials; however,
-    #    better to test features directly (not via Jupyter/IPython)
-    _t("w0", f"{W}_baseline_using_xlsx_import_part1"),
-    _t("w0", f"{W}_baseline_using_xlsx_import_part2"),
-    _t("w0", f"{W}_emissions_bounds"),
-    _t("w0", f"{W}_emissions_taxes"),  ###
-    _t("w0", f"{W}_firm_capacity"),  ###
-    _t("w0", f"{W}_flexible_generation"),  ###
-    _t("w0", f"{W}_fossil_resource"),
-    _t("w0", f"{W}_share_constraint"),
-    _t("w0", f"{W}_soft_constraints"),  ###
-    _t("w0", f"{W}_addon_technologies"),
-    _t("w0", f"{W}_historical_new_capacity"),
-    _t("w0", f"{W}_multinode_energy_trade"),
-    _t("w0", f"{W}_sankey"),
-    # NB This is the same count as in test_report.test_reporter_from_scenario.
-    #    Using len(MISSING_IXMP4) for atol allows the test to pass when the value is
-    #    N - 8.
-    _t(None, f"{W}_report", check=[("len-rep-graph", 28764, 1e-7, len(MISSING_IXMP4))]),
-    _t("at0", "austria", check=[("solve-objective-value", 206321.90625)]),
-    _t(
-        "at0", "austria_single_policy", check=[("solve-objective-value", 205310.34375)]
-    ),  ###
-    _t("at0", "austria_multiple_policies"),
-    _t("at0", "austria_multiple_policies-answers"),
-    _t("at0", "austria_load_scenario"),
-    # R tutorials using the IR Jupyter kernel
-    _t("at1", "R_austria", marks=[MARK[0], MARK[1]]),
-    _t("at1", "R_austria_load_scenario", marks=[MARK[0], MARK[1]]),
-]
+@dataclass
+class Tutorial:
+    """A test case for a single tutorial notebook."""
 
-# Short, readable IDs for the tests. Use getattr() to unpack the values from
-# pytest.param()
-IDS = [getattr(arg, "values", arg)[0][-1] for arg in TUTORIALS]
+    #: Relative path to the notebook file. This path is resolved within
+    #: :data:`TUTORIAL_DIR`.
+    path: Path = field(default_factory=Path)
 
-#: List of data files required by "westeros_baseline_using_xlsx_import_part2".
-DATA_FILES = [
-    "westeros_baseline_demand.xlsx",
-    "westeros_baseline_technology_basic.xlsx",
-    "westeros_baseline_technology_constraint.xlsx",
-    "westeros_baseline_technology_economic.xlsx",
-    "westeros_baseline_technology_historic.xlsx",
-]
+    #: Group ID. When pytest-xdist is used, tests in the same group are run in sequence
+    #: on the same worker. If one tutorial depends on contents in the temporary test
+    #: database produced by another tutorial, they should be in the same group.
+    group: str | None = None
+
+    #: Each tuple consists of:
+    #:
+    #: 1. Name or index of cell whose output will contain a certain value, e.g. the
+    #:    MESSAGE objective function value. This cell's output is retrieved and passed
+    #:    as the first positional argument (`actual`) to
+    #:    :func:`numpy.testing.assert_allclose`.
+    #: 2. Further positional arguments to :func:`numpy.testing.assert_allclose`:
+    #:    `desired`, `rtol`, `atol`, etc.
+    check: list[tuple] = field(default_factory=list)
+
+    #: Any :mod:`pytest` marks applicable to the test.
+    marks: list[pytest.MarkDecorator] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.path = TUTORIAL_DIR.joinpath(self.path).with_suffix(".ipynb")
+
+        if self.group:
+            # Mark the test as belonging to an xdist group
+            self.marks.append(pytest.mark.xdist_group(name=self.group))
+
+        TUTORIALS.append(pytest.param(self, marks=self.marks))
+
+    @property
+    def args(self) -> dict[str, Any]:
+        """Keyword arguments to :func:`.run_notebook`."""
+        result: dict[str, Any] = {}
+        if self.path.name.startswith("R_"):
+            result["kernel_name"] = "IR"  # Use a different kernel for R notebooks
+        return result
 
 
-@pytest.fixture
-def nb_path(
-    request: pytest.FixtureRequest, tutorial_path: Path
-) -> Generator[Path, Any, None]:
-    """Prepare the `nb_path` fixture to `test_tutorial`."""
-    # Combine the filename parts with the tutorial_path fixture
-    yield tutorial_path.joinpath(*request.param).with_suffix(".ipynb")
+def W(basename, **kwargs) -> None:
+    """Shorthand for Westeros tutorials."""
+    kwargs.setdefault("group", "w0")
+    Tutorial(Path("westeros", f"westeros_{basename}"), **kwargs)
 
 
-def default_args() -> dict[str, int | str]:
-    """Default arguments for :func:`.run_notebook."""
-    if GHA:
-        # Use a longer timeout
-        return dict(timeout=30)
-    else:
-        return dict()
+W("baseline", check=[("solve-objective-value", 159025.82812)])
+# NB could also check objective function values in the following tutorials; however,
+#    better to test features directly (not via Jupyter/IPython).
+W("baseline_using_xlsx_import_part1")
+W("baseline_using_xlsx_import_part2")
+W("emissions_bounds")
+W("emissions_taxes")
+W("firm_capacity")
+W("flexible_generation")
+W("fossil_resource")
+W("share_constraint")
+W("soft_constraints")
+W("addon_technologies")
+W("historical_new_capacity")
+W("multinode_energy_trade")
+W("sankey")
+
+# NB This is the same count as in test_report.test_reporter_from_scenario. Using
+#    len(MISSING_IXMP4) for atol allows the test to pass when the value is N - 8.
+W("report", group=None, check=[("len-rep-graph", 28764, 1e-7, len(MISSING_IXMP4))])
 
 
-# Parametrize the first 3 arguments using the variables *TUTORIALS* and *IDS*.
-# Argument 'nb_path' is indirect so that the above function can modify it.
-@pytest.mark.parametrize("nb_path, checks", TUTORIALS, ids=IDS, indirect=["nb_path"])
+def AT(basename, **kwargs) -> None:
+    """Shorthand for Austria tutorials."""
+    kwargs.update(group="at0")
+    Tutorial(Path("Austrian_energy_system", f"austria{basename}"), **kwargs)
+
+
+AT("", check=[("solve-objective-value", 206321.90625)])
+AT("_single_policy", check=[("solve-objective-value", 205310.34375)])
+AT("_multiple_policies")
+AT("_multiple_policies-answers")
+AT("_load_scenario")
+
+
+def AT_R(basename) -> None:
+    """Shorthand for R tutorials using the IR kernel."""
+    Tutorial(
+        Path("Austrian_energy_system", f"R_austria{basename}"),
+        group="at1",
+        marks=[
+            pytest.mark.skipif(
+                condition=sys.platform == "linux", reason="IR kernel times out on Linux"
+            )
+        ],
+    )
+
+
+AT_R("")
+AT_R("_load_scenario")
+
+
 @pytest.mark.parametrize("ixmp_backend", ixmp.backend.available())
+@pytest.mark.parametrize("tutorial", TUTORIALS, ids=lambda t: t.path.stem)
 def test_tutorial(
     caplog: pytest.LogCaptureFixture,
-    nb_path: Path,
-    checks: list[tuple],
     tmp_path: Path,
     tmp_env: os._Environ[str],
+    tutorial_path: Path,
     ixmp_backend: str,
+    tutorial: Tutorial,
 ) -> None:
-    """Test tutorial in the IPython or IR notebook at `nb_path`.
+    """Test the IPython or IR notebook in `tutorial`.
 
-    If `checks` are given, values in the specified cells are tested.
+    If :attr:`Tutorial.check` has entries, values in the specified cells are tested.
     """
     caplog.set_level(logging.INFO, "traitlets")
     tmp_env.update(PYDEVD_DISABLE_FILE_VALIDATION="1")
 
-    if nb_path.name == "westeros_baseline_using_xlsx_import_part2.ipynb":
-        # Copy data files used by this tutorial to `tmp_path`
-        for name in DATA_FILES:
-            copyfile(nb_path.parent / name, tmp_path / name)
+    # Copy any data files used by this tutorial to `tmp_path`
+    for name in DATA_FILES.get(tutorial.path.name, ()):
+        copyfile(tutorial.path.parent / name, tmp_path / name)
 
-    # Determine arguments for run_notebook()
-    args = default_args()
-    if nb_path.name.startswith("R_"):
-        args.update(kernel_name="IR")
-
-    # Set the "default" platform to be either the platform named "local" or
-    # "ixmp4-local", according to the ixmp_backend parameter
-    p = {"jdbc": "local", "ixmp4": "ixmp4-local"}[ixmp_backend]
+    # Arguments for run_notebook()
+    # - Set the "default" platform to be either the platform named "local" or
+    #   "ixmp4-local", according to the ixmp_backend parameter
+    args = tutorial.args | dict(
+        default_platform={"jdbc": "local", "ixmp4": "ixmp4-local"}[ixmp_backend]
+    )
 
     # The notebook can be run without errors
     try:
-        nb, errors = run_notebook(
-            nb_path, tmp_path, tmp_env, default_platform=p, **args
-        )
+        nb, errors = run_notebook(tutorial.path, tmp_path, tmp_env, **args)
     except (CellExecutionError, CellTimeoutError) as e:
         if ixmp_backend == "ixmp4":
             # Show errors but make these non-fatal. We do this because it is complicated
             # to apply an XFAIL mark that is conditional on the value of `ixmp_backend`.
             log.error(f"with IXMP4Backend:\n{e!r}")
             return
-        else:
-            raise
+        elif GHA and sys.platform == "darwin" and ixmp_backend == "jdbc":
+            # All tests with JDBCBackend time out on macOS runners
+            log.error(f"with JDBCBackend on macOS: {e}")
+            return
+        raise  # all other exceptions
 
     assert errors == []
 
     # Cell(s) identified by name or index have a particular value
-    for cell, *check_args in checks:
+    for cell, *check_args in tutorial.check:
         npt.assert_allclose(get_cell_output(nb, cell), *check_args)

--- a/message_ix/tests/test_tutorials.py
+++ b/message_ix/tests/test_tutorials.py
@@ -37,7 +37,7 @@ MARK = [
 pytestmark = [
     pytest.mark.tutorial,
     pytest.mark.flaky(
-        reruns=5,
+        reruns=2,
         rerun_delay=2,
         condition=GHA,
         reason="Flaky; fails occasionally on GitHub Actions runners",


### PR DESCRIPTION
For some weeks, the `macOS-latest tutorial` job in the "pytest" CI workflow has failed. In particular, all tests running on JDBCBackend time out. See [here](https://github.com/iiasa/message_ix/actions/runs/34189540718/job/101944599110#step:11:7496) for an example.

This PR attempts to address this by…
1. Increasing the heap space available for these jobs, on the hunch that memory limitations were causing the jobs to time out.

   This did not change the outcome.
2. Temporarily XFAILing these particular cases.

In addition:
- PostgreSQL is added to the "tutorial" CI job. Many of the tests running on IXMP4Backend still fail, but with more instructive errors, probably to be resolved by iiasa/ixmp#640.
- The collection of fixtures and pytest feature usage in test_tutorials.py is simplified using a new class.

## How to review

I added a temporary commit on this branch to run using the version of `pytest.yaml` on the branch, rather than the version on `main` as occurs with the pull_request_target event. See [this run](https://github.com/iiasa/message_ix/actions/runs/34291585433) in which all three tutorial checks pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A; CI changes only
- ~Update release notes.~ ditto